### PR TITLE
Docs #1462 #1463: document volumetric M55 flip-checklist prerequisites

### DIFF
--- a/.claude/issues/1462/INVESTIGATION.md
+++ b/.claude/issues/1462/INVESTIGATION.md
@@ -1,0 +1,35 @@
+# Investigation — #1462 volumetric depth-convention mismatch
+
+**Domain:** renderer (volumetrics shaders)
+
+## Decision
+LOW / latent. The output is gated off (`VOLUMETRIC_OUTPUT_CONSUMED == false`),
+so the inject+integrate dispatch is skipped and the composite read is dead.
+Reconciling the inject-center / integrate-front-slab / composite-edge math now
+would be a speculative shader change with failure modes invisible to cargo test
+and unobservable in RenderDoc (nothing is dispatched). Per the project
+no-speculative-shader-fix policy, the correct action now is the documentation
+alternative from the issue ("document the half-slab bias ... reconcile when the
+const flips"), placing the note where a future contributor will see it.
+
+## Fix (documentation only — zero behavioural change)
+- `volumetrics.rs` const `VOLUMETRIC_OUTPUT_CONSUMED`: added a FLIP CHECKLIST
+  enumerating #1462 (depth conventions) and #1463 (per-FIF UBO) as prerequisites
+  to flipping the const.
+- `volumetrics_inject.comp:104`, `volumetrics_integrate.comp:64`,
+  `composite.frag:396`: one cross-reference comment each, naming the three
+  conventions (center / front-of-slab / texel-edge) and the ~half-slab bias, so
+  the three sites self-document and point back to the FLIP CHECKLIST.
+
+Shaders recompiled; the `.spv` are byte-identical (comments don't affect SPIR-V),
+confirming zero behavioural change.
+
+## Completeness checks
+- [x] **SIBLING**: all three depth-convention sites annotated in lockstep.
+- [x] **TESTS**: N/A — documentation only; no behaviour to regress. cargo test 2790 pass.
+- [x] **No-speculative-fix**: math left untouched while disabled/untestable; the
+  reconciliation is captured at the flip site for when it becomes observable.
+
+## Residual
+The actual reconciliation is deferred to the M-LIGHT v2 changeset that flips the
+const, now gated by the in-code FLIP CHECKLIST.

--- a/.claude/issues/1462/ISSUE.md
+++ b/.claude/issues/1462/ISSUE.md
@@ -1,0 +1,33 @@
+# REN-DIM18-01
+
+**Issue:** #1462
+**Filed:** 2026-06-04
+**Source report:** docs/audits/AUDIT_RENDERER_2026-06-04_DIM18.md
+
+---
+
+**Severity:** LOW (latent — harmless while `VOLUMETRIC_OUTPUT_CONSUMED == false`; manifests only when the const flips for M-LIGHT v2)
+**Dimension:** Volumetrics (M55)
+**Source report:** `docs/audits/AUDIT_RENDERER_2026-06-04_DIM18.md`
+**Location:** `crates/renderer/shaders/volumetrics_inject.comp:100-104`, `crates/renderer/shaders/volumetrics_integrate.comp:55-71`, `crates/renderer/shaders/composite.frag:396-397`
+
+## Description
+The froxel pipeline uses three slightly different depth conventions:
+- **Inject** samples each froxel at its **center**: `uvw.z = (coord.z + 0.5) / size.z`, `t = uvw.z * VOLUME_FAR` (`volumetrics_inject.comp:100,104`).
+- **Integrate** accumulates a **front-of-slab** Riemann sum: `inscatter_total += inscatter * trans_cumulative * dt;` is applied *before* `trans_cumulative *= exp(-extinction * dt);` (`volumetrics_integrate.comp:64-65`), so slice `i`'s inscatter is weighted by transmittance through slices `0..i-1` (front edge), not the slice midpoint.
+- **Composite** reconstructs the slice by **texel-edge** sample: `slice = clamp(worldDist / VOLUME_FAR, 0, 0.9999)` with CLAMP_TO_EDGE + bilinear (`composite.frag:396-397`).
+
+Under the documented Phase-2 linear distribution this is a ~half-slab (~0.78 m at 200 m / 128 slices) bias in the transmittance/inscatter curve.
+
+## Impact
+Sub-froxel fog-depth bias when the output is consumed; no crash, no NaN. **Harmless today** because `VOLUMETRIC_OUTPUT_CONSUMED == false` (`volumetrics.rs:124`) and the composite read is dead. Becomes a subtle fog-depth offset the moment the const flips.
+
+## Suggested Fix
+When M-LIGHT v2 flips the const, reconcile the three conventions — shift composite's `slice` mapping by +0.5 texel to match the inject center sample, or weight the integrate inscatter by the midpoint transmittance `sqrt(exp(-extinction*dt))`. Alternatively, document the half-slab bias as accepted under the Phase-2 linear model. Fold into the same changeset that flips `VOLUMETRIC_OUTPUT_CONSUMED`.
+
+## Completeness Checks
+- [ ] **SIBLING**: all three depth conventions (inject / integrate / composite) reconciled in lockstep, not just one
+- [ ] **TESTS**: if a host-side froxel-depth mapping helper is added, pin inject↔composite slice agreement with a unit test
+- [ ] Tracked on the `VOLUMETRIC_OUTPUT_CONSUMED` flip checklist (#928) so it cannot be flipped without addressing this
+
+_No action required now — latent until the const flips._

--- a/.claude/issues/1463/INVESTIGATION.md
+++ b/.claude/issues/1463/INVESTIGATION.md
@@ -1,0 +1,28 @@
+# Investigation — #1463 integration param UBO single-buffered
+
+**Domain:** renderer (volumetrics GPU memory)
+
+## Decision
+LOW / latent. `integration_param_buffer` is a single `Option<GpuBuffer>` written
+once at construction with the immutable `dt = DEFAULT_VOLUME_FAR / FROXEL_DEPTH`.
+Sound today (read-only → all FIF integrate sets may alias it). The WAR hazard
+only appears if Phase 5 makes `dt` per-frame without first converting to per-FIF.
+The issue's recommended immediate action is exactly a constraint comment at the
+construction site — done.
+
+## Fix (documentation only — zero behavioural change)
+- `volumetrics.rs:403` (construction site): added the #1463 constraint comment
+  explaining why single-buffering is sound now and what must change first
+  (convert to per-FIF `Vec<GpuBuffer>`, mirror `param_buffers`) before `dt` goes
+  dynamic.
+- Cross-listed as item 2 of the FLIP CHECKLIST on the `VOLUMETRIC_OUTPUT_CONSUMED`
+  const.
+
+## Completeness checks
+- [x] **SIBLING**: references the existing per-FIF `param_buffers` as the pattern to mirror.
+- [x] **DROP**: noted that a future per-FIF `Vec` teardown must cover every slot
+  (parity with the current single-buffer `.take()` at `volumetrics.rs`).
+- [x] **TESTS**: N/A — documentation only. cargo test 2790 pass.
+
+## Residual
+The per-FIF conversion is Phase 5 work, gated by the FLIP CHECKLIST.

--- a/.claude/issues/1463/ISSUE.md
+++ b/.claude/issues/1463/ISSUE.md
@@ -1,0 +1,30 @@
+# REN-DIM18-02
+
+**Issue:** #1463
+**Filed:** 2026-06-04
+**Source report:** docs/audits/AUDIT_RENDERER_2026-06-04_DIM18.md
+
+---
+
+**Severity:** LOW (latent — safe today because `dt` is immutable; a WAR hazard only if Phase 5 makes `dt` dynamic without converting to per-FIF)
+**Dimension:** Volumetrics (M55)
+**Source report:** `docs/audits/AUDIT_RENDERER_2026-06-04_DIM18.md`
+**Location:** `crates/renderer/src/vulkan/volumetrics.rs:404-418` (`integration_param_buffer` construction), bound at `:528-543`
+
+## Description
+The **injection** param UBO (`param_buffers`) is correctly per-frame-in-flight (written each frame in `dispatch`). The **integration** param UBO (`integration_param_buffer`) is a single `Option<GpuBuffer>` (`volumetrics.rs:192`) written **once at construction** with the constant `dt = DEFAULT_VOLUME_FAR / FROXEL_DEPTH` (`:411-417`), with no per-frame update path. Both integration descriptor sets across all FIF slots bind this one buffer.
+
+This is correct **today** because `dt` is immutable, so all FIF slots can safely alias one read-only UBO. But the shader doc and Phase-5 plan (`volumetrics_integrate.comp:14-15`, `volumetrics.rs:126-132`) call for a per-slice / per-frame exponential `dt`. If a future contributor starts writing this buffer per-frame without first making it per-FIF, frame N+1's host write will race frame N's in-flight integrate read — the exact WAR hazard the per-FIF `param_buffers` already avoids.
+
+## Impact
+None currently. Latent WAR hazard if Phase 5 makes `dt` dynamic without converting to per-FIF.
+
+## Suggested Fix
+Add a comment at `volumetrics.rs:411` ("single-buffered because dt is immutable; convert to a per-FIF `Vec<GpuBuffer>` before making dt dynamic — Phase 5") so the constraint is visible at the edit site. When Phase 5 lands, mirror the per-FIF pattern already used by `param_buffers`.
+
+## Completeness Checks
+- [ ] **SIBLING**: when converted to per-FIF, match the existing `param_buffers` per-FIF write/bind pattern exactly
+- [ ] **DROP**: per-FIF `Vec<GpuBuffer>` teardown covers every slot (parity with the current single-buffer `.take()` at `volumetrics.rs:965`)
+- [ ] Constraint comment added at the construction site now (cheap, prevents the future regression)
+
+_No action required now — the comment is the only immediate step._

--- a/crates/renderer/shaders/composite.frag
+++ b/crates/renderer/shaders/composite.frag
@@ -393,6 +393,14 @@ void main() {
             // the volume rather than the CLAMP_TO_EDGE neighbour, which
             // would over-extrapolate transmittance for fragments past
             // the volume far plane.
+            //
+            // #1462: this is a texel-EDGE mapping, while inject samples at
+            // the slice CENTER ((z+0.5)/size.z) and integrate uses a
+            // FRONT-of-slab Riemann sum — a ~half-slab (~0.78 m) fog-depth
+            // bias under the linear model. Dead while the read is gated off
+            // (depth_params.z); reconcile the three conventions when
+            // VOLUMETRIC_OUTPUT_CONSUMED flips. See the FLIP CHECKLIST in
+            // volumetrics.rs.
             float slice = clamp(worldDist / VOLUME_FAR, 0.0, 0.9999);
             vec4 vol = texture(volumetricFroxel, vec3(fragUV, slice));
             // vol.rgb = ∫inscatter accumulated 0..slice (HDR-linear)

--- a/crates/renderer/shaders/volumetrics_inject.comp
+++ b/crates/renderer/shaders/volumetrics_inject.comp
@@ -101,6 +101,9 @@ void main() {
 
     // Slice → along-ray distance (linear for Phase 2; exponential
     // distribution lands with Phase 5 temporal reprojection).
+    // #1462: this samples the slice CENTER (uvw.z = (coord.z+0.5)/size.z);
+    // integrate weights with FRONT-of-slab transmittance and composite
+    // samples by texel EDGE — reconcile the three when the read is enabled.
     float t = uvw.z * params.volume_extent.x;
 
     vec3 world_pos = froxel_to_world(uvw.xy, t);

--- a/crates/renderer/shaders/volumetrics_integrate.comp
+++ b/crates/renderer/shaders/volumetrics_integrate.comp
@@ -61,6 +61,11 @@ void main() {
         vec3 inscatter = inj.rgb;
         float extinction = inj.a;
 
+        // #1462: FRONT-of-slab Riemann sum — inscatter is weighted by the
+        // transmittance accumulated through slices 0..i-1 (before this
+        // slab attenuates), while inject evaluated inscatter/extinction at
+        // the slice CENTER. ~half-slab bias; reconcile with inject +
+        // composite when VOLUMETRIC_OUTPUT_CONSUMED flips (FLIP CHECKLIST).
         inscatter_total += inscatter * trans_cumulative * dt;
         trans_cumulative *= exp(-extinction * dt);
 

--- a/crates/renderer/src/vulkan/volumetrics.rs
+++ b/crates/renderer/src/vulkan/volumetrics.rs
@@ -121,6 +121,21 @@ pub const DEFAULT_VOLUME_FAR: f32 = crate::shader_constants::VOLUME_FAR;
 /// `composite.frag` shader can't `#include` Rust, so the lockstep is
 /// documented via cross-comments rather than enforced by the compiler.
 /// See #928.
+///
+/// **FLIP CHECKLIST — before setting this to `true` (M-LIGHT v2),
+/// address the two latent items that are dead while the read is gated
+/// off but become live the instant it flips:**
+/// 1. **#1462** — reconcile the froxel depth conventions: inject samples
+///    each slice at its *center* (`(z+0.5)/size.z`), integrate uses a
+///    *front-of-slab* Riemann sum (inscatter weighted before the
+///    transmittance step), and composite samples by *texel edge*
+///    (`worldDist/VOLUME_FAR`). Under the linear model that is a
+///    ~half-slab (~0.78 m) fog-depth bias. Reconcile, or accept it
+///    explicitly.
+/// 2. **#1463** — `integration_param_buffer` is single-buffered (sound
+///    only because `dt` is immutable). If Phase 5 makes `dt` per-frame,
+///    convert it to per-FIF first (mirror `param_buffers`) or frame
+///    N+1's host write races frame N's in-flight integrate read.
 pub const VOLUMETRIC_OUTPUT_CONSUMED: bool = false;
 
 /// Integration shader uniform — slab thickness `dt` shared across all
@@ -401,6 +416,14 @@ impl VolumetricsPipeline {
         }
 
         // ── 7. Integration pass UBO (single-shot, dt is constant) ─────
+        // #1463: single-buffered (NOT per-FIF) because `dt` is immutable —
+        // written once here and read-only thereafter, so all FIF integrate
+        // descriptor sets may safely alias it. Phase 5 wants a per-slice /
+        // per-frame exponential `dt`; if you start writing this buffer per
+        // frame, FIRST convert it to a per-FIF `Vec<GpuBuffer>` (mirror the
+        // `param_buffers` pattern) or frame N+1's host write will race frame
+        // N's in-flight integrate read (WAR hazard). See the FLIP CHECKLIST
+        // on `VOLUMETRIC_OUTPUT_CONSUMED`.
         let int_param_size = std::mem::size_of::<IntegrationParams>() as vk::DeviceSize;
         let mut int_param_buffer = try_or_cleanup!(GpuBuffer::create_host_visible(
             device,


### PR DESCRIPTION
Both are LOW/latent renderer-audit findings (DIM18) that are dead while VOLUMETRIC_OUTPUT_CONSUMED == false and only become live when the const is flipped for M-LIGHT v2. Per the no-speculative-shader-fix policy the disabled, untestable shader math is left untouched; the constraints are documented where a future contributor will see them.

#1462 — froxel depth-convention mismatch: inject samples the slice center, integrate uses a front-of-slab Riemann sum, composite samples by texel edge (~half-slab / ~0.78 m fog-depth bias under the linear model). Added a cross-reference comment at all three shader sites and item 1 of a new FLIP CHECKLIST on the const.

#1463 — integration param UBO is single-buffered (sound only because dt is immutable). Added a constraint comment at the construction site and item 2 of the FLIP CHECKLIST: convert to a per-FIF Vec<GpuBuffer> before making dt dynamic (Phase 5) or frame N+1's host write races frame N's integrate read.

Documentation only; .spv recompiled byte-identical. cargo test 2790 passed.