### PR TITLE
feat(config): [defaults] launch table — default game / cell / paths f…

### DIFF
--- a/assets/debug_profiles.toml
+++ b/assets/debug_profiles.toml
@@ -24,6 +24,18 @@
 #                         BGSM/BGEM materials archives (FO4+/FO76/SF
 #                         only; empty for Skyrim and older).
 #   sample_cells          Curated cell editor IDs for one-click loads.
+#
+# Optional [defaults] table — launch defaults applied when the engine
+# is run with no CLI load flags. Left unset in the shipped file so a
+# bare `cargo run` keeps the spinning-cube demo; set it in your
+# `~/.byroredux/profiles.toml` to boot straight into a game/cell:
+#
+#   [defaults]
+#   game             = "fnv"                       # profile key; used when no --game/--esm/--mesh/--cmd
+#   cell             = "GSProspectorSaloonInterior" # used when no --cell/--grid/--wrld
+#   games_root       = "/path/to/games"            # like --games-root / BYROREDUX_GAMES_ROOT
+#   light_atten_knee = 0.5                          # REND-#1451 attenuation knee (see `light.atten`)
+#   light_atten_legacy = false
 
 [profiles.fnv]
 name = "Fallout New Vegas"

--- a/byroredux/src/game_profiles.rs
+++ b/byroredux/src/game_profiles.rs
@@ -98,10 +98,77 @@ impl From<ProfileEntryDe> for GameProfileEntry {
     }
 }
 
+/// Serde landing type for the optional `[defaults]` table — the
+/// launch defaults that let `cargo run` (and `--bench-hold`) boot
+/// straight into a game/cell with no CLI flags. Every field is
+/// optional; an absent table or field falls back to the engine's
+/// built-in behaviour (the spinning-cube demo when no game is set).
+#[derive(Debug, Default, Deserialize)]
+struct DefaultsDe {
+    /// Profile key (a `[profiles.<key>]` block) loaded when no
+    /// `--game` / `--esm` / `--mesh` / `--cmd` flag is given.
+    #[serde(default)]
+    game: Option<String>,
+    /// Cell editor ID loaded when a profile is resolved and no
+    /// `--cell` / `--grid` / `--wrld` flag is given.
+    #[serde(default)]
+    cell: Option<String>,
+    /// Shared games root override (same role as `--games-root` /
+    /// `BYROREDUX_GAMES_ROOT`). Lets a non-Steam install point the
+    /// whole registry at one folder from the config file.
+    #[serde(default)]
+    games_root: Option<String>,
+    /// REND-#1451 — initial point/spot attenuation knee fraction for
+    /// the `LightTuning` resource, so a benched value persists across
+    /// runs without a `light.atten` command each session.
+    #[serde(default)]
+    light_atten_knee: Option<f32>,
+    /// REND-#1451 — start with the legacy window-only attenuation.
+    #[serde(default)]
+    light_atten_legacy: Option<bool>,
+}
+
+/// Resolved launch defaults (the `[defaults]` table), merged across
+/// the shipped file and the per-user override (user fields win when
+/// present). All fields optional — callers apply only what is set.
+#[derive(Debug, Default, Clone)]
+pub struct LaunchDefaults {
+    pub game: Option<String>,
+    pub cell: Option<String>,
+    pub games_root: Option<String>,
+    pub light_atten_knee: Option<f32>,
+    pub light_atten_legacy: Option<bool>,
+}
+
+impl LaunchDefaults {
+    /// Overlay `other` onto `self`: every `Some` field in `other`
+    /// replaces `self`'s value. Used to let the per-user override's
+    /// `[defaults]` win over the shipped file's, field by field.
+    fn overlay(&mut self, other: DefaultsDe) {
+        if other.game.is_some() {
+            self.game = other.game;
+        }
+        if other.cell.is_some() {
+            self.cell = other.cell;
+        }
+        if other.games_root.is_some() {
+            self.games_root = other.games_root;
+        }
+        if other.light_atten_knee.is_some() {
+            self.light_atten_knee = other.light_atten_knee;
+        }
+        if other.light_atten_legacy.is_some() {
+            self.light_atten_legacy = other.light_atten_legacy;
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ProfilesFile {
     #[serde(default)]
     profiles: BTreeMap<String, ProfileEntryDe>,
+    #[serde(default)]
+    defaults: DefaultsDe,
 }
 
 /// Load profiles using the engine-default + user-override merge
@@ -172,6 +239,66 @@ fn merge_from(path: &Path, out: &mut BTreeMap<String, GameProfileEntry>) {
     );
 }
 
+/// The ordered config files to read, shipped-first then per-user
+/// override: `[assets/debug_profiles.toml (CWD or exe-parent),
+/// ~/.byroredux/profiles.toml]`, filtered to those that exist. Both
+/// `load_default` (profiles) and [`load_launch_defaults`] consume this
+/// so the two stay in lockstep on which files contribute.
+fn ordered_config_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for shipped in [
+        PathBuf::from(DEFAULT_PROFILES_PATH),
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join(DEFAULT_PROFILES_PATH)))
+            .unwrap_or_default(),
+    ] {
+        if shipped.exists() {
+            paths.push(shipped);
+            break;
+        }
+    }
+    if let Some(home) = home_dir() {
+        let user_path = home.join(".byroredux").join("profiles.toml");
+        if user_path.exists() {
+            paths.push(user_path);
+        }
+    }
+    paths
+}
+
+/// Load the merged `[defaults]` launch table from the shipped file +
+/// per-user override (user fields win, field by field). Missing files
+/// / missing table → all-`None` defaults (engine keeps its built-in
+/// behaviour). Parse failures log a warning and are skipped — never an
+/// error, so a typo in the config can't brick the launch.
+pub fn load_launch_defaults() -> LaunchDefaults {
+    let mut out = LaunchDefaults::default();
+    for path in ordered_config_paths() {
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("launch defaults: failed to read {}: {}", path.display(), e);
+                continue;
+            }
+        };
+        match toml::from_str::<ProfilesFile>(&contents) {
+            Ok(parsed) => out.overlay(parsed.defaults),
+            Err(e) => {
+                log::warn!("launch defaults: failed to parse {}: {}", path.display(), e);
+            }
+        }
+    }
+    // Expand a leading `~/` on games_root so callers get an absolute
+    // path (mirrors the profile-root expansion in `load_default`).
+    if let Some(root) = out.games_root.as_ref().and_then(|r| r.strip_prefix("~/")) {
+        if let Some(home) = home_dir() {
+            out.games_root = Some(home.join(root).to_string_lossy().into_owned());
+        }
+    }
+    out
+}
+
 fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
@@ -213,6 +340,50 @@ sample_cells = ["GSDocMitchellHouse"]
         }
         .into();
         assert!(!entry.is_usable());
+    }
+
+    #[test]
+    fn parses_defaults_table() {
+        let toml = r#"
+[defaults]
+game = "fnv"
+cell = "GSProspectorSaloonInterior"
+light_atten_knee = 0.4
+
+[profiles.fnv]
+name = "FNV"
+esm = "FalloutNV.esm"
+        "#;
+        let parsed: ProfilesFile = toml::from_str(toml).expect("parse");
+        assert_eq!(parsed.defaults.game.as_deref(), Some("fnv"));
+        assert_eq!(parsed.defaults.cell.as_deref(), Some("GSProspectorSaloonInterior"));
+        assert_eq!(parsed.defaults.light_atten_knee, Some(0.4));
+        assert_eq!(parsed.defaults.games_root, None);
+    }
+
+    #[test]
+    fn missing_defaults_table_is_all_none() {
+        let toml = "[profiles.fnv]\nname = \"FNV\"\nesm = \"FalloutNV.esm\"\n";
+        let parsed: ProfilesFile = toml::from_str(toml).expect("parse");
+        assert!(parsed.defaults.game.is_none());
+        assert!(parsed.defaults.cell.is_none());
+        assert!(parsed.defaults.light_atten_knee.is_none());
+    }
+
+    #[test]
+    fn launch_defaults_overlay_user_wins_field_by_field() {
+        // Shipped sets game+cell; user overrides only cell + adds knee.
+        let mut acc = LaunchDefaults::default();
+        let shipped: ProfilesFile =
+            toml::from_str("[defaults]\ngame = \"fnv\"\ncell = \"ShippedCell\"\n").unwrap();
+        acc.overlay(shipped.defaults);
+        let user: ProfilesFile =
+            toml::from_str("[defaults]\ncell = \"UserCell\"\nlight_atten_knee = 0.35\n").unwrap();
+        acc.overlay(user.defaults);
+
+        assert_eq!(acc.game.as_deref(), Some("fnv"), "shipped game survives (user didn't set it)");
+        assert_eq!(acc.cell.as_deref(), Some("UserCell"), "user cell wins");
+        assert_eq!(acc.light_atten_knee, Some(0.35), "user-only field applies");
     }
 
     #[test]

--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -432,7 +432,17 @@ impl App {
         world.insert_resource(SkinCoverageStats::default());
         // REND-#1451 — live attenuation tuning, read into the renderer
         // each frame and mutated by the `light.atten` console command.
-        world.insert_resource(crate::components::LightTuning::default());
+        // Seed from the config `[defaults]` so a benched knee persists
+        // across runs.
+        let light_defaults = crate::game_profiles::load_launch_defaults();
+        let mut light_tuning = crate::components::LightTuning::default();
+        if let Some(knee) = light_defaults.light_atten_knee {
+            light_tuning.knee_frac = knee.clamp(0.05, 1.0);
+        }
+        if let Some(legacy) = light_defaults.light_atten_legacy {
+            light_tuning.legacy = legacy;
+        }
+        world.insert_resource(light_tuning);
         // CPU-side per-frame timings — fence_wait / submit_present /
         // etc. Filled by the binary's RedrawRequested handler after
         // each `draw_frame` from the renderer's `FrameTimings`
@@ -2475,11 +2485,28 @@ fn apply_debug_ui_outputs(
 fn expand_game_profile_args(mut args: Vec<String>) -> Vec<String> {
     use crate::cli_args::parse_string_arg;
 
+    // Launch defaults from the `[defaults]` table (profiles.toml,
+    // shipped + per-user override). Let an explicit `--game` win; fall
+    // back to `[defaults].game` ONLY when no other content-loading flag
+    // is present, so `--mesh foo.nif`, `--cmd`, an explicit `--esm`, or
+    // a master-only run aren't hijacked into loading the default cell.
+    let defaults = crate::game_profiles::load_launch_defaults();
+    let has_other_load_flags = ["--esm", "--mesh", "--tree", "--kf", "--cmd", "--master"]
+        .iter()
+        .any(|f| args.iter().any(|a| a == f));
     let game_key = match parse_string_arg(&args, "--game") {
         Some(k) => k,
-        None => return args,
+        None => match defaults.game.clone() {
+            Some(k) if !has_other_load_flags => {
+                eprintln!("[defaults] game = {k:?} (no --game / load flag given)");
+                k
+            }
+            _ => return args,
+        },
     };
-    let games_root_cli = parse_string_arg(&args, "--games-root");
+    // `--games-root` CLI wins; else the config `[defaults].games_root`.
+    let games_root_cli =
+        parse_string_arg(&args, "--games-root").or_else(|| defaults.games_root.clone());
 
     // Strip the two new flags + their values from the returned
     // args; downstream code doesn't recognise them.
@@ -2551,6 +2578,21 @@ fn expand_game_profile_args(mut args: Vec<String>) -> Vec<String> {
     for bsa in &entry.default_materials_bsas {
         args.push("--materials-ba2".to_string());
         args.push(join_arg(bsa));
+    }
+
+    // Default cell: inject `[defaults].cell` only when the profile was
+    // resolved and no explicit location flag is present. A bare
+    // `--game fnv` (or a no-arg default-game launch) then boots
+    // straight into the configured cell.
+    if let Some(cell) = &defaults.cell {
+        let has_location = ["--cell", "--grid", "--wrld"]
+            .iter()
+            .any(|f| args.iter().any(|a| a == f));
+        if !has_location {
+            eprintln!("[defaults] cell = {cell:?} (no --cell / --grid / --wrld given)");
+            args.push("--cell".to_string());
+            args.push(cell.clone());
+        }
     }
     args
 }


### PR DESCRIPTION
…rom profiles.toml

Running the engine previously required spelling out --game (or --esm/--bsa/…) and --cell on every invocation; a bare run gave only the spinning-cube demo. This adds an optional [defaults] table to the existing profiles.toml system (shipped assets/debug_profiles.toml + per-user ~/.byroredux/profiles.toml, merged user-wins field-by-field):

  [defaults]
  game               = "fnv"                        # used when no --game/--esm/--mesh/--cmd
  cell               = "GSProspectorSaloonInterior" # used when no --cell/--grid/--wrld
  games_root         = "/path/to/games"             # like --games-root / BYROREDUX_GAMES_ROOT
  light_atten_knee   = 0.5                           # REND-#1451 LightTuning seed
  light_atten_legacy = false

expand_game_profile_args now falls back to [defaults].game (only when no other content-loading flag is present, so --mesh / --cmd / explicit --esm aren't hijacked), injects [defaults].cell when no location flag is given, and uses [defaults].games_root as the games-root override. World init seeds the LightTuning resource from light_atten_knee/legacy so a benched value persists across runs. The shipped file leaves [defaults] unset (documented only) so a bare `cargo run` keeps the cube demo for devs without game data.

Enables the REND-#1451 bench to run as just `--bench-hold` + `light.atten`, no path flags. Adds 3 parse/merge tests.