### PR TITLE
Fix #1331, #1332: per-file BSVER flag-width gate + parse-block covera…

### DIFF
--- a/.claude/issues/1331/INVESTIGATION.md
+++ b/.claude/issues/1331/INVESTIGATION.md
@@ -1,0 +1,37 @@
+# #1331 — NiAVObject flag width uses variant helper instead of per-file BSVER>26
+
+## Root cause (confirmed)
+`crates/nif/src/blocks/base.rs:78` branched on `stream.variant().avobject_flags_u32()`
+(a *variant*-level predicate) where nif.xml gates `NiAVObject.Flags` strictly on the
+*per-file* `#BSVER# #GT# 26` (uint) vs `#LTE# 26` (ushort). A transitional v20.2.0.7
+export with `uv=11 / bsver≤26` (NifSkope / newer-tool Oblivion + non-Bethesda Gamebryo
+content) detects as the `Fallout3` variant (`version.rs` `NifVariant::detect`, uv=11 &
+uv2<34), whose helper returns `true` → reads u32 where 2 bytes are on disk, slipping the
+stream +2 from `flags` onward (block_size realignment masks the slip — same failure mode
+as #342).
+
+The properties-list branch directly below (base.rs:103) already used the correct
+`stream.bsver() <= …::FO3_FNV` per-file pattern (#160) — the flags branch was the last
+variant-level predicate shadowing a strict per-file BSVER gate.
+
+## Sibling (same anti-pattern)
+`crates/nif/src/blocks/shader.rs:166` — `BSShaderNoLightingProperty` falloff fields
+(4×f32) used the same `variant().avobject_flags_u32()` gate. nif.xml line 6236 gates
+them on `#BSVER# #GT# 26` (verified against `/mnt/data/src/reference/nifxml/nif.xml`).
+Fixed in the same change.
+
+## Fix
+Both sites now branch on `stream.bsver() > crate::version::bsver::FLAGS_U32_THRESHOLD`
+(the `=26` constant that already existed for exactly this gate, `version.rs:282`).
+
+## Verification
+- `NifVariant::detect(V20_2_0_7, uv=11, uv2=11)` → `Fallout3` (confirmed) → old code
+  read u32; new code reads u16. The u16 regression test is red before the fix, green
+  after.
+- New tests (all green):
+  - `base.rs::niavobject_version_gate_tests::flags_read_as_u16_when_bsver_le_26`
+  - `base.rs::niavobject_version_gate_tests::flags_read_as_u32_when_bsver_gt_26`
+  - `shader_tests.rs::no_lighting_falloff_absent_when_bsver_le_26`
+  - `shader_tests.rs::no_lighting_falloff_present_when_bsver_gt_26`
+- Standard Oblivion (v20.0.0.x) is unaffected: caught by the Oblivion variant branch
+  before the uv match, bsver≤26 → u16 either way.

--- a/.claude/issues/1332/INVESTIGATION.md
+++ b/.claude/issues/1332/INVESTIGATION.md
@@ -1,0 +1,51 @@
+# #1332 — No parse-block coverage regression pin (block-count parity / NiUnknown ceiling)
+
+## What was missing
+Neither existing harness pins parse-block coverage:
+- `translation_completeness.rs` measures Material *translation*, never block counts.
+- `per_block_baselines.rs` pins per-type `NiUnknown` *growth* (a regression delta),
+  not an absolute coverage gate, and doesn't assert block-count parity.
+
+So sizeless-cascade truncations (Oblivion, where a block with no dispatch arm drops the
+rest of the file but the file-level recoverable-rate stays 100%) land silently.
+
+## New pin: `crates/nif/tests/block_coverage_baselines.rs`
+A distinct surface (kept separate from `translation_completeness` per the
+CANONICAL-BOUNDARY check), opt-in `#[ignore]` like the other real-data tests.
+
+- **Oblivion (sizeless): block-count parity, regression-gated.** Walk the mesh archive;
+  a truncated parse is `scene.truncated || scene.dropped_block_count > 0`. The set of
+  truncating files is checked in (`oblivion_truncations.tsv`); the gate is
+  *no-new-truncation* (improvements silent, a newly-truncating file fails). An F-01-class
+  regression (sizeless dispatch arm removed) re-truncates files absent from the baseline → red.
+- **Sized games (FO3+): NiUnknown-rate ceiling.** `block_size` recovery keeps the block
+  count whole, so the signal is the *rate* of `NiUnknown` placeholders, pinned per game.
+
+## Key finding — premise was partly stale, plus a broader gap
+- F-01 (NIF-2026-05-29-01) is **already fixed**: `bhkConvexSweepShape` / `bhkMeshShape`
+  have dispatch arms (`blocks/mod.rs:1107-1108`); the three named files
+  (`handscythe01.nif` / `oar01.nif` / `ungrdltraphingedoor.nif`) parse whole now. The
+  pin is correctly *green* for them ("green after the HIGH fix").
+- **But 55 vanilla Oblivion meshes still truncate** from *other* undispatched sizeless
+  block types (e.g. `summondaedra.nif` −107, `tumbler.nif` −102, creature heads, markers).
+  A hard `parsed==num_blocks` gate would be red on all 55; fixing them means writing new
+  block parsers — out of scope for a coverage-pin. They are now the visible, tracked
+  contents of `oblivion_truncations.tsv` rather than a silent loss. **Follow-up worth a
+  separate issue: dispatch/skip the remaining 55-file Oblivion sizeless-truncation tail.**
+
+## Baselines captured (all 7 games' data present on the dev machine)
+| Game | total blocks | NiUnknown | rate |
+|------|-------------:|----------:|-----:|
+| Oblivion | — | — | 55 truncating files / 8032 |
+| Fallout 3 | 287,331 | 0 | 0% |
+| Fallout NV | 492,796 | 0 | 0% |
+| Skyrim SE | 665,846 | 0 | 0% |
+| Fallout 4 | 740,562 | 0 | 0% |
+| Fallout 76 | 1,548,202 | 0 | 0% |
+| Starfield | 770,322 | 1,036 | 0.1345% |
+
+## Verification
+- Regen → run: all 7 tests green against checked-in baselines.
+- F-01 files confirmed absent from `oblivion_truncations.tsv` → an F-01 regression
+  surfaces as a NEW truncation (red).
+- Default `cargo test` unaffected (tests are `#[ignore]`d).

--- a/crates/nif/src/blocks/base.rs
+++ b/crates/nif/src/blocks/base.rs
@@ -73,9 +73,13 @@ impl NiAVObjectData {
         let net = NiObjectNETData::parse(stream)?;
 
         // Flags: u32 for BSVER > 26 (FO3+), u16 for older (Oblivion and non-Bethesda).
-        // Use actual BSVER from header, not the variant's hardcoded value, to handle
-        // transitional versions (e.g., Oblivion files with uv=11, bsver=11).
-        let flags = if stream.variant().avobject_flags_u32() {
+        // nif.xml gates NiAVObject.Flags on `#BSVER# #GT# 26` (uint) vs `#LTE# 26`
+        // (ushort) — a strict *per-file* gate. Use the actual header BSVER, not
+        // `variant().avobject_flags_u32()`: a transitional v20.2.0.7 export with
+        // uv=11/bsver≤26 (NifSkope/newer-tool Oblivion + non-Bethesda content)
+        // detects as the `Fallout3` variant, whose helper says u32 — reading 4
+        // bytes where 2 are on disk and slipping the stream +2. See #1331.
+        let flags = if stream.bsver() > crate::version::bsver::FLAGS_U32_THRESHOLD {
             stream.read_u32_le()?
         } else {
             stream.read_u16_le()? as u32
@@ -367,5 +371,98 @@ mod niavobject_version_gate_tests {
             "pre-Gamebryo NiAVObject must consume the velocity + has_bv bool"
         );
         assert!(data.collision_ref.is_null());
+    }
+
+    // ── #1331: NiAVObject.Flags width follows per-file BSVER, not variant ──
+
+    /// v20.2.0.7 header with explicit user_version + BSVER (user_version_2).
+    fn header_v20_2_bsver(bsver: u32) -> NifHeader {
+        NifHeader {
+            version: NifVersion::V20_2_0_7,
+            little_endian: true,
+            user_version: 11,
+            user_version_2: bsver,
+            num_blocks: 0,
+            block_types: Vec::new(),
+            block_type_indices: Vec::new(),
+            block_sizes: Vec::new(),
+            strings: Vec::new(),
+            max_string_length: 0,
+            num_groups: 0,
+        }
+    }
+
+    /// NiObjectNET prologue for v20.2.0.7 (>= 20.1.0.1 string-table layout):
+    /// name string-index = -1 (None), counted extra_data list = 0,
+    /// controller_ref = -1.
+    fn modern_objectnet_prologue() -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&(-1i32).to_le_bytes()); // name index -1 → None
+        d.extend_from_slice(&0u32.to_le_bytes()); // extra_data list count = 0
+        d.extend_from_slice(&(-1i32).to_le_bytes()); // controller_ref = -1
+        d
+    }
+
+    /// NiAVObject tail after `flags`: identity transform (52 B) + empty
+    /// properties list (bsver ≤ 34) + null collision_ref (version ≥ 10.0.1.0).
+    fn modern_avobject_tail() -> Vec<u8> {
+        let mut d = Vec::new();
+        for _ in 0..3 {
+            d.extend_from_slice(&0.0f32.to_le_bytes()); // translation
+        }
+        for row in 0..3 {
+            for col in 0..3 {
+                let v: f32 = if row == col { 1.0 } else { 0.0 };
+                d.extend_from_slice(&v.to_le_bytes()); // identity rotation
+            }
+        }
+        d.extend_from_slice(&1.0f32.to_le_bytes()); // scale
+        d.extend_from_slice(&0u32.to_le_bytes()); // properties list count = 0
+        d.extend_from_slice(&(-1i32).to_le_bytes()); // collision_ref = -1
+        d
+    }
+
+    /// #1331 — a transitional v20.2.0.7 export with bsver=11 (NifSkope /
+    /// newer-tool Oblivion + non-Bethesda content) detects as the `Fallout3`
+    /// variant, but nif.xml gates `NiAVObject.Flags` as `ushort` for
+    /// BSVER ≤ 26. The width must follow the per-file BSVER, not the variant
+    /// helper — otherwise a u32 read slips the stream +2 from `flags` on.
+    /// Red before the fix (variant helper → u32), green after.
+    #[test]
+    fn flags_read_as_u16_when_bsver_le_26() {
+        let header = header_v20_2_bsver(11);
+        let mut bytes = modern_objectnet_prologue();
+        bytes.extend_from_slice(&0xABCDu16.to_le_bytes()); // flags as u16
+        bytes.extend(modern_avobject_tail());
+
+        let mut stream = NifStream::new(&bytes, &header);
+        let data = NiAVObjectData::parse(&mut stream)
+            .expect("v20.2.0.7 / bsver=11 NiAVObject should parse");
+        assert_eq!(data.flags, 0xABCD, "bsver ≤ 26 must read flags as u16");
+        assert_eq!(
+            stream.position() as usize,
+            bytes.len(),
+            "u16 flags must consume exactly 2 bytes — a u32 read slips the stream +2"
+        );
+    }
+
+    /// #1331 — retail FO3/FNV (bsver=34 > 26) reads `NiAVObject.Flags` as
+    /// `uint`. Pins the upper branch so the fix doesn't regress sized games.
+    #[test]
+    fn flags_read_as_u32_when_bsver_gt_26() {
+        let header = header_v20_2_bsver(34);
+        let mut bytes = modern_objectnet_prologue();
+        bytes.extend_from_slice(&0x0001_ABCDu32.to_le_bytes()); // flags as u32
+        bytes.extend(modern_avobject_tail());
+
+        let mut stream = NifStream::new(&bytes, &header);
+        let data = NiAVObjectData::parse(&mut stream)
+            .expect("v20.2.0.7 / bsver=34 NiAVObject should parse");
+        assert_eq!(data.flags, 0x0001_ABCD, "bsver > 26 must read flags as u32");
+        assert_eq!(
+            stream.position() as usize,
+            bytes.len(),
+            "u32 flags must consume exactly 4 bytes"
+        );
     }
 }

--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -162,8 +162,14 @@ impl BSShaderNoLightingProperty {
         let (shader, texture_clamp_mode) = BSShaderPropertyData::parse_fo3(stream)?;
         let file_name = stream.read_sized_string()?;
 
+        // nif.xml gates the four falloff fields on `#BSVER# #GT# 26` (nif.xml
+        // line 6236) — the same strict per-file BSVER gate as NiAVObject.Flags.
+        // Use the header BSVER, not `variant().avobject_flags_u32()`: a
+        // transitional v20.2.0.7/bsver≤26 export detects as the `Fallout3`
+        // variant (helper → true) and would read 16 phantom bytes of falloff
+        // that aren't on disk. Sibling of the NiAVObject flag-width fix. See #1331.
         let (falloff_start_angle, falloff_stop_angle, falloff_start_opacity, falloff_stop_opacity) =
-            if stream.variant().avobject_flags_u32() {
+            if stream.bsver() > crate::version::bsver::FLAGS_U32_THRESHOLD {
                 (
                     stream.read_f32_le()?,
                     stream.read_f32_le()?,
@@ -1277,7 +1283,7 @@ fn parse_shader_type_data_fo4(
         1 => {
             let env_map_scale = stream.read_f32_le()?;
             // FO4-specific: SSR bools (BSVER 130–139).
-            if bsver >= crate::version::bsver::FALLOUT4 && bsver < crate::version::bsver::FO4_DLC_UPPER {
+            if (crate::version::bsver::FALLOUT4..crate::version::bsver::FO4_DLC_UPPER).contains(&bsver) {
                 let _use_ssr = stream.read_byte_bool()?;
                 let _wetness_use_ssr = stream.read_byte_bool()?;
             }
@@ -1290,7 +1296,7 @@ fn parse_shader_type_data_fo4(
                 stream.read_f32_le()?,
             ];
             // FO4-specific: skin tint alpha (BSVER 130–139).
-            if bsver >= crate::version::bsver::FALLOUT4 && bsver < crate::version::bsver::FO4_DLC_UPPER {
+            if (crate::version::bsver::FALLOUT4..crate::version::bsver::FO4_DLC_UPPER).contains(&bsver) {
                 let _skin_tint_alpha = stream.read_f32_le()?;
             }
             Ok(ShaderTypeData::SkinTint { skin_tint_color })

--- a/crates/nif/src/blocks/shader_tests.rs
+++ b/crates/nif/src/blocks/shader_tests.rs
@@ -1740,3 +1740,77 @@ fn bsshader_pplighting_fnv_has_no_emissive_color() {
     // Default emissive when absent: [0,0,0,1]
     assert_eq!(prop.emissive_color, [0.0, 0.0, 0.0, 1.0]);
 }
+
+// ── #1331 sibling: BSShaderNoLightingProperty falloff width per-file BSVER ──
+
+/// Build a `BSShaderNoLightingProperty` block: NiObjectNET (name idx 0) +
+/// FO3 shader base + texture_clamp_mode + sized `file_name`, optionally
+/// followed by the four falloff floats.
+fn build_no_lighting_bytes(file_name: &str, falloff: Option<[f32; 4]>) -> Vec<u8> {
+    let mut d = Vec::new();
+    // NiObjectNET
+    d.extend_from_slice(&0i32.to_le_bytes()); // name string index 0
+    d.extend_from_slice(&0u32.to_le_bytes()); // extra_data list count = 0
+    d.extend_from_slice(&(-1i32).to_le_bytes()); // controller_ref = -1
+    // BSShaderPropertyData::parse_base
+    d.extend_from_slice(&0u16.to_le_bytes()); // shade_flags
+    d.extend_from_slice(&1u32.to_le_bytes()); // shader_type
+    d.extend_from_slice(&0u32.to_le_bytes()); // shader_flags_1
+    d.extend_from_slice(&0u32.to_le_bytes()); // shader_flags_2
+    d.extend_from_slice(&1.0f32.to_le_bytes()); // env_map_scale
+    // BSShaderLightingProperty texture_clamp_mode
+    d.extend_from_slice(&3u32.to_le_bytes());
+    // file_name (sized string)
+    d.extend_from_slice(&(file_name.len() as u32).to_le_bytes());
+    d.extend_from_slice(file_name.as_bytes());
+    if let Some(f) = falloff {
+        for v in f {
+            d.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    d
+}
+
+/// #1331 sibling — nif.xml (line 6236) gates the four falloff fields on
+/// `#BSVER# #GT# 26`. A transitional v20.2.0.7/bsver=11 export detects as
+/// the `Fallout3` variant, so the old `variant().avobject_flags_u32()` gate
+/// read 16 phantom falloff bytes past end-of-block (EOF / misalign). With
+/// the per-file BSVER ≤ 26 gate the absent-field default branch is taken.
+/// Red before the fix (over-read → parse error), green after.
+#[test]
+fn no_lighting_falloff_absent_when_bsver_le_26() {
+    let header = make_header(11, 11);
+    let data = build_no_lighting_bytes("ui\\elem.dds", None);
+    let mut stream = NifStream::new(&data, &header);
+    let prop = BSShaderNoLightingProperty::parse(&mut stream)
+        .expect("v20.2.0.7 / bsver=11 BSShaderNoLightingProperty should parse");
+    assert_eq!(prop.file_name, "ui\\elem.dds");
+    // Absent-field defaults.
+    assert_eq!(prop.falloff_start_angle, 0.0);
+    assert_eq!(prop.falloff_start_opacity, 1.0);
+    assert_eq!(
+        stream.position() as usize,
+        data.len(),
+        "bsver ≤ 26 must NOT read the four falloff floats"
+    );
+}
+
+/// #1331 sibling — retail FO3/FNV (bsver=34 > 26) reads all four falloff
+/// floats. Pins the upper branch so the fix doesn't regress sized games.
+#[test]
+fn no_lighting_falloff_present_when_bsver_gt_26() {
+    let header = make_header(11, 34);
+    let data = build_no_lighting_bytes("ui\\elem.dds", Some([0.1, 0.2, 0.3, 0.4]));
+    let mut stream = NifStream::new(&data, &header);
+    let prop = BSShaderNoLightingProperty::parse(&mut stream)
+        .expect("v20.2.0.7 / bsver=34 BSShaderNoLightingProperty should parse");
+    assert!((prop.falloff_start_angle - 0.1).abs() < 1e-6);
+    assert!((prop.falloff_stop_angle - 0.2).abs() < 1e-6);
+    assert!((prop.falloff_start_opacity - 0.3).abs() < 1e-6);
+    assert!((prop.falloff_stop_opacity - 0.4).abs() < 1e-6);
+    assert_eq!(
+        stream.position() as usize,
+        data.len(),
+        "bsver > 26 must read all four falloff floats"
+    );
+}

--- a/crates/nif/tests/block_coverage_baselines.rs
+++ b/crates/nif/tests/block_coverage_baselines.rs
@@ -1,0 +1,316 @@
+//! Parse-block coverage regression pin (#1332 / NIF-2026-05-29-04).
+//!
+//! A **distinct surface** from the two existing baseline harnesses:
+//!   * `translation_completeness.rs` measures whether parsed blocks
+//!     *translate* to a canonical Material — it never looks at block
+//!     counts, so a truncated file that produces no Material anyway is
+//!     invisible to it.
+//!   * `per_block_baselines.rs` pins per-type `NiUnknown` growth against
+//!     a checked-in histogram — a *regression* signal, not an absolute
+//!     coverage gate.
+//!
+//! Neither asserts **block-count parity**. That is the gap the Oblivion
+//! `bhkConvexSweepShape` / `bhkMeshShape` cascade (F-01 / #1331's audit
+//! sibling) slipped through: a sizeless block with no dispatch arm drops
+//! the rest of the file, the file-level recoverable-rate stays 100%, and
+//! only an ad-hoc probe caught it. This pin closes that:
+//!
+//!   * **Oblivion (sizeless): block-count parity, regression-gated.**
+//!     A sizeless truncation drops the rest of the file
+//!     (`scene.len() < header.num_blocks`). The ideal is zero truncation,
+//!     but vanilla Oblivion still has a tail of files whose undispatched
+//!     sizeless blocks truncate (beyond the F-01 `bhkConvexSweepShape` /
+//!     `bhkMeshShape` pair, which *is* fixed — those three named files
+//!     parse whole now). Fixing the remaining tail means writing new
+//!     block parsers — out of scope for a coverage-pin. So, like
+//!     `per_block_baselines`, the gate is **no-new-truncation**: the set
+//!     of truncating files is checked in, improvements are silent, and a
+//!     *new* truncating file (e.g. an F-01-class dispatch-arm regression)
+//!     fails the test. The baseline file is the visible, tracked record
+//!     of the remaining gap — the opposite of the silent loss this pin
+//!     exists to prevent.
+//!   * **Sized games (FO3+): NiUnknown-rate ceiling.** `block_size` lets
+//!     the loop seek past a busted block and drop a `NiUnknown`
+//!     placeholder, so the count stays whole; the regression signal is
+//!     the *rate* of those placeholders. Pinned against a checked-in
+//!     per-game baseline (improvement is silent; growth fails).
+//!
+//! ## Why opt-in
+//!
+//! Same constraint as `parse_real_nifs.rs` / `per_block_baselines.rs`:
+//! CI machines have no game data, so every test is `#[ignore]`d and skips
+//! cleanly when the archive can't be opened.
+//!
+//! Capture the sized-game baselines once on a machine that has the data:
+//!
+//! ```sh
+//! BYROREDUX_REGEN_BASELINES=1 \
+//!   cargo test -p byroredux-nif --test block_coverage_baselines -- --ignored --nocapture
+//! ```
+//!
+//! That writes `crates/nif/tests/data/block_coverage_baselines/<game>.tsv`
+//! for every sized game whose data is available. Check those files in.
+
+mod common;
+
+use common::{open_mesh_archive, Game};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+fn regen_mode() -> bool {
+    std::env::var("BYROREDUX_REGEN_BASELINES")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+}
+
+fn baselines_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data")
+        .join("block_coverage_baselines")
+}
+
+// ── Oblivion: exact block-count parity (sizeless) ─────────────────────
+
+/// Oblivion is sizeless — an undispatched block can't be skipped, so it
+/// truncates the rest of the file (`scene.len() < header.num_blocks`).
+/// Gate on **no new truncation** against a checked-in set of the files
+/// that currently truncate: improvements are silent, a newly-truncating
+/// file fails loud. An F-01-class regression (dispatch arm removed for a
+/// sizeless block — `handscythe01.nif` / `oar01.nif` /
+/// `ungrdltraphingedoor.nif` parse whole now) re-truncates files that
+/// aren't in the baseline → red.
+#[test]
+#[ignore]
+fn oblivion_block_count_parity() {
+    let Some(archive) = open_mesh_archive(Game::Oblivion) else {
+        return;
+    };
+    let files: Vec<String> = archive
+        .list_files()
+        .into_iter()
+        .filter(|p| p.to_ascii_lowercase().ends_with(".nif"))
+        .collect();
+
+    let mut parsed = 0usize;
+    // path -> dropped block count, sorted for a stable baseline file.
+    let mut truncating: BTreeMap<String, usize> = BTreeMap::new();
+    for path in &files {
+        let Ok(bytes) = archive.extract(path) else {
+            continue;
+        };
+        // A hard parse error is a different failure mode (covered by
+        // `parse_real_nifs.rs`); this pin is specifically about *silent*
+        // block loss on an otherwise-Ok parse.
+        let Ok(scene) = byroredux_nif::parse_nif(&bytes) else {
+            continue;
+        };
+        parsed += 1;
+        if scene.truncated || scene.dropped_block_count > 0 {
+            truncating.insert(path.clone(), scene.dropped_block_count);
+        }
+    }
+
+    eprintln!(
+        "[Oblivion] block-count parity: {}/{} NIFs whole, {} truncating",
+        parsed - truncating.len(),
+        parsed,
+        truncating.len()
+    );
+
+    let path = baseline_path("oblivion_truncations");
+    if regen_mode() {
+        std::fs::create_dir_all(path.parent().unwrap()).expect("create baselines dir");
+        let mut body = format!(
+            "# Oblivion sizeless-truncation baseline\ttruncating={}\tparsed={}\n",
+            truncating.len(),
+            parsed
+        );
+        for (p, dropped) in &truncating {
+            body.push_str(&format!("{p}\t{dropped}\n"));
+        }
+        std::fs::write(&path, &body).expect("write baseline");
+        eprintln!("[Oblivion] regen mode: wrote {}", path.display());
+        return;
+    }
+
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => panic!(
+            "[Oblivion] no baseline at {} ({}); regenerate with \
+             `BYROREDUX_REGEN_BASELINES=1 cargo test -p byroredux-nif \
+             --test block_coverage_baselines -- --ignored`",
+            path.display(),
+            e
+        ),
+    };
+    let baseline: BTreeSet<String> = text
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .filter_map(|l| l.split('\t').next().map(str::to_string))
+        .collect();
+
+    let new_truncations: Vec<&String> = truncating
+        .keys()
+        .filter(|p| !baseline.contains(*p))
+        .collect();
+
+    if !new_truncations.is_empty() {
+        for p in new_truncations.iter().take(20) {
+            eprintln!("  NEW TRUNCATION {p}: dropped {}", truncating[*p]);
+        }
+        panic!(
+            "[Oblivion] {} file(s) newly lose blocks to sizeless truncation — \
+             not in the checked-in baseline. A sizeless block lost its dispatch \
+             arm (F-01-class regression). If intentional, regenerate with \
+             `BYROREDUX_REGEN_BASELINES=1`.",
+            new_truncations.len()
+        );
+    }
+    eprintln!(
+        "[Oblivion] no new truncation ({} known, all in baseline)",
+        truncating.len()
+    );
+}
+
+// ── Sized games: NiUnknown-rate ceiling ───────────────────────────────
+
+/// Aggregate parse-block coverage for one sized game.
+struct Coverage {
+    total_blocks: usize,
+    unknown_blocks: usize,
+}
+
+impl Coverage {
+    fn rate(&self) -> f64 {
+        if self.total_blocks == 0 {
+            0.0
+        } else {
+            self.unknown_blocks as f64 / self.total_blocks as f64
+        }
+    }
+}
+
+fn measure_coverage(game: Game) -> Option<Coverage> {
+    let archive = open_mesh_archive(game)?;
+    let (_stats, hist) = common::parse_archive_with_histogram(&archive, None);
+    let total_blocks: usize = hist.counts.values().map(|c| c.parsed + c.unknown).sum();
+    Some(Coverage {
+        total_blocks,
+        unknown_blocks: hist.total_unknown(),
+    })
+}
+
+/// Baseline file: two `key\tvalue` lines (`total_blocks`, `unknown_blocks`)
+/// plus a `#` header. Hand-readable and diffable.
+fn baseline_path(stem: &str) -> PathBuf {
+    baselines_dir().join(format!("{stem}.tsv"))
+}
+
+fn write_baseline(path: &std::path::Path, cov: &Coverage) {
+    std::fs::create_dir_all(path.parent().unwrap()).expect("create baselines dir");
+    let body = format!(
+        "# block coverage baseline (NiUnknown ceiling)\n\
+         total_blocks\t{}\nunknown_blocks\t{}\n",
+        cov.total_blocks, cov.unknown_blocks
+    );
+    std::fs::write(path, body).expect("write baseline");
+}
+
+fn read_baseline_unknown(text: &str) -> usize {
+    text.lines()
+        .find_map(|l| l.strip_prefix("unknown_blocks\t"))
+        .and_then(|v| v.trim().parse().ok())
+        .expect("baseline missing `unknown_blocks` line")
+}
+
+/// Shared driver for the sized-game ceiling tests.
+fn run_unknown_ceiling(game: Game, stem: &str) {
+    let Some(cov) = measure_coverage(game) else {
+        return; // no data on this host — skip, like the sibling harnesses.
+    };
+    eprintln!(
+        "[{}] {} blocks, {} NiUnknown ({:.4}% recovery rate)",
+        game.label(),
+        cov.total_blocks,
+        cov.unknown_blocks,
+        cov.rate() * 100.0
+    );
+
+    let path = baseline_path(stem);
+    if regen_mode() {
+        write_baseline(&path, &cov);
+        eprintln!("[{}] regen mode: wrote {}", game.label(), path.display());
+        return;
+    }
+
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => panic!(
+            "[{}] no baseline at {} ({}); regenerate with \
+             `BYROREDUX_REGEN_BASELINES=1 cargo test -p byroredux-nif \
+             --test block_coverage_baselines -- --ignored`",
+            game.label(),
+            path.display(),
+            e
+        ),
+    };
+    let baseline_unknown = read_baseline_unknown(&text);
+
+    // Vanilla archives are fixed content, so the counts are deterministic:
+    // a parser change can only lower the unknown count (improvement) or
+    // raise it (regression). Improvement is silent; growth fails.
+    assert!(
+        cov.unknown_blocks <= baseline_unknown,
+        "[{}] NiUnknown recovery count grew {} -> {} ({} blocks total). A block \
+         type that used to dispatch now lands on the NiUnknown recovery path. \
+         Investigate via `per_block_baselines`; if intentional, regenerate with \
+         `BYROREDUX_REGEN_BASELINES=1`.",
+        game.label(),
+        baseline_unknown,
+        cov.unknown_blocks,
+        cov.total_blocks,
+    );
+    eprintln!(
+        "[{}] NiUnknown ceiling OK ({} <= {})",
+        game.label(),
+        cov.unknown_blocks,
+        baseline_unknown
+    );
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_fallout_3() {
+    run_unknown_ceiling(Game::Fallout3, "fallout_3");
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_fallout_nv() {
+    run_unknown_ceiling(Game::FalloutNV, "fallout_nv");
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_skyrim_se() {
+    run_unknown_ceiling(Game::SkyrimSE, "skyrim_se");
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_fallout_4() {
+    run_unknown_ceiling(Game::Fallout4, "fallout_4");
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_fallout_76() {
+    run_unknown_ceiling(Game::Fallout76, "fallout_76");
+}
+
+#[test]
+#[ignore]
+fn unknown_ceiling_starfield() {
+    run_unknown_ceiling(Game::Starfield, "starfield");
+}

--- a/crates/nif/tests/data/block_coverage_baselines/fallout_3.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/fallout_3.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	287331
+unknown_blocks	0

--- a/crates/nif/tests/data/block_coverage_baselines/fallout_4.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/fallout_4.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	740562
+unknown_blocks	0

--- a/crates/nif/tests/data/block_coverage_baselines/fallout_76.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/fallout_76.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	1548202
+unknown_blocks	0

--- a/crates/nif/tests/data/block_coverage_baselines/fallout_nv.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/fallout_nv.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	492796
+unknown_blocks	0

--- a/crates/nif/tests/data/block_coverage_baselines/oblivion_truncations.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/oblivion_truncations.tsv
@@ -1,0 +1,56 @@
+# Oblivion sizeless-truncation baseline	truncating=55	parsed=8032
+meshes\creatures\dog\doghead.nif	15
+meshes\creatures\ghost\deatharray.nif	7
+meshes\creatures\goblin\goblinhead.nif	21
+meshes\creatures\goblin\head.nif	21
+meshes\creatures\horse\bridle.nif	8
+meshes\creatures\minotaur\eyelids.nif	12
+meshes\creatures\minotaur\head.nif	12
+meshes\creatures\mountainlion\head.nif	10
+meshes\creatures\mountainlion\paw_l.nif	10
+meshes\creatures\mountainlion\paw_r.nif	10
+meshes\dungeons\ayleidruins\interior\argreatwelkydstoneitem01.nif	31
+meshes\dungeons\ayleidruins\interior\arwelkydclusterfx01.nif	7
+meshes\dungeons\ayleidruins\interior\traps\artrapchannelspikes01.nif	121
+meshes\dungeons\ayleidruins\interior\traps\artrapevilstone01.nif	11
+meshes\dungeons\misc\dustcloudhorizontal01.nif	90
+meshes\dungeons\misc\dustfallingbits01.nif	11
+meshes\dungeons\misc\dustgroundpuff01.nif	13
+meshes\dungeons\misc\fx\fxcloudthick02.nif	11
+meshes\dungeons\misc\fx\fxdustcloud01.nif	14
+meshes\dungeons\misc\fx\fxdustcloudfaint01.nif	7
+meshes\dungeons\misc\fx\fxdustfall01.nif	13
+meshes\dungeons\misc\fx\fxdustpuffup01.nif	14
+meshes\dungeons\misc\fx\fxlightbeamdust01.nif	7
+meshes\dungeons\misc\fx\fxplasmacloud01.nif	11
+meshes\dungeons\misc\fx\fxtwinklelights01.nif	10
+meshes\dungeons\misc\risingdustcloud01.nif	13
+meshes\effects\metalsparks.nif	40
+meshes\effects\skeletonbloodspray.nif	129
+meshes\effects\stonedustcloud.nif	40
+meshes\effects\willothewispbloodspray.nif	113
+meshes\landscape\miscfirefly01.nif	14
+meshes\landscape\miscfirefly02.nif	14
+meshes\landscape\miscfirefly03.nif	14
+meshes\landscape\miscfirefly04.nif	14
+meshes\magiceffects\binditem.nif	36
+meshes\magiceffects\summondaedra.nif	107
+meshes\marker_arrow.nif	5
+meshes\marker_divine.nif	9
+meshes\marker_map.nif	8
+meshes\marker_radius.nif	2
+meshes\marker_temple.nif	9
+meshes\marker_travel.nif	5
+meshes\menus\armor repair\hammer.nif	15
+meshes\menus\armor repair\white spot.nif	16
+meshes\menus\enemy health bar\health_bar01_old.nif	98
+meshes\menus\enemy health bar\health_bar_old.nif	102
+meshes\menus\hud_brackets\a_b_c_d_seq.nif	117
+meshes\menus\lockpicking\boltgearsloop.nif	48
+meshes\menus\lockpicking\pickold.nif	42
+meshes\menus\lockpicking\tumbler.nif	102
+meshes\menus\lockpicking\tumbler01.nif	47
+meshes\menus\lockpicking\tumbler02.nif	47
+meshes\menus\persuasion\gradient.nif	30
+meshes\menus\spell effect timer\timer.nif	102
+meshes\oblivion\architecture\citadel\interior\switch\scampswitch01.nif	52

--- a/crates/nif/tests/data/block_coverage_baselines/skyrim_se.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/skyrim_se.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	665846
+unknown_blocks	0

--- a/crates/nif/tests/data/block_coverage_baselines/starfield.tsv
+++ b/crates/nif/tests/data/block_coverage_baselines/starfield.tsv
@@ -1,0 +1,3 @@
+# block coverage baseline (NiUnknown ceiling)
+total_blocks	770322
+unknown_blocks	1036


### PR DESCRIPTION
…ge pin

#1331 — NiAVObject.Flags and BSShaderNoLightingProperty falloff width followed the variant-level `avobject_flags_u32()` helper, but nif.xml gates both strictly per-file on `#BSVER# #GT# 26`. A transitional v20.2.0.7/uv=11/bsver<=26 export (NifSkope/newer-tool Oblivion + non-Bethesda Gamebryo) detects as the Fallout3 variant, so the helper said u32 where 2 bytes (flags) / 0 bytes (falloff) are on disk — slipping the stream, masked by block_size realignment (cf. #342). Both sites now branch on `stream.bsver() > bsver::FLAGS_U32_THRESHOLD` (the =26 constant that already existed for this gate). Regression tests pin the u16 (bsver=11) and u32 (bsver=34) branches for both blocks.

#1332 — add `crates/nif/tests/block_coverage_baselines.rs`, a parse-block coverage pin distinct from translation_completeness (Material surface) and per_block_baselines (per-type unknown growth):
  * Oblivion (sizeless): block-count parity, gated no-new-truncation against a checked-in set of currently-truncating files. F-01 is fixed (handscythe01/oar01/ungrdltraphingedoor parse whole), so an F-01-class dispatch-arm regression re-truncates files absent from the baseline -> red.
  * Sized games (FO3+): NiUnknown-rate ceiling per game. Opt-in #[ignore] (CABI has no game data); baselines captured for all 7 games. Surfaced a broader gap: 55 vanilla Oblivion meshes still truncate from other undispatched sizeless block types (now visible/tracked in oblivion_truncations.tsv) — follow-up worth its own issue.