### PR TITLE
chore: clear workspace clippy debt for `cargo clippy --workspace -- -…

### DIFF
--- a/byroredux/src/cell_loader.rs
+++ b/byroredux/src/cell_loader.rs
@@ -78,6 +78,7 @@ mod exterior;
 pub use index::LoadedCellIndex;
 pub use transition::{
     load_interior_cell, log_transition_header, position_zup_to_yup, reposition_camera,
+    InteriorCellRequest,
     rotation_zup_to_yup_quat, take_pending_transition, unload_current_interior, CurrentCellRoot,
     LoadedPluginSet, PendingCellTransition, PendingCellTransitionSlot, TransitionDestination,
 };

--- a/byroredux/src/cell_loader/exterior.rs
+++ b/byroredux/src/cell_loader/exterior.rs
@@ -279,13 +279,15 @@ pub fn load_one_exterior_cell(
     if let Some(ref land) = cell.landscape {
         let _ = terrain::spawn_terrain_mesh(
             world,
-            ctx,
-            tex_provider,
-            &index.landscape_textures,
+            terrain::TerrainSpawnCtx {
+                ctx: &mut *ctx,
+                tex_provider,
+                landscape_textures: &index.landscape_textures,
+                blas_specs: &mut *blas_sink,
+            },
             gx,
             gy,
             land,
-            blas_sink,
         );
     }
     // Water plane. A cell's explicit XCLW height wins; cells without one

--- a/byroredux/src/cell_loader/load.rs
+++ b/byroredux/src/cell_loader/load.rs
@@ -273,7 +273,7 @@ pub fn load_cell_with_masters(
         world,
         ctx,
         tex_provider,
-        mat_provider.as_deref_mut(),
+        mat_provider,
         &cell.editor_id,
         &load_order,
         absorbed,

--- a/byroredux/src/cell_loader/object_lod.rs
+++ b/byroredux/src/cell_loader/object_lod.rs
@@ -200,9 +200,7 @@ fn spawn_object_lod_quad(
         return None;
     }
 
-    if ctx.allocator.is_none() {
-        return None;
-    }
+    ctx.allocator.as_ref()?;
 
     // Shared object atlas for the worldspace (`<world>.objects.dds`). `0` /
     // fallback → the LOD draws untextured-grey, still better than no distant

--- a/byroredux/src/cell_loader/precombined.rs
+++ b/byroredux/src/cell_loader/precombined.rs
@@ -11,8 +11,8 @@
 //! **Current state** (M49 — complete): this loader reads each `_oc.nif`
 //! from the asset BSA chain (typically `Fallout4 - MeshesExtra.ba2`), then
 //! resolves the vertex / triangle data from the companion `Fallout4 - Geometry.csg`
-//! blob via `CsgArchive` (one big zlib-compressed PSG keyed by filename hash
-//! + offset per `BSPackedGeomObject`). Meshes are decoded to Y-up, spawned
+//! blob via `CsgArchive` (one big zlib-compressed PSG keyed by filename
+//! hash + offset per `BSPackedGeomObject`). Meshes are decoded to Y-up, spawned
 //! at cell-local identity, and tagged as `RenderLayer::Architecture`. LOD is
 //! selected by triangle count (finest LOD only, per `fo4-csg-format.md:138-142`).
 //! Absorption gate in [`super::load::load_cell_with_masters`] (conditional on

--- a/byroredux/src/cell_loader/spawn.rs
+++ b/byroredux/src/cell_loader/spawn.rs
@@ -16,6 +16,7 @@ use byroredux_core::form_id::{FormIdPair, FormIdPool};
 use byroredux_core::math::coord::EXTERIOR_CELL_UNITS;
 use byroredux_core::math::{Quat, Vec3};
 use byroredux_plugin::esm;
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::VulkanContext;
 
 use crate::asset_provider::{
@@ -667,24 +668,23 @@ pub(super) fn spawn_placed_instances(
                 .collect();
 
             let alloc = ctx.allocator.as_ref().unwrap();
+            let upload_ctx = GpuUploadCtx {
+                device: &ctx.device,
+                allocator: alloc,
+                queue: &ctx.graphics_queue,
+                command_pool: ctx.transfer_pool,
+            };
             let upload_result = match mesh_cache_key {
                 Some(key) => ctx.mesh_registry.register_scene_mesh_keyed(
-                    &ctx.device,
-                    alloc,
-                    &ctx.graphics_queue,
-                    ctx.transfer_pool,
+                    upload_ctx,
                     &vertices,
                     &mesh.indices,
                     ctx.device_caps.ray_query_supported,
                     None,
-                    key,
-                    sub_mesh_index_u32,
+                    (key, sub_mesh_index_u32),
                 ),
                 None => ctx.mesh_registry.upload_scene_mesh(
-                    &ctx.device,
-                    alloc,
-                    &ctx.graphics_queue,
-                    ctx.transfer_pool,
+                    upload_ctx,
                     &vertices,
                     &mesh.indices,
                     ctx.device_caps.ray_query_supported,

--- a/byroredux/src/cell_loader/terrain.rs
+++ b/byroredux/src/cell_loader/terrain.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use byroredux_core::ecs::{GlobalTransform, MeshHandle, TextureHandle, Transform, World};
 use byroredux_core::math::coord::EXTERIOR_CELL_UNITS;
 use byroredux_plugin::esm;
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::{Vertex, VulkanContext};
 
 use crate::asset_provider::{resolve_texture, TextureProvider};
@@ -292,16 +293,30 @@ fn release_splat_layer_textures(ctx: &mut VulkanContext, indices: &[u32]) {
     }
 }
 
+/// Renderer-side borrows shared by terrain spawning: the Vulkan context,
+/// texture provider, the cell's landscape-texture lookup, and the BLAS spec
+/// sink the caller batches builds through. Grouped to keep
+/// [`spawn_terrain_mesh`]'s argument count in check.
+pub(super) struct TerrainSpawnCtx<'a> {
+    pub ctx: &'a mut VulkanContext,
+    pub tex_provider: &'a TextureProvider,
+    pub landscape_textures: &'a HashMap<u32, String>,
+    pub blas_specs: &'a mut Vec<(u32, u32, u32)>,
+}
+
 pub(super) fn spawn_terrain_mesh(
     world: &mut World,
-    ctx: &mut VulkanContext,
-    tex_provider: &TextureProvider,
-    landscape_textures: &HashMap<u32, String>,
+    spawn: TerrainSpawnCtx,
     grid_x: i32,
     grid_y: i32,
     land: &esm::cell::LandscapeData,
-    blas_specs: &mut Vec<(u32, u32, u32)>,
 ) -> Option<usize> {
+    let TerrainSpawnCtx {
+        ctx,
+        tex_provider,
+        landscape_textures,
+        blas_specs,
+    } = spawn;
     const GRID: usize = 33;
     const SPACING: f32 = EXTERIOR_CELL_UNITS / 32.0; // 128.0
 
@@ -409,11 +424,14 @@ pub(super) fn spawn_terrain_mesh(
         release_splat_layer_textures(ctx, &splat_tex_indices);
         return None;
     }
+    let upload_ctx = GpuUploadCtx {
+        device: &ctx.device,
+        allocator: ctx.allocator.as_ref().unwrap(), // non-None checked just above
+        queue: &ctx.graphics_queue,
+        command_pool: ctx.transfer_pool,
+    };
     let mesh_handle = match ctx.mesh_registry.upload_scene_mesh(
-        &ctx.device,
-        ctx.allocator.as_ref().unwrap(), // non-None checked just above
-        &ctx.graphics_queue,
-        ctx.transfer_pool,
+        upload_ctx,
         &vertices,
         &indices,
         ctx.device_caps.ray_query_supported,

--- a/byroredux/src/cell_loader/terrain_lod.rs
+++ b/byroredux/src/cell_loader/terrain_lod.rs
@@ -134,7 +134,7 @@ fn assemble_hole_mask(bi: i32, bj: i32, holed: impl Fn(i32, i32) -> bool) -> u16
 
 /// Mask with every cell holed — an empty block (no geometry to draw).
 fn all_holed_mask() -> u16 {
-    (((1u32 << (LOD_BLOCK_CELLS * LOD_BLOCK_CELLS)) - 1)) as u16
+    ((1u32 << (LOD_BLOCK_CELLS * LOD_BLOCK_CELLS)) - 1) as u16
 }
 
 /// The 16-bit per-cell hole pattern for block `(bi, bj)` given the player's
@@ -406,9 +406,7 @@ fn spawn_lod_block(
         return None; // entirely holes — nothing to draw
     }
 
-    if ctx.allocator.is_none() {
-        return None;
-    }
+    ctx.allocator.as_ref()?;
 
     // World-space bound from the emitted (non-hole) vertices for frustum
     // culling. Computed over all pushed vertices; hole placeholders sit at

--- a/byroredux/src/cell_loader/transition.rs
+++ b/byroredux/src/cell_loader/transition.rs
@@ -207,17 +207,32 @@ pub fn reposition_camera(
 ///
 /// Returns the engine-Y-up camera position on success so the App can
 /// log + signal the SVGF/TAA temporal-discontinuity recovery window.
+/// Source + destination descriptor for an interior transition: which cell to
+/// load (`editor_id` resolved against `masters` / `esm_path`) and where to
+/// drop the camera afterwards (Z-up position + rotation, converted to Y-up
+/// inside [`load_interior_cell`]). Grouped to keep the argument count down.
+pub struct InteriorCellRequest<'a> {
+    pub editor_id: &'a str,
+    pub masters: &'a [String],
+    pub esm_path: &'a str,
+    pub dest_pos_zup: [f32; 3],
+    pub dest_rot_zup: [f32; 3],
+}
+
 pub fn load_interior_cell(
     world: &mut byroredux_core::ecs::World,
     ctx: &mut byroredux_renderer::VulkanContext,
     tex_provider: &crate::asset_provider::TextureProvider,
     mat_provider: Option<&mut crate::asset_provider::MaterialProvider>,
-    editor_id: &str,
-    masters: &[String],
-    esm_path: &str,
-    dest_pos_zup: [f32; 3],
-    dest_rot_zup: [f32; 3],
+    request: InteriorCellRequest,
 ) -> Result<Vec3, String> {
+    let InteriorCellRequest {
+        editor_id,
+        masters,
+        esm_path,
+        dest_pos_zup,
+        dest_rot_zup,
+    } = request;
     unload_current_interior(world, ctx);
     let result = super::load_cell_with_masters(
         masters,

--- a/byroredux/src/cell_loader/water.rs
+++ b/byroredux/src/cell_loader/water.rs
@@ -31,6 +31,7 @@ use byroredux_core::ecs::components::water::{WaterPlane, WaterVolume};
 use byroredux_core::ecs::{GlobalTransform, MeshHandle, Transform, World};
 use byroredux_plugin::esm;
 use byroredux_core::math::{Quat, Vec3};
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::{Vertex, VulkanContext};
 use std::collections::HashMap;
 
@@ -156,11 +157,14 @@ pub(super) fn spawn_water_plane(
     // Y-up local), so emit CCW directly.
     let indices = vec![0u32, 2, 1, 1, 2, 3];
 
-    let mesh_handle = match ctx.mesh_registry.upload_scene_mesh(
-        &ctx.device,
+    let upload_ctx = GpuUploadCtx {
+        device: &ctx.device,
         allocator,
-        &ctx.graphics_queue,
-        ctx.transfer_pool,
+        queue: &ctx.graphics_queue,
+        command_pool: ctx.transfer_pool,
+    };
+    let mesh_handle = match ctx.mesh_registry.upload_scene_mesh(
+        upload_ctx,
         &vertices,
         &indices,
         // Water meshes do NOT need BLAS — they're skipped from TLAS

--- a/byroredux/src/commands.rs
+++ b/byroredux/src/commands.rs
@@ -107,7 +107,7 @@ impl ConsoleCommand for EntitiesCommand {
             Some(cq) => {
                 let mesh_q = world.query::<MeshHandle>();
                 cq.iter()
-                    .filter(|(e, _)| mesh_q.as_ref().map_or(true, |mq| !mq.contains(*e)))
+                    .filter(|(e, _)| mesh_q.as_ref().is_none_or(|mq| !mq.contains(*e)))
                     .count()
             }
             None => 0,
@@ -195,7 +195,7 @@ impl ConsoleCommand for TexMissingCommand {
         }
 
         let mut sorted: Vec<_> = missing.into_iter().collect();
-        sorted.sort_by(|a, b| b.1.0.cmp(&a.1.0));
+        sorted.sort_by_key(|e| std::cmp::Reverse(e.1.0));
 
         let mut lines = vec![format!("{} unique missing textures:", sorted.len())];
         for (path, (count, samples)) in sorted.iter().take(50) {
@@ -252,7 +252,7 @@ impl ConsoleCommand for TexLoadedCommand {
             fallback_count
         )];
         let mut sorted: Vec<_> = loaded.into_iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
         for (path, count) in sorted.iter().take(30) {
             lines.push(format!("  {:4}x  {}", count, path));
         }

--- a/byroredux/src/debug_load.rs
+++ b/byroredux/src/debug_load.rs
@@ -60,11 +60,13 @@ pub fn execute_pending_debug_loads(
                     world,
                     ctx,
                     streaming,
-                    &esm,
+                    DebugLoadSource {
+                        esm: &esm,
+                        masters: &masters,
+                        bsas: &bsas,
+                        textures_bsas: &textures_bsas,
+                    },
                     &cell,
-                    &masters,
-                    &bsas,
-                    &textures_bsas,
                 );
             }
             PendingDebugLoad::ExteriorCell {
@@ -81,14 +83,18 @@ pub fn execute_pending_debug_loads(
                     world,
                     ctx,
                     streaming,
-                    &esm,
-                    grid_x,
-                    grid_y,
-                    radius,
-                    worldspace.as_deref(),
-                    &masters,
-                    &bsas,
-                    &textures_bsas,
+                    DebugLoadSource {
+                        esm: &esm,
+                        masters: &masters,
+                        bsas: &bsas,
+                        textures_bsas: &textures_bsas,
+                    },
+                    DebugExteriorTarget {
+                        grid_x,
+                        grid_y,
+                        radius,
+                        worldspace: worldspace.as_deref(),
+                    },
                 );
             }
         }
@@ -177,16 +183,39 @@ fn resolve_nif_bytes(path: &str) -> Option<Vec<u8>> {
     None
 }
 
+/// Shared plugin + archive source for a debug cell load: the ESM, its master
+/// chain, and the mesh / texture BSA lists used to synthesize a provider.
+/// Grouped so both [`exec_load_interior`] and [`exec_load_exterior`] stay
+/// under the argument-count limit.
+struct DebugLoadSource<'a> {
+    esm: &'a str,
+    masters: &'a [String],
+    bsas: &'a [String],
+    textures_bsas: &'a [String],
+}
+
+/// Exterior grid target for a debug load: the center cell, stream radius, and
+/// optional worldspace editor-id override.
+struct DebugExteriorTarget<'a> {
+    grid_x: i32,
+    grid_y: i32,
+    radius: u8,
+    worldspace: Option<&'a str>,
+}
+
 fn exec_load_interior(
     world: &mut World,
     ctx: &mut VulkanContext,
     streaming: &mut Option<streaming::WorldStreamingState>,
-    esm: &str,
+    source: DebugLoadSource,
     cell: &str,
-    masters: &[String],
-    bsas: &[String],
-    textures_bsas: &[String],
 ) {
+    let DebugLoadSource {
+        esm,
+        masters,
+        bsas,
+        textures_bsas,
+    } = source;
     if streaming.is_some() {
         drain_streaming_state(world, ctx, streaming);
     }
@@ -239,15 +268,21 @@ fn exec_load_exterior(
     world: &mut World,
     ctx: &mut VulkanContext,
     streaming: &mut Option<streaming::WorldStreamingState>,
-    esm: &str,
-    grid_x: i32,
-    grid_y: i32,
-    radius: u8,
-    worldspace: Option<&str>,
-    masters: &[String],
-    bsas: &[String],
-    textures_bsas: &[String],
+    source: DebugLoadSource,
+    target: DebugExteriorTarget,
 ) {
+    let DebugLoadSource {
+        esm,
+        masters,
+        bsas,
+        textures_bsas,
+    } = source;
+    let DebugExteriorTarget {
+        grid_x,
+        grid_y,
+        radius,
+        worldspace,
+    } = target;
     // CLI radius cap is 1..=7 — clamp the wire value here so a
     // bogus `0` doesn't trip the assertion in
     // `build_exterior_world_context` and a runaway `200` doesn't try

--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -39,7 +39,8 @@ use byroredux_core::ecs::{
 };
 use byroredux_core::string::StringPool;
 use byroredux_platform::window::{self, WindowConfig};
-use byroredux_renderer::vulkan::context::DrawCommand;
+use byroredux_renderer::vulkan::context::{DrawCommand, FrameInputs};
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::VulkanContext;
 use byroredux_ui::UiManager;
 use std::collections::HashMap;
@@ -1191,8 +1192,8 @@ impl App {
     ///   (drain `state.loaded`, shutdown the worker thread), then
     ///   call `cell_loader::load_interior_cell` for the destination.
     /// * `Exterior` — tear down current interior (if any), tear down
-    ///   existing streaming state, build a fresh `ExteriorWorldContext`
-    ///   + `WorldStreamingState` for the destination worldspace,
+    ///   existing streaming state, build a fresh `ExteriorWorldContext` +
+    ///   `WorldStreamingState` for the destination worldspace,
     ///   stream initial radius, reposition camera.
     ///
     /// Provider construction is per-transition: rebuilding from CLI
@@ -1241,11 +1242,13 @@ impl App {
                     ctx,
                     &tex_provider,
                     Some(&mut mat_provider),
-                    &editor_id,
-                    &masters,
-                    &esm_path,
-                    pending.destination_position_zup,
-                    pending.destination_rotation_zup,
+                    cell_loader::InteriorCellRequest {
+                        editor_id: &editor_id,
+                        masters: &masters,
+                        esm_path: &esm_path,
+                        dest_pos_zup: pending.destination_position_zup,
+                        dest_rot_zup: pending.destination_rotation_zup,
+                    },
                 ) {
                     Ok(cam_pos) => {
                         log::info!(
@@ -1356,20 +1359,20 @@ impl App {
 
 }
 
-/// Tear down the active exterior streaming state: drain every loaded
-/// cell via `unload_cell`, flush the renderer's deferred-destroy
-/// queues, then shutdown the worker thread with a bounded timeout.
-/// Leaves `*streaming_slot = None` on return.
-///
-/// Free function (not an `App` method) so the caller can split-borrow
-/// `&mut self.world` / `&mut self.streaming` / `&mut self.renderer`
-/// without aliasing — the `App` method form fights the borrow checker
-/// when `ctx` was already extracted from `self.renderer.as_mut()`.
-///
-/// Pulled out of the `WindowEvent::CloseRequested` handler so
-/// transition flows can re-use the same teardown sequence — the
-/// shutdown ordering invariants (loaded cells before worker join
-/// before context drop) are identical at door transitions.
+// Tear down the active exterior streaming state: drain every loaded
+// cell via `unload_cell`, flush the renderer's deferred-destroy
+// queues, then shutdown the worker thread with a bounded timeout.
+// Leaves `*streaming_slot = None` on return.
+//
+// Free function (not an `App` method) so the caller can split-borrow
+// `&mut self.world` / `&mut self.streaming` / `&mut self.renderer`
+// without aliasing — the `App` method form fights the borrow checker
+// when `ctx` was already extracted from `self.renderer.as_mut()`.
+//
+// Pulled out of the `WindowEvent::CloseRequested` handler so
+// transition flows can re-use the same teardown sequence — the
+// shutdown ordering invariants (loaded cells before worker join
+// before context drop) are identical at door transitions.
 
 // Phase 14 — `render_one_frame` is an inherent method on `App` so it
 // can be called from both the `WindowEvent::RedrawRequested` arm (now
@@ -1417,7 +1420,7 @@ impl App {
         };
         self.debug_ui_refresh_entities = false;
 
-        let (egui_frame, outputs) = if let (Some(ref mut ui), Some(ref win)) =
+        let (egui_frame, outputs) = if let (Some(ref mut ui), Some(win)) =
             (self.debug_ui.as_mut(), self.window.as_ref())
         {
             let outputs = ui.run(win, &snapshot);
@@ -1507,15 +1510,14 @@ impl App {
                 if let Some(pixels) = ui.render() {
                     if let Some(handle) = self.ui_texture_handle {
                         let allocator = ctx.allocator.as_ref().unwrap();
-                        if let Err(e) = ctx.texture_registry.update_rgba(
-                            &ctx.device,
+                        let upload_ctx = GpuUploadCtx {
+                            device: &ctx.device,
                             allocator,
-                            &ctx.graphics_queue,
-                            ctx.transfer_pool,
-                            handle,
-                            ui_w,
-                            ui_h,
-                            pixels,
+                            queue: &ctx.graphics_queue,
+                            command_pool: ctx.transfer_pool,
+                        };
+                        if let Err(e) = ctx.texture_registry.update_rgba(
+                            upload_ctx, handle, ui_w, ui_h, pixels,
                         ) {
                             log::error!("UI texture update failed: {e:#}");
                         }
@@ -1588,29 +1590,29 @@ impl App {
                 ctx.light_atten_knee = lt.knee_frac;
                 ctx.light_atten_legacy = lt.legacy;
             }
-            match ctx.draw_frame(
+            match ctx.draw_frame(FrameInputs {
                 clear_color,
-                &frame.view_proj,
-                &self.draw_commands,
-                &self.gpu_lights,
-                &self.bone_world,
-                &pending_with_data,
-                self.material_table.materials(),
-                frame.camera_pos,
-                frame.ambient,
-                frame.fog_color,
-                frame.fog_near,
-                frame.fog_far,
-                frame.fog_clip,
-                frame.fog_power,
-                ui_tex,
-                &frame.sky,
+                view_proj: &frame.view_proj,
+                draw_commands: &self.draw_commands,
+                lights: &self.gpu_lights,
+                bone_world: &self.bone_world,
+                bind_inverse_pending_uploads: &pending_with_data,
+                materials: self.material_table.materials(),
+                camera_pos: frame.camera_pos,
+                ambient_color: frame.ambient,
+                fog_color: frame.fog_color,
+                fog_near: frame.fog_near,
+                fog_far: frame.fog_far,
+                fog_clip: frame.fog_clip,
+                fog_power: frame.fog_power,
+                ui_texture_handle: ui_tex,
+                sky_params: &frame.sky,
                 dof,
-                frame_timings.as_mut(),
-                &self.water_commands,
-                compute_underwater_params(&self.world),
-                self.skin_slot_pool.pose_dirty(),
-            ) {
+                timings: frame_timings.as_mut(),
+                water_commands: &self.water_commands,
+                underwater: compute_underwater_params(&self.world),
+                pose_dirty: self.skin_slot_pool.pose_dirty(),
+            }) {
                 Ok(needs_recreate) => {
                     let last_draw_stats = ctx.last_draw_call_stats;
                     world_resource_set::<DebugStats>(&self.world, |s| {
@@ -1810,7 +1812,7 @@ impl ApplicationHandler for App {
         // dragging an egui slider. CloseRequested + Resized always
         // run their normal handlers — egui doesn't care about
         // those.
-        let egui_consumed = if let (Some(ref mut state), Some(ref win)) =
+        let egui_consumed = if let (Some(ref mut state), Some(win)) =
             (self.debug_ui.as_mut(), self.window.as_ref())
         {
             state.on_window_event(win, &event).consumed

--- a/byroredux/src/render/water.rs
+++ b/byroredux/src/render/water.rs
@@ -37,7 +37,7 @@ use byroredux_renderer::vulkan::water::{WaterDrawCommand, WaterPush};
 /// scale.
 pub(super) fn reemit_water_planes(
     world: &World,
-    draw_commands: &mut Vec<DrawCommand>,
+    draw_commands: &mut [DrawCommand],
     water_commands: &mut Vec<WaterDrawCommand>,
 ) {
     let time_secs = world

--- a/byroredux/src/scene.rs
+++ b/byroredux/src/scene.rs
@@ -9,6 +9,7 @@ use byroredux_core::ecs::{
 };
 use byroredux_core::math::{Quat, Vec3};
 use byroredux_core::string::StringPool;
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::{cube_vertices, quad_vertices, triangle_vertices, VulkanContext};
 use byroredux_ui::UiManager;
 
@@ -314,54 +315,33 @@ pub(crate) fn setup_scene(
         let queue = &ctx.graphics_queue;
         let pool = ctx.transfer_pool;
         let rt = ctx.device_caps.ray_query_supported;
+        let upload_ctx = GpuUploadCtx {
+            device: &ctx.device,
+            allocator: alloc,
+            queue,
+            command_pool: pool,
+        };
         let cube_handle = ctx
             .mesh_registry
-            .upload(&ctx.device, alloc, queue, pool, &verts, &idxs, rt, None)
+            .upload(upload_ctx, &verts, &idxs, rt, None)
             .expect("Failed to upload cube mesh");
 
         let (quad_verts, quad_idxs) = quad_vertices();
         let quad_handle = ctx
             .mesh_registry
-            .upload(
-                &ctx.device,
-                alloc,
-                queue,
-                pool,
-                &quad_verts,
-                &quad_idxs,
-                rt,
-                None,
-            )
+            .upload(upload_ctx, &quad_verts, &quad_idxs, rt, None)
             .expect("Failed to upload quad mesh");
 
         let (red_verts, red_idxs) = triangle_vertices([1.0, 0.2, 0.2]);
         let red_handle = ctx
             .mesh_registry
-            .upload(
-                &ctx.device,
-                alloc,
-                queue,
-                pool,
-                &red_verts,
-                &red_idxs,
-                rt,
-                None,
-            )
+            .upload(upload_ctx, &red_verts, &red_idxs, rt, None)
             .expect("Failed to upload red triangle mesh");
 
         let (blue_verts, blue_idxs) = triangle_vertices([0.2, 0.2, 1.0]);
         let blue_handle = ctx
             .mesh_registry
-            .upload(
-                &ctx.device,
-                alloc,
-                queue,
-                pool,
-                &blue_verts,
-                &blue_idxs,
-                rt,
-                None,
-            )
+            .upload(upload_ctx, &blue_verts, &blue_idxs, rt, None)
             .expect("Failed to upload blue triangle mesh");
 
         // Batched BLAS build for RT shadows on demo meshes.
@@ -823,15 +803,16 @@ pub(crate) fn setup_scene(
                             // Create the initial UI texture (transparent black).
                             let pixels = vec![0u8; (w * h * 4) as usize];
                             let allocator = ctx.allocator.as_ref().unwrap();
-                            match ctx.texture_registry.register_rgba(
-                                &ctx.device,
+                            let upload_ctx = GpuUploadCtx {
+                                device: &ctx.device,
                                 allocator,
-                                &ctx.graphics_queue,
-                                ctx.transfer_pool,
-                                w,
-                                h,
-                                &pixels,
-                            ) {
+                                queue: &ctx.graphics_queue,
+                                command_pool: ctx.transfer_pool,
+                            };
+                            match ctx
+                                .texture_registry
+                                .register_rgba(upload_ctx, w, h, &pixels)
+                            {
                                 Ok(handle) => {
                                     *ui_texture_handle = Some(handle);
                                     log::info!("UI texture registered (handle {})", handle);

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -19,6 +19,7 @@ use byroredux_core::ecs::{
 };
 use byroredux_core::math::{Mat4, Quat, Vec3};
 use byroredux_core::string::StringPool;
+use byroredux_renderer::vulkan::GpuUploadCtx;
 use byroredux_renderer::{Vertex, VulkanContext};
 
 use crate::asset_provider::{
@@ -658,14 +659,17 @@ pub(crate) fn load_nif_bytes_with_skeleton(
             .collect();
 
         let alloc = ctx.allocator.as_ref().unwrap();
+        let upload_ctx = GpuUploadCtx {
+            device: &ctx.device,
+            allocator: alloc,
+            queue: &ctx.graphics_queue,
+            command_pool: ctx.transfer_pool,
+        };
         // upload_scene_mesh registers the vertices/indices into the global
         // geometry SSBO that RT ray queries sample for reflection UVs.
         // See #371.
         let mesh_handle = match ctx.mesh_registry.upload_scene_mesh(
-            &ctx.device,
-            alloc,
-            &ctx.graphics_queue,
-            ctx.transfer_pool,
+            upload_ctx,
             &vertices,
             &mesh.indices,
             ctx.device_caps.ray_query_supported,
@@ -857,7 +861,7 @@ pub(crate) fn load_nif_bytes_with_skeleton(
         }
         // #890 Stage 2c — BSEffectShaderProperty greyscale LUT. Mirrors
         // the cell_loader::spawn site.
-        if let Some(ref lut_path) =
+        if let Some(lut_path) =
             mesh.effect_shader.as_ref().and_then(|es| es.greyscale_texture.as_ref())
         {
             let h = resolve_texture(ctx, tex_provider, Some(lut_path.as_str()));

--- a/byroredux/src/systems/light_anim.rs
+++ b/byroredux/src/systems/light_anim.rs
@@ -1,7 +1,7 @@
 //! Procedural per-frame light animation — Phase 17.
 //!
-//! Walks every entity with a `LightFlicker` companion + `LightSource`
-//! + `Transform`, modulates the light's intensity + position from the
+//! Walks every entity with a `LightFlicker` companion + `LightSource` +
+//! `Transform`, modulates the light's intensity + position from the
 //! FNAM flicker / pulse parameters parsed off the LIGH record.
 //! Skyrim's vanilla flicker bits map to four animation shapes:
 //!

--- a/byroredux/src/systems/weather.rs
+++ b/byroredux/src/systems/weather.rs
@@ -256,6 +256,10 @@ pub(crate) fn cloud_scroll_rate_from_wind(wind_speed: u8) -> f32 {
     wind_speed as f32 * WIND_TO_SCROLL_RATE
 }
 
+/// Seven blended WTHR sky fields, in order:
+/// zenith, horizon, lower, sun_col, ambient, sunlight, fog_col.
+type WthrColors = ([f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3]);
+
 /// Sample a `WeatherDataRes`-shaped snapshot at the given `(slot_a, slot_b, t)`
 /// tuple. Returns the seven blended fields the WTHR cross-fade composer
 /// needs: zenith, horizon, lower, sun_col, ambient, sunlight, fog_col.
@@ -269,7 +273,7 @@ fn sample_wthr_colors(
     slot_a: usize,
     slot_b: usize,
     t: f32,
-) -> ([f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3], [f32; 3]) {
+) -> WthrColors {
     use byroredux_plugin::esm::records::weather::*;
     (
         lerp3(sky_colors[SKY_UPPER][slot_a], sky_colors[SKY_UPPER][slot_b], t),

--- a/crates/bsa/src/archive/hash.rs
+++ b/crates/bsa/src/archive/hash.rs
@@ -62,7 +62,7 @@ pub(super) fn genhash_folder(name: &[u8]) -> u64 {
 pub(super) fn genhash_file(name: &[u8]) -> u64 {
     let (stem_bytes, ext_bytes) = match name.iter().rposition(|&c| c == b'.') {
         Some(i) => (&name[..i], &name[i..]),
-        None => (&name[..], &name[..0]),
+        None => (name, &name[..0]),
     };
 
     // Base hash over the stem.

--- a/crates/bsa/src/ba2.rs
+++ b/crates/bsa/src/ba2.rs
@@ -296,7 +296,7 @@ impl Ba2Archive {
         }
 
         let mut map = HashMap::with_capacity(file_count);
-        for (name, entry) in names.into_iter().zip(files.into_iter()) {
+        for (name, entry) in names.into_iter().zip(files) {
             map.insert(name, entry);
         }
 
@@ -412,11 +412,13 @@ impl Ba2Archive {
                 chunks,
             } => extract_dx10(
                 &mut *file,
-                *dxgi_format,
-                *width,
-                *height,
-                *num_mips,
-                *is_cubemap,
+                Dx10TexInfo {
+                    dxgi_format: *dxgi_format,
+                    width: *width,
+                    height: *height,
+                    num_mips: *num_mips,
+                    is_cubemap: *is_cubemap,
+                },
                 chunks,
                 self.compression,
             ),
@@ -721,13 +723,21 @@ fn extract_general<R: Read + Seek>(
     }
 }
 
-fn extract_dx10<R: Read + Seek>(
-    reader: &mut R,
+/// The DX10 texture-header fields needed to synthesize a DDS header for
+/// a BA2 DX10 entry. Bundled so `extract_dx10` stays within the argument
+/// budget (`clippy::too_many_arguments`); mirrors the `Ba2Entry::Dx10`
+/// header fields one-to-one.
+struct Dx10TexInfo {
     dxgi_format: u8,
     width: u16,
     height: u16,
     num_mips: u8,
     is_cubemap: bool,
+}
+
+fn extract_dx10<R: Read + Seek>(
+    reader: &mut R,
+    info: Dx10TexInfo,
     chunks: &[Dx10Chunk],
     compression: Ba2Compression,
 ) -> io::Result<Vec<u8>> {
@@ -749,11 +759,11 @@ fn extract_dx10<R: Read + Seek>(
 
     // Reconstruct a DDS header in front of the pixel data.
     let mut dds = build_dds_header(
-        dxgi_format,
-        width,
-        height,
-        num_mips,
-        is_cubemap,
+        info.dxgi_format,
+        info.width,
+        info.height,
+        info.num_mips,
+        info.is_cubemap,
         &pixel_data,
     );
     dds.extend_from_slice(&pixel_data);

--- a/crates/core/src/animation/stack.rs
+++ b/crates/core/src/animation/stack.rs
@@ -86,6 +86,12 @@ pub struct AnimationStack {
     pub root_entity: Option<EntityId>,
 }
 
+impl Default for AnimationStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AnimationStack {
     pub fn new() -> Self {
         Self {

--- a/crates/core/src/console.rs
+++ b/crates/core/src/console.rs
@@ -49,6 +49,12 @@ pub struct CommandRegistry {
 
 impl Resource for CommandRegistry {}
 
+impl Default for CommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CommandRegistry {
     pub fn new() -> Self {
         Self {

--- a/crates/core/src/ecs/components/material.rs
+++ b/crates/core/src/ecs/components/material.rs
@@ -94,6 +94,7 @@ pub struct Material {
     ///   * `0` = Ignore (vertex colors disabled)
     ///   * `1` = Emissive (colors drive self-illumination)
     ///   * `2` = AmbientDiffuse (default, colors drive diffuse)
+    ///
     /// The NIF importer already honors `Ignore` by not populating the
     /// mesh's vertex color vec. `Emissive` is forwarded here so the
     /// material system can route the data later. See #214.

--- a/crates/core/src/ecs/components/render_layer.rs
+++ b/crates/core/src/ecs/components/render_layer.rs
@@ -34,11 +34,13 @@ use crate::ecs::storage::Component;
 #[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
+#[derive(Default)]
 pub enum RenderLayer {
     /// Walls, floors, fireplaces, doors, plants rooted in ground,
     /// terrain, vending machines, wall-mounted lamps, terminals,
     /// containers/footlockers built into the level. The base layer that
     /// owns the depth buffer; zero bias.
+    #[default]
     Architecture = 0,
     /// Player-pickup-able items: weapons, armor, ammo, misc clutter,
     /// keys, alchemy, ingredients, books, notes. Small things that
@@ -82,11 +84,6 @@ impl RenderLayer {
     }
 }
 
-impl Default for RenderLayer {
-    fn default() -> Self {
-        Self::Architecture
-    }
-}
 
 /// Apply the spawn-site decal / cutout bias escalation. Two distinct
 /// signals, two distinct outcomes (they used to be conflated — see below):

--- a/crates/core/src/ecs/resources.rs
+++ b/crates/core/src/ecs/resources.rs
@@ -513,8 +513,8 @@ pub struct SkinCoverageStats {
 /// **Why this resource exists**: the GPU TIMESTAMP brackets in
 /// `SkinCoverageStats` measure only work bracketed inside the main
 /// command buffer. Operations that happen OUTSIDE that bracket —
-/// the fence wait at the top of `draw_frame`, the `vkQueueSubmit`
-/// + `vkQueuePresentKHR` block at the end, the egui set_textures
+/// the fence wait at the top of `draw_frame`, the
+/// `vkQueueSubmit` + `vkQueuePresentKHR` block at the end, the egui set_textures
 /// transfer-queue submit-and-wait — are invisible to those
 /// brackets. A pathology surfaced by Phase 7 instrumentation
 /// (sum of 12 GPU brackets = 78 ms vs 389 ms wall frame time = 311 ms

--- a/crates/core/src/ecs/scheduler.rs
+++ b/crates/core/src/ecs/scheduler.rs
@@ -98,6 +98,7 @@ pub struct Scheduler {
 /// to N — that's the parallelism gain. A single system reading
 /// far above the stage wall time means it dominates and the
 /// others run "for free" alongside it.
+#[derive(Default)]
 pub struct SchedulerSystemTimings {
     /// `(system_name, ms)` pairs sorted descending. Re-populated
     /// at the end of every `Scheduler::run`.
@@ -106,13 +107,6 @@ pub struct SchedulerSystemTimings {
 
 impl Resource for SchedulerSystemTimings {}
 
-impl Default for SchedulerSystemTimings {
-    fn default() -> Self {
-        Self {
-            systems: Vec::new(),
-        }
-    }
-}
 
 impl Scheduler {
     pub fn new() -> Self {
@@ -443,7 +437,7 @@ impl Scheduler {
         // rayon worker count (≤ 1 lock per worker per stage), so
         // a ~20-system schedule pays ~20 µs at most.
         let timings: Mutex<Vec<(String, u64)>> = Mutex::new(Vec::new());
-        for (_stage, data) in &mut self.stages {
+        for data in self.stages.values_mut() {
             // Phase 1: run parallel systems concurrently.
             #[cfg(feature = "parallel-scheduler")]
             {
@@ -491,7 +485,7 @@ impl Scheduler {
         // not an error — older callers that never insert it just
         // pay the Mutex-build cost and discard the result.
         let mut all = timings.into_inner().unwrap_or_else(|e| e.into_inner());
-        all.sort_by(|a, b| b.1.cmp(&a.1));
+        all.sort_by_key(|e| std::cmp::Reverse(e.1));
         if let Some(mut out) = world.try_resource_mut::<SchedulerSystemTimings>() {
             out.systems.clear();
             const NS_TO_MS: f32 = 1.0e-6;

--- a/crates/core/src/ecs/systems.rs
+++ b/crates/core/src/ecs/systems.rs
@@ -214,7 +214,7 @@ pub fn make_transform_propagation_system() -> impl FnMut(&World, f32) + Send + S
         // Shared BFS drain. Requires both Parent (to look up each child's
         // parent) and Children (to enqueue grandchildren); a flat scene with
         // neither already reached its final state in the seeding above.
-        let (Some(ref pq), Some(ref cq)) = (parent_q.as_ref(), children_q.as_ref()) else {
+        let (Some(pq), Some(cq)) = (parent_q.as_ref(), children_q.as_ref()) else {
             return;
         };
 

--- a/crates/core/src/string/mod.rs
+++ b/crates/core/src/string/mod.rs
@@ -53,7 +53,7 @@ impl StringPool {
         let mut buf = [0u8; LOWERCASE_STACK_BUF];
         match ascii_lowercase_into_buf(s, &mut buf) {
             Some(lower) => self.0.get_or_intern(lower),
-            None => self.0.get_or_intern(&s.to_ascii_lowercase()),
+            None => self.0.get_or_intern(s.to_ascii_lowercase()),
         }
     }
 
@@ -83,7 +83,7 @@ impl StringPool {
         let mut buf = [0u8; LOWERCASE_STACK_BUF];
         match ascii_lowercase_into_buf(s, &mut buf) {
             Some(lower) => self.0.get(lower),
-            None => self.0.get(&s.to_ascii_lowercase()),
+            None => self.0.get(s.to_ascii_lowercase()),
         }
     }
 }

--- a/crates/debug-protocol/src/registry.rs
+++ b/crates/debug-protocol/src/registry.rs
@@ -6,6 +6,21 @@
 
 use std::collections::BTreeMap;
 
+// Boxed type-erased accessor closures. The concrete `Component` type is
+// captured inside each closure; callers pass the erased store (`&dyn Any`)
+// + an entity id. Aliased to keep [`ComponentDescriptor`] readable and to
+// satisfy `clippy::type_complexity`.
+type GetJsonFn =
+    Box<dyn Fn(&dyn std::any::Any, u32) -> Option<serde_json::Value> + Send + Sync>;
+type SetJsonFn =
+    Box<dyn Fn(&dyn std::any::Any, u32, serde_json::Value) -> Result<(), String> + Send + Sync>;
+type ListEntitiesFn = Box<dyn Fn(&dyn std::any::Any) -> Vec<u32> + Send + Sync>;
+type GetFieldFn =
+    Box<dyn Fn(&dyn std::any::Any, u32, &str) -> Option<serde_json::Value> + Send + Sync>;
+type SetFieldFn = Box<
+    dyn Fn(&dyn std::any::Any, u32, &str, serde_json::Value) -> Result<(), String> + Send + Sync,
+>;
+
 /// Type-erased accessors for a single component type.
 ///
 /// The closures capture the concrete `Component` type and call through to
@@ -18,21 +33,15 @@ pub struct ComponentDescriptor {
     pub field_names: Vec<&'static str>,
     /// Serialize the entire component on an entity to JSON.
     /// Returns None if the entity doesn't have this component.
-    pub get_json: Box<dyn Fn(&dyn std::any::Any, u32) -> Option<serde_json::Value> + Send + Sync>,
+    pub get_json: GetJsonFn,
     /// Deserialize a JSON value and overwrite the entire component on an entity.
-    pub set_json:
-        Box<dyn Fn(&dyn std::any::Any, u32, serde_json::Value) -> Result<(), String> + Send + Sync>,
+    pub set_json: SetJsonFn,
     /// List all entity IDs that have this component.
-    pub list_entities: Box<dyn Fn(&dyn std::any::Any) -> Vec<u32> + Send + Sync>,
+    pub list_entities: ListEntitiesFn,
     /// Serialize a single field of the component to JSON.
-    pub get_field:
-        Box<dyn Fn(&dyn std::any::Any, u32, &str) -> Option<serde_json::Value> + Send + Sync>,
+    pub get_field: GetFieldFn,
     /// Deserialize and set a single field of the component.
-    pub set_field: Box<
-        dyn Fn(&dyn std::any::Any, u32, &str, serde_json::Value) -> Result<(), String>
-            + Send
-            + Sync,
-    >,
+    pub set_field: SetFieldFn,
 }
 
 /// Registry of all inspectable components, keyed by name.
@@ -41,6 +50,12 @@ pub struct ComponentDescriptor {
 /// the component name strings that appear in debug expressions.
 pub struct ComponentRegistry {
     descriptors: BTreeMap<String, ComponentDescriptor>,
+}
+
+impl Default for ComponentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ComponentRegistry {

--- a/crates/debug-server/src/evaluator.rs
+++ b/crates/debug-server/src/evaluator.rs
@@ -349,7 +349,7 @@ fn eval_walk_entity(world: &World, root: u32, max_depth: u32) -> DebugResponse {
         let kids: Vec<u32> = children_q
             .as_ref()
             .and_then(|q| q.get(entity))
-            .map(|c| c.0.iter().copied().collect())
+            .map(|c| c.0.to_vec())
             .unwrap_or_default();
         let gt_t = gt_q
             .as_ref()
@@ -408,7 +408,7 @@ fn eval_walk_entity(world: &World, root: u32, max_depth: u32) -> DebugResponse {
 /// through the in-engine command, a miss falls back to Papyrus
 /// evaluation (so `42.Transform.translation.x` still works).
 fn eval_request(world: &World, registry: &ComponentRegistry, expr: &str) -> DebugResponse {
-    let first_word = expr.trim().split_whitespace().next().unwrap_or("");
+    let first_word = expr.split_whitespace().next().unwrap_or("");
     if !first_word.is_empty() {
         if let Some(reg) = world.try_resource::<CommandRegistry>() {
             if reg.list().iter().any(|(name, _)| *name == first_word) {
@@ -806,7 +806,7 @@ fn eval_tex_missing(world: &World) -> DebugResponse {
         *missing.entry(path.to_string()).or_insert(0) += 1;
     }
     let mut sorted: Vec<_> = missing.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
     let lines: Vec<String> =
         std::iter::once(format!("{} unique missing texture paths:", sorted.len()))
             .chain(
@@ -838,7 +838,7 @@ fn eval_tex_loaded(world: &World) -> DebugResponse {
         *loaded.entry(path.to_string()).or_insert(0) += 1;
     }
     let mut sorted: Vec<_> = loaded.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1));
     let lines: Vec<String> = std::iter::once(format!(
         "{} unique loaded, {} fallback entities",
         sorted.len(),

--- a/crates/debug-server/src/registration.rs
+++ b/crates/debug-server/src/registration.rs
@@ -73,7 +73,7 @@ fn register_component<T>(
 
                 let mut q = world
                     .query_mut::<T>()
-                    .ok_or_else(|| format!("no storage for component"))?;
+                    .ok_or_else(|| "no storage for component".to_string())?;
 
                 let comp = q
                     .get_mut(entity)
@@ -94,7 +94,7 @@ fn register_component<T>(
                     // Tuple struct — replace the whole value
                     json = value;
                 } else {
-                    return Err(format!("component is not a struct with named fields"));
+                    return Err("component is not a struct with named fields".to_string());
                 }
 
                 // Deserialize back and overwrite

--- a/crates/debug-ui/src/panels.rs
+++ b/crates/debug-ui/src/panels.rs
@@ -112,18 +112,15 @@ pub fn draw(
 /// Tab selector enum — `PartialEq` because `selectable_value` needs
 /// it to highlight the active choice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub enum PanelTab {
+    #[default]
     Metrics,
     Loader,
     Entities,
     Console,
 }
 
-impl Default for PanelTab {
-    fn default() -> Self {
-        PanelTab::Metrics
-    }
-}
 
 fn draw_metrics(ui: &mut egui::Ui, snap: Option<&MetricsSnapshotView>) {
     let Some(m) = snap else {
@@ -299,7 +296,7 @@ fn draw_entities(
         None => {
             ui.label("Click 'Refresh' to load the entity list.");
         }
-        Some(list) if list.is_empty() => {
+        Some([]) => {
             ui.label("(no named entities)");
         }
         Some(list) => {

--- a/crates/nif/src/anim/bspline.rs
+++ b/crates/nif/src/anim/bspline.rs
@@ -91,11 +91,11 @@ pub fn deboor_cubic(control_points: &[f32], n: usize, stride: usize, u: f32) -> 
         vec![0.0; stride],
         vec![0.0; stride],
     ];
-    for j in 0..=BSPLINE_DEGREE {
+    for (j, dj) in d.iter_mut().enumerate() {
         let cp_idx = k + j - BSPLINE_DEGREE;
         let cp_idx = cp_idx.min(n - 1);
         let start = cp_idx * stride;
-        d[j].copy_from_slice(&control_points[start..start + stride]);
+        dj.copy_from_slice(&control_points[start..start + stride]);
     }
 
     // Open uniform clamped knot vector for `n` control points and
@@ -126,8 +126,9 @@ pub fn deboor_cubic(control_points: &[f32], n: usize, stride: usize, u: f32) -> 
             } else {
                 0.0
             };
-            for c in 0..stride {
-                d[j][c] = (1.0 - alpha) * d[j - 1][c] + alpha * d[j][c];
+            let (prev, curr) = d.split_at_mut(j);
+            for (dst, &src) in curr[0].iter_mut().zip(prev[j - 1].iter()) {
+                *dst = (1.0 - alpha) * src + alpha * *dst;
             }
         }
     }
@@ -221,7 +222,7 @@ pub fn extract_float_channel_bspline(
 
     let duration = (interp.stop_time - interp.start_time).max(0.0);
     let n_samples_f = (duration * BSPLINE_SAMPLE_HZ).ceil();
-    let n_samples = (n_samples_f as usize).max(2).min(1_000_000);
+    let n_samples = (n_samples_f as usize).clamp(2, 1_000_000);
     let u_max = (n_cp - BSPLINE_DEGREE) as f32;
 
     let mut keys = Vec::with_capacity(n_samples);
@@ -273,7 +274,7 @@ pub fn extract_transform_channel_bspline(
     // out at a few thousand samples even for the longest cinematics.
     let duration = (interp.stop_time - interp.start_time).max(0.0);
     let n_samples_f = (duration * BSPLINE_SAMPLE_HZ).ceil();
-    let n_samples = (n_samples_f as usize).max(2).min(1_000_000);
+    let n_samples = (n_samples_f as usize).clamp(2, 1_000_000);
 
     // Per-channel setup. Each handle is an offset in i16 units into
     // `data.compact_control_points` where that channel's run of
@@ -493,7 +494,7 @@ pub fn channel_slice(
     let needed = n_cp * stride;
     if start
         .checked_add(needed)
-        .map_or(true, |end| end > raw.len())
+        .is_none_or(|end| end > raw.len())
     {
         log::debug!(
             "NiBSplineCompTransformInterpolator: handle {} + {} > data len {}",

--- a/crates/nif/src/anim/channel.rs
+++ b/crates/nif/src/anim/channel.rs
@@ -246,7 +246,7 @@ pub fn sample_color_keys_bspline_point3(
 
     let duration = (interp.stop_time - interp.start_time).max(0.0);
     let n_samples_f = (duration * BSPLINE_SAMPLE_HZ).ceil();
-    let n_samples = (n_samples_f as usize).max(2).min(1_000_000);
+    let n_samples = (n_samples_f as usize).clamp(2, 1_000_000);
     let u_max = (n_cp - BSPLINE_DEGREE) as f32;
 
     let mut keys = Vec::with_capacity(n_samples);

--- a/crates/nif/src/anim/entry.rs
+++ b/crates/nif/src/anim/entry.rs
@@ -128,7 +128,7 @@ pub fn import_embedded_animations(scene: &NifScene) -> Option<AnimationClip> {
     // every block type the import pipeline cares about — adding a new
     // block kind with its own embedded-controller chain is a one-line
     // downcast addition here.
-    fn net_of<'a>(block: &'a dyn crate::NiObject) -> Option<&'a NiObjectNETData> {
+    fn net_of(block: &dyn crate::NiObject) -> Option<&NiObjectNETData> {
         let any = block.as_any();
         if let Some(n) = any.downcast_ref::<NiNode>() {
             return Some(&n.av.net);

--- a/crates/nif/src/blocks/bs_geometry.rs
+++ b/crates/nif/src/blocks/bs_geometry.rs
@@ -209,7 +209,7 @@ pub enum BSGeometryMeshKind {
     /// `0x200` is set. Vanilla Starfield does **not** ship inline
     /// data — every mesh references an external `.mesh` file — but
     /// the format permits it and authoring tools / ports may emit it.
-    Internal { mesh_data: BSGeometryMeshData },
+    Internal { mesh_data: Box<BSGeometryMeshData> },
 }
 
 impl BSGeometryMesh {
@@ -222,7 +222,7 @@ impl BSGeometryMesh {
 
         let kind = if internal {
             BSGeometryMeshKind::Internal {
-                mesh_data: BSGeometryMeshData::parse(stream)?,
+                mesh_data: Box::new(BSGeometryMeshData::parse(stream)?),
             }
         } else {
             // `meshName.Sync(stream, 4)` in nifly — a u32 length-prefixed
@@ -460,14 +460,12 @@ impl BSGeometryMeshData {
         // Per nifly: weight count is interpreted as a *flat* count of
         // BoneWeight entries; the per-vertex grouping is `weights_per_vert`.
         // When `weights_per_vert == 0` we skip the resize (no skin weights).
-        let mut skin_weights: Vec<Vec<BoneWeight>> = if weights_per_vert > 0 {
-            let outer_len = n_total_weights / weights_per_vert;
-            stream.allocate_vec::<Vec<BoneWeight>>(outer_len)?
-        } else {
-            Vec::new()
+        let mut skin_weights: Vec<Vec<BoneWeight>> = match n_total_weights.checked_div(weights_per_vert) {
+            Some(outer_len) => stream.allocate_vec::<Vec<BoneWeight>>(outer_len)?,
+            None => Vec::new(),
         };
-        if weights_per_vert > 0 {
-            let outer_len = (n_total_weights / weights_per_vert) as usize;
+        if let Some(outer_len) = n_total_weights.checked_div(weights_per_vert) {
+            let outer_len = outer_len as usize;
             for _ in 0..outer_len {
                 // #768: route the inner allocation through `allocate_vec`
                 // so a hostile `weights_per_vert = 0xFFFFFFFF` cannot

--- a/crates/nif/src/blocks/collision/constraints.rs
+++ b/crates/nif/src/blocks/collision/constraints.rs
@@ -15,7 +15,7 @@ use std::io;
 /// Opaque stub for a Havok constraint block.
 ///
 /// Holds just the shared `bhkConstraintCInfo` base (two entity refs
-/// + priority); everything else is skipped. The concrete constraint
+/// plus priority); everything else is skipped. The concrete constraint
 /// type is preserved in `type_name` so downstream consumers and
 /// telemetry can identify it. See #117.
 #[derive(Debug)]

--- a/crates/nif/src/blocks/collision/ragdoll.rs
+++ b/crates/nif/src/blocks/collision/ragdoll.rs
@@ -150,7 +150,7 @@ impl BhkRagdollTemplate {
 ///
 /// First-pass stub per #980 / NIF-D5-NEW-04: parse the leading
 /// scalars (Name / Mass / Restitution / Friction / Radius / Material)
-/// + the constraint count, then skip the constraint array via
+/// plus the constraint count, then skip the constraint array via
 /// `block_size` so the stream stays aligned. The fixed-layout head
 /// covers what we'd actually consume today (ragdoll mass tuning);
 /// the polymorphic tail is left for a follow-up.

--- a/crates/nif/src/blocks/extra_data.rs
+++ b/crates/nif/src/blocks/extra_data.rs
@@ -962,20 +962,11 @@ impl BsPackedCombinedGeomDataExtra {
     }
 }
 
-fn parse_common_geom_header(
-    stream: &mut NifStream,
-) -> io::Result<(
-    u32,
-    u32,
-    u32,
-    u32,
-    u32,
-    u32,
-    u32,
-    u32,
-    Vec<BsPackedGeomDataCombined>,
-    u64,
-)> {
+/// Decoded fields of the shared `BSPackedCombined*` geometry header,
+/// returned by [`parse_common_geom_header`].
+type CommonGeomHeader = (u32, u32, u32, u32, u32, u32, u32, u32, Vec<BsPackedGeomDataCombined>, u64);
+
+fn parse_common_geom_header(stream: &mut NifStream) -> io::Result<CommonGeomHeader> {
     let num_verts = stream.read_u32_le()?;
     let lod_levels = stream.read_u32_le()?;
     let tri_count_lod0 = stream.read_u32_le()?;

--- a/crates/nif/src/blocks/legacy_particle.rs
+++ b/crates/nif/src/blocks/legacy_particle.rs
@@ -336,8 +336,8 @@ pub struct NiParticleSystemController {
     pub num_particles: u16,
     pub num_valid: u16,
     /// Raw particle records. Each is 32 bytes (velocity:vec3 +
-    /// unknown_vector:vec3 + lifetime:f32 + lifespan:f32 + timestamp:f32
-    /// + unknown_short:u16 + vertex_id:u16). We keep them opaque — the
+    /// unknown_vector:vec3 + lifetime:f32 + lifespan:f32 + timestamp:f32,
+    /// then unknown_short:u16 + vertex_id:u16). We keep them opaque — the
     /// renderer doesn't consume authored particles yet.
     pub particles: Vec<[u8; 32]>,
 

--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -400,9 +400,11 @@ impl TallGrassShaderProperty {
 /// bytes (`texture_clamp_mode + texture_set_ref + refraction +
 /// parallax`) — the per-block tail (sky filename / sky type / water
 /// flags) never reached the importer.
-fn parse_skyrim_shader_base(
-    stream: &mut NifStream,
-) -> io::Result<(u32, u32, Vec<u32>, Vec<u32>, [f32; 2], [f32; 2])> {
+/// Shared Skyrim+ shader-property head: `(shader_flags_1, shader_flags_2,
+/// sf1_crcs, sf2_crcs, uv_offset, uv_scale)`.
+type SkyrimShaderBase = (u32, u32, Vec<u32>, Vec<u32>, [f32; 2], [f32; 2]);
+
+fn parse_skyrim_shader_base(stream: &mut NifStream) -> io::Result<SkyrimShaderBase> {
     let bsver = stream.bsver();
 
     let (shader_flags_1, shader_flags_2) = if bsver < crate::version::bsver::FO4_CRC_FLAGS {

--- a/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
+++ b/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
@@ -331,7 +331,7 @@ impl BsTriShape {
             if (data_size as usize) != expected_data_size {
                 let derived_stride = if num_vertices > 0 {
                     let payload = (data_size as usize).saturating_sub(num_triangles as usize * 6);
-                    if payload % num_vertices as usize == 0 {
+                    if payload.is_multiple_of(num_vertices as usize) {
                         Some(payload / num_vertices as usize)
                     } else {
                         None
@@ -653,7 +653,7 @@ impl BsTriShape {
                 } else {
                     stream.set_position(segmentation_start);
                 }
-                shape.kind = BsTriShapeKind::SubIndex(Box::new(BsSubIndexTriShapeData::default()));
+                shape.kind = BsTriShapeKind::SubIndex(Box::default());
             }
         }
         Ok(shape)

--- a/crates/nif/src/blocks/tri_shape/ni_tri_shape.rs
+++ b/crates/nif/src/blocks/tri_shape/ni_tri_shape.rs
@@ -270,11 +270,9 @@ pub struct NiTriShapeData {
     pub triangles: Vec<[u16; 3]>,
 }
 
-/// Parse the NiGeometryData base class fields shared by NiTriShapeData and NiTriStripsData.
-/// Returns (vertices, data_flags, normals, center, radius, vertex_colors, uv_sets).
-pub(crate) fn parse_geometry_data_base(
-    stream: &mut NifStream,
-) -> io::Result<(
+/// Decoded NiGeometryData base-class fields:
+/// `(vertices, data_flags, normals, center, radius, vertex_colors, uv_sets)`.
+pub(crate) type GeometryDataBase = (
     Vec<NiPoint3>,      // vertices
     u16,                // data_flags
     Vec<NiPoint3>,      // normals
@@ -282,7 +280,11 @@ pub(crate) fn parse_geometry_data_base(
     f32,                // radius
     Vec<[f32; 4]>,      // vertex_colors
     Vec<Vec<[f32; 2]>>, // uv_sets
-)> {
+);
+
+/// Parse the NiGeometryData base class fields shared by NiTriShapeData and NiTriStripsData.
+/// Returns (vertices, data_flags, normals, center, radius, vertex_colors, uv_sets).
+pub(crate) fn parse_geometry_data_base(stream: &mut NifStream) -> io::Result<GeometryDataBase> {
     parse_geometry_data_base_inner(stream, false)
 }
 
@@ -291,32 +293,11 @@ pub(crate) fn parse_geometry_data_base(
 /// NiPSysData on BS_GTE_FO3 streams where nif.xml (line 3880) says:
 /// "Vertices, Normals, Tangents, Colors, and UV arrays do not have length
 /// for NiPSysData regardless of 'Num' or booleans." See #322.
-pub(crate) fn parse_psys_geometry_data_base(
-    stream: &mut NifStream,
-) -> io::Result<(
-    Vec<NiPoint3>,
-    u16,
-    Vec<NiPoint3>,
-    NiPoint3,
-    f32,
-    Vec<[f32; 4]>,
-    Vec<Vec<[f32; 2]>>,
-)> {
+pub(crate) fn parse_psys_geometry_data_base(stream: &mut NifStream) -> io::Result<GeometryDataBase> {
     parse_geometry_data_base_inner(stream, true)
 }
 
-fn parse_geometry_data_base_inner(
-    stream: &mut NifStream,
-    zero_arrays: bool,
-) -> io::Result<(
-    Vec<NiPoint3>,
-    u16,
-    Vec<NiPoint3>,
-    NiPoint3,
-    f32,
-    Vec<[f32; 4]>,
-    Vec<Vec<[f32; 2]>>,
-)> {
+fn parse_geometry_data_base_inner(stream: &mut NifStream, zero_arrays: bool) -> io::Result<GeometryDataBase> {
     // Group ID: nif.xml says `since="10.1.0.114"` (0x0A010072), not
     // 10.0.1.0. Files in the [10.0.1.0, 10.1.0.114) range (non-Bethesda
     // Gamebryo, pre-Civ IV era) read 4 phantom bytes, misaligning every

--- a/crates/nif/src/header.rs
+++ b/crates/nif/src/header.rs
@@ -178,7 +178,7 @@ impl NifHeader {
             let num_block_types = read_u16_le(&mut cursor)? as usize;
             if num_block_types
                 .checked_mul(4)
-                .map_or(true, |n| n > remaining)
+                .is_none_or(|n| n > remaining)
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -198,7 +198,7 @@ impl NifHeader {
             // must fit in what's left of the file.
             if (num_blocks as usize)
                 .checked_mul(2)
-                .map_or(true, |n| n > remaining)
+                .is_none_or(|n| n > remaining)
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -227,7 +227,7 @@ impl NifHeader {
             let remaining = total_bytes.saturating_sub(pos);
             if (num_blocks as usize)
                 .checked_mul(4)
-                .map_or(true, |n| n > remaining)
+                .is_none_or(|n| n > remaining)
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -256,7 +256,7 @@ impl NifHeader {
             // before the first read fails.
             let pos = cursor.position() as usize;
             let remaining = total_bytes.saturating_sub(pos);
-            if num_strings.checked_mul(4).map_or(true, |n| n > remaining) {
+            if num_strings.checked_mul(4).is_none_or(|n| n > remaining) {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(

--- a/crates/nif/src/import/collision.rs
+++ b/crates/nif/src/import/collision.rs
@@ -149,7 +149,7 @@ fn extract_from_classic(
     }
 
     let motion_type = match body.motion_type {
-        1 | 2 | 3 => MotionType::Dynamic,
+        1..=3 => MotionType::Dynamic,
         4 => MotionType::Keyframed,
         _ => MotionType::Static,
     };

--- a/crates/nif/src/import/material/walker.rs
+++ b/crates/nif/src/import/material/walker.rs
@@ -992,7 +992,7 @@ pub(crate) fn extract_material_info_from_refs(
                 }
                 // NiDitherProperty: flags=1 enables 16-bit color dithering,
                 // a legacy hint with no Vulkan analogue. Safe to ignore.
-                "NiDitherProperty" | _ => {}
+                _ => {}
             }
         }
 

--- a/crates/nif/src/import/mesh/bs_geometry.rs
+++ b/crates/nif/src/import/mesh/bs_geometry.rs
@@ -32,7 +32,7 @@ pub fn extract_bs_geometry(
         // returned `None` when LOD 0 was `External` despite later LODs
         // being `Internal` (#1209). Matches the Stage-B iteration.
         shape.meshes.iter().find_map(|m| match &m.kind {
-            BSGeometryMeshKind::Internal { mesh_data } => Some(mesh_data),
+            BSGeometryMeshKind::Internal { mesh_data } => Some(mesh_data.as_ref()),
             BSGeometryMeshKind::External { .. } => None,
         })?
     } else {

--- a/crates/nif/src/import/mesh/bs_geometry_tangent_tests.rs
+++ b/crates/nif/src/import/mesh/bs_geometry_tangent_tests.rs
@@ -134,7 +134,7 @@ fn make_internal(version: u32) -> BSGeometryMesh {
         num_verts: 0,
         flags: 0,
         kind: BSGeometryMeshKind::Internal {
-            mesh_data: BSGeometryMeshData {
+            mesh_data: Box::new(BSGeometryMeshData {
                 version,
                 triangles: Vec::new(),
                 scale: 0.0,
@@ -149,7 +149,7 @@ fn make_internal(version: u32) -> BSGeometryMesh {
                 lods: Vec::new(),
                 meshlets: Vec::new(),
                 cull_data: Vec::new(),
-            },
+            }),
         },
     }
 }
@@ -169,7 +169,7 @@ fn make_external(name: &str) -> BSGeometryMesh {
 /// LOD slot regardless of position.
 fn select_internal(meshes: &[BSGeometryMesh]) -> Option<&BSGeometryMeshData> {
     meshes.iter().find_map(|m| match &m.kind {
-        BSGeometryMeshKind::Internal { mesh_data } => Some(mesh_data),
+        BSGeometryMeshKind::Internal { mesh_data } => Some(mesh_data.as_ref()),
         BSGeometryMeshKind::External { .. } => None,
     })
 }

--- a/crates/nif/src/import/mesh/skin.rs
+++ b/crates/nif/src/import/mesh/skin.rs
@@ -382,10 +382,11 @@ pub fn remap_bs_tri_shape_bone_indices(
 /// `remap_bs_tri_shape_bone_indices` for the partition-local → global
 /// remap. The weights are pass-through — they're already partition-
 /// agnostic. See #638.
-pub fn decode_sse_skin_payload(
-    scene: &NifScene,
-    shape: &BsTriShape,
-) -> Option<(Vec<[f32; 4]>, Vec<[u8; 4]>)> {
+/// Decoded SSE skin payload: per-vertex `(weights, partition-local bone
+/// indices)`, returned by [`decode_sse_skin_payload`].
+pub type SseSkinPayload = (Vec<[f32; 4]>, Vec<[u8; 4]>);
+
+pub fn decode_sse_skin_payload(scene: &NifScene, shape: &BsTriShape) -> Option<SseSkinPayload> {
     let skin_idx = shape.skin_ref.index()?;
     let partition_ref = if let Some(inst) = scene.get_as::<NiSkinInstance>(skin_idx) {
         inst.skin_partition_ref

--- a/crates/nif/src/import/mesh/sse_recon.rs
+++ b/crates/nif/src/import/mesh/sse_recon.rs
@@ -197,11 +197,12 @@ pub struct DecodedPackedBuffer {
 ///    on `(ARG & 0x401) == 0x401`); or
 /// 2. keeping the upstream `try_reconstruct_sse_geometry` gate
 ///    locked to the SSE band so this decoder never sees FO4 input.
+///
 /// Without either, FO4 meshes that ship without `VF_FULL_PRECISION`
 /// (the common case) would silently mis-decode every vertex.
 pub fn decode_sse_packed_buffer(buffer: &SseSkinGlobalBuffer) -> Option<DecodedPackedBuffer> {
     let vertex_size = buffer.vertex_size as usize;
-    if vertex_size == 0 || buffer.raw_bytes.len() % vertex_size != 0 {
+    if vertex_size == 0 || !buffer.raw_bytes.len().is_multiple_of(vertex_size) {
         return None;
     }
     let num_vertices = buffer.raw_bytes.len() / vertex_size;

--- a/crates/nif/src/import/mesh/tangent.rs
+++ b/crates/nif/src/import/mesh/tangent.rs
@@ -70,7 +70,7 @@ pub fn extract_tangents_from_extra_data(
         // shader's standard-convention `mat3(T, B, N)` and producing
         // the chrome-walls regression on FNV (R-N2 / #786).
         let bethesda_bitangent_offset = num_verts * 12;
-        for i in 0..num_verts {
+        for (i, n_zup) in normals_zup.iter().enumerate().take(num_verts) {
             let bethesda_t_off = i * 12;
             let bethesda_b_off = bethesda_bitangent_offset + i * 12;
             // Read Vector3 (3 × f32 LE).
@@ -92,7 +92,6 @@ pub fn extract_tangents_from_extra_data(
             let b_yup = [bethesda_tx, bethesda_tz, -bethesda_ty];
 
             // Normal in Y-up — use the matching vertex normal.
-            let n_zup = normals_zup[i];
             let n_yup = [n_zup.x, n_zup.z, -n_zup.y];
 
             // Bitangent sign: sign(dot(B, cross(N, T))). With T = ∂P/∂U
@@ -352,7 +351,7 @@ pub fn bs_tangents_zup_to_yup(zup: &[[f32; 4]]) -> Vec<[f32; 4]> {
 
 /// Y-up sibling of [`synthesize_tangents`] for inputs already in the
 /// renderer's coordinate space — namely Starfield `BSGeometry` (positions
-/// + normals decoded Y-up by the BSGeometryMeshData parser) and SSE
+/// and normals decoded Y-up by the BSGeometryMeshData parser) and SSE
 /// skin-reconstructed `BSTriShape` (positions / normals / uvs filled
 /// from `try_reconstruct_sse_geometry` which writes Y-up). The Z-up
 /// flavour applies a `(x, y, z) → (x, z, -y)` swap at both the

--- a/crates/nif/src/import/mod.rs
+++ b/crates/nif/src/import/mod.rs
@@ -159,16 +159,14 @@ fn import_nif_scene_impl(
     };
 
     let mut props_stack: Vec<crate::types::BlockRef> = Vec::new();
-    walk::walk_node_hierarchical(
+    let mut hier_ctx = walk::HierWalkCtx {
         scene,
-        root_idx,
-        None,
-        &mut props_stack,
-        &mut imported,
+        inherited_props: &mut props_stack,
+        out: &mut imported,
         pool,
         resolver,
-        0,
-    );
+    };
+    walk::walk_node_hierarchical(&mut hier_ctx, root_idx, None, 0);
 
     // Resolve extra data from the root node (BSXFlags, BSBound,
     // BSConnectPoint::Parents / Children).
@@ -285,17 +283,15 @@ fn import_nif_impl(
     };
 
     let mut props_stack: Vec<crate::types::BlockRef> = Vec::new();
-    walk::walk_node_flat(
+    let mut flat_ctx = walk::FlatWalkCtx {
         scene,
-        root_idx,
-        &NiTransform::default(),
-        &mut props_stack,
-        &mut meshes,
-        None,
+        inherited_props: &mut props_stack,
+        out: &mut meshes,
+        collisions: None,
         pool,
         resolver,
-        0,
-    );
+    };
+    walk::walk_node_flat(&mut flat_ctx, root_idx, &NiTransform::default(), 0);
     meshes
 }
 
@@ -432,17 +428,15 @@ fn import_nif_with_collision_impl(
     };
 
     let mut props_stack: Vec<crate::types::BlockRef> = Vec::new();
-    walk::walk_node_flat(
+    let mut flat_ctx = walk::FlatWalkCtx {
         scene,
-        root_idx,
-        &NiTransform::default(),
-        &mut props_stack,
-        &mut meshes,
-        Some(&mut collisions),
+        inherited_props: &mut props_stack,
+        out: &mut meshes,
+        collisions: Some(&mut collisions),
         pool,
         resolver,
-        0,
-    );
+    };
+    walk::walk_node_flat(&mut flat_ctx, root_idx, &NiTransform::default(), 0);
     (meshes, collisions)
 }
 

--- a/crates/nif/src/import/transform.rs
+++ b/crates/nif/src/import/transform.rs
@@ -26,11 +26,9 @@ pub(super) fn compose_transforms(parent: &NiTransform, child: &NiTransform) -> N
 
 pub(super) fn mul_matrix3(a: &NiMatrix3, b: &NiMatrix3) -> NiMatrix3 {
     let mut result = [[0.0f32; 3]; 3];
-    for i in 0..3 {
-        for j in 0..3 {
-            result[i][j] = a.rows[i][0] * b.rows[0][j]
-                + a.rows[i][1] * b.rows[1][j]
-                + a.rows[i][2] * b.rows[2][j];
+    for (result_row, a_row) in result.iter_mut().zip(a.rows.iter()) {
+        for (j, cell) in result_row.iter_mut().enumerate() {
+            *cell = a_row[0] * b.rows[0][j] + a_row[1] * b.rows[1][j] + a_row[2] * b.rows[2][j];
         }
     }
     NiMatrix3 { rows: result }

--- a/crates/nif/src/import/types.rs
+++ b/crates/nif/src/import/types.rs
@@ -486,6 +486,7 @@ pub struct ImportedMesh {
     ///     `(L - 0.04) / 0.96` so dielectric spec (≈ 0.04) lands at
     ///     0 and conductor spec (≈ 0.95) lands near 1.
     ///   * Future: Starfield .mat translator.
+    ///
     /// `None` seeds a NaN sentinel on the canonical `Material.metalness`,
     /// which `Material::resolve_pbr` then fills via `classify_pbr_keyword`
     /// (Oblivion / FO3 / FNV keyword path) — at the boundary, NOT per-draw.

--- a/crates/nif/src/import/walk/mod.rs
+++ b/crates/nif/src/import/walk/mod.rs
@@ -161,23 +161,32 @@ fn switch_active_children(block: &dyn NiObject) -> Option<(&NiNode, Vec<usize>)>
 /// crashing the parser via stack overflow (#1269 / SAFE-DIM3-NEW-01).
 pub(crate) const MAX_NIF_NODE_DEPTH: u32 = 128;
 
+/// Long-lived context threaded through [`walk_node_hierarchical`]'s
+/// recursion: the read-only scene + resolver and the mutable output /
+/// string-pool / inherited-property accumulators. Bundling these keeps
+/// the per-call recursion signature small (block index / parent / depth).
+pub(super) struct HierWalkCtx<'a> {
+    pub scene: &'a NifScene,
+    /// Accumulates property BlockRefs from ancestor NiNodes via
+    /// push/truncate stack discipline — no per-node Vec clone. Gamebryo
+    /// propagates properties down the scene graph; children inherit
+    /// parent properties unless they override with their own (#208/#276).
+    pub inherited_props: &'a mut Vec<BlockRef>,
+    pub out: &'a mut ImportedScene,
+    pub pool: &'a mut StringPool,
+    pub resolver: Option<&'a dyn MeshResolver>,
+}
+
 /// Recursively walk the scene graph, preserving hierarchy.
 /// NiNodes become ImportedNode entries; geometry becomes ImportedMesh with parent_node set.
-///
-/// `inherited_props` accumulates property BlockRefs from ancestor NiNodes via
-/// push/truncate stack discipline — no per-node Vec clone. Gamebryo propagates
-/// properties down the scene graph; children inherit parent properties unless
-/// they override with their own. See #208, #276.
 pub(super) fn walk_node_hierarchical(
-    scene: &NifScene,
+    ctx: &mut HierWalkCtx,
     block_idx: usize,
     parent_node_idx: Option<usize>,
-    inherited_props: &mut Vec<BlockRef>,
-    out: &mut ImportedScene,
-    pool: &mut StringPool,
-    resolver: Option<&dyn MeshResolver>,
     depth: u32,
 ) {
+    let scene = ctx.scene;
+    let resolver = ctx.resolver;
     if depth > MAX_NIF_NODE_DEPTH {
         log::warn!(
             "walk_node_hierarchical: depth cap {} hit at block {} — \
@@ -218,8 +227,9 @@ pub(super) fn walk_node_hierarchical(
         let bs_value_node = extract_bs_value_node(block);
         let bs_ordered_node = extract_bs_ordered_node(block);
 
-        let this_node_idx = out.nodes.len();
-        out.nodes.push(ImportedNode {
+        let this_node_idx = ctx.out.nodes.len();
+        let lod_group = extract_lod_group(scene, block);
+        ctx.out.nodes.push(ImportedNode {
             name: node.av.net.name.clone(),
             translation: zup_point_to_yup(t),
             rotation: quat,
@@ -235,24 +245,15 @@ pub(super) fn walk_node_hierarchical(
             // NiLODNode → its NiRangeLODData ranges (surfaced for a future
             // distance-switch; import still walks child 0 only). `None` for
             // NiSwitchNode. In-cell-LOD foundation.
-            lod_group: extract_lod_group(scene, block),
+            lod_group,
         });
 
-        let prev_len = inherited_props.len();
-        inherited_props.extend_from_slice(&node.av.properties);
+        let prev_len = ctx.inherited_props.len();
+        ctx.inherited_props.extend_from_slice(&node.av.properties);
         for idx in active_children {
-            walk_node_hierarchical(
-                scene,
-                idx,
-                Some(this_node_idx),
-                inherited_props,
-                out,
-                pool,
-                resolver,
-                depth + 1,
-            );
+            walk_node_hierarchical(ctx, idx, Some(this_node_idx), depth + 1);
         }
-        inherited_props.truncate(prev_len);
+        ctx.inherited_props.truncate(prev_len);
         return;
     }
 
@@ -322,8 +323,8 @@ pub(super) fn walk_node_hierarchical(
         let bs_value_node = extract_bs_value_node(block);
         let bs_ordered_node = extract_bs_ordered_node(block);
 
-        let this_node_idx = out.nodes.len();
-        out.nodes.push(ImportedNode {
+        let this_node_idx = ctx.out.nodes.len();
+        ctx.out.nodes.push(ImportedNode {
             name: node.av.net.name.clone(),
             translation: zup_point_to_yup(t),
             rotation: quat,
@@ -345,23 +346,14 @@ pub(super) fn walk_node_hierarchical(
         // discipline. Child shapes see the union; their own properties
         // take priority inside extract_material_info because shape props
         // are iterated before inherited props.
-        let prev_len = inherited_props.len();
-        inherited_props.extend_from_slice(&node.av.properties);
+        let prev_len = ctx.inherited_props.len();
+        ctx.inherited_props.extend_from_slice(&node.av.properties);
         for child_ref in &node.children {
             if let Some(idx) = child_ref.index() {
-                walk_node_hierarchical(
-                    scene,
-                    idx,
-                    Some(this_node_idx),
-                    inherited_props,
-                    out,
-                    pool,
-                    resolver,
-                    depth + 1,
-                );
+                walk_node_hierarchical(ctx, idx, Some(this_node_idx), depth + 1);
             }
         }
-        inherited_props.truncate(prev_len);
+        ctx.inherited_props.truncate(prev_len);
         return;
     }
 
@@ -394,18 +386,18 @@ pub(super) fn walk_node_hierarchical(
         // (audit 2026-05-12). Oblivion + some FO3 modded content
         // attaches collision to the shape directly.
         if let Some(parent_idx) = parent_node_idx {
-            if let Some(parent) = out.nodes.get(parent_idx) {
+            if let Some(parent) = ctx.out.nodes.get(parent_idx) {
                 if parent.collision.is_none() {
                     if let Some(collision) = extract_collision(scene, shape.av.collision_ref) {
-                        out.nodes[parent_idx].collision = Some(collision);
+                        ctx.out.nodes[parent_idx].collision = Some(collision);
                     }
                 }
             }
         }
-        if let Some(mesh) = extract_mesh_local(scene, shape, inherited_props, pool) {
+        if let Some(mesh) = extract_mesh_local(scene, shape, ctx.inherited_props, ctx.pool) {
             let mut mesh = mesh;
             mesh.parent_node = parent_node_idx;
-            out.meshes.push(mesh);
+            ctx.out.meshes.push(mesh);
         }
     }
 
@@ -431,18 +423,18 @@ pub(super) fn walk_node_hierarchical(
 
         // Mirror of the NiTriShape branch above — see NIF-D4-NEW-04.
         if let Some(parent_idx) = parent_node_idx {
-            if let Some(parent) = out.nodes.get(parent_idx) {
+            if let Some(parent) = ctx.out.nodes.get(parent_idx) {
                 if parent.collision.is_none() {
                     if let Some(collision) = extract_collision(scene, shape.av.collision_ref) {
-                        out.nodes[parent_idx].collision = Some(collision);
+                        ctx.out.nodes[parent_idx].collision = Some(collision);
                     }
                 }
             }
         }
-        if let Some(mesh) = extract_bs_tri_shape_local(scene, shape, pool) {
+        if let Some(mesh) = extract_bs_tri_shape_local(scene, shape, ctx.pool) {
             let mut mesh = mesh;
             mesh.parent_node = parent_node_idx;
-            out.meshes.push(mesh);
+            ctx.out.meshes.push(mesh);
         }
     }
 
@@ -463,18 +455,18 @@ pub(super) fn walk_node_hierarchical(
         }
         // Mirror of the NiTriShape branch above — see NIF-D4-NEW-04.
         if let Some(parent_idx) = parent_node_idx {
-            if let Some(parent) = out.nodes.get(parent_idx) {
+            if let Some(parent) = ctx.out.nodes.get(parent_idx) {
                 if parent.collision.is_none() {
                     if let Some(collision) = extract_collision(scene, shape.av.collision_ref) {
-                        out.nodes[parent_idx].collision = Some(collision);
+                        ctx.out.nodes[parent_idx].collision = Some(collision);
                     }
                 }
             }
         }
-        if let Some(mesh) = extract_mesh_local(scene, shape, inherited_props, pool) {
+        if let Some(mesh) = extract_mesh_local(scene, shape, ctx.inherited_props, ctx.pool) {
             let mut mesh = mesh;
             mesh.parent_node = parent_node_idx;
-            out.meshes.push(mesh);
+            ctx.out.meshes.push(mesh);
         }
     }
 
@@ -487,18 +479,18 @@ pub(super) fn walk_node_hierarchical(
         }
         // Mirror of the NiTriShape branch above — see NIF-D4-NEW-04.
         if let Some(parent_idx) = parent_node_idx {
-            if let Some(parent) = out.nodes.get(parent_idx) {
+            if let Some(parent) = ctx.out.nodes.get(parent_idx) {
                 if parent.collision.is_none() {
                     if let Some(collision) = extract_collision(scene, shape.av.collision_ref) {
-                        out.nodes[parent_idx].collision = Some(collision);
+                        ctx.out.nodes[parent_idx].collision = Some(collision);
                     }
                 }
             }
         }
-        if let Some(mesh) = extract_bs_geometry_local(scene, shape, pool, resolver) {
+        if let Some(mesh) = extract_bs_geometry_local(scene, shape, ctx.pool, resolver) {
             let mut mesh = mesh;
             mesh.parent_node = parent_node_idx;
-            out.meshes.push(mesh);
+            ctx.out.meshes.push(mesh);
         }
     }
 
@@ -516,7 +508,8 @@ pub(super) fn walk_node_hierarchical(
         .as_any()
         .downcast_ref::<crate::blocks::particle::NiParticleSystem>()
     {
-        out.particle_emitters
+        ctx.out
+            .particle_emitters
             .push(crate::import::ImportedParticleEmitter {
                 parent_node: parent_node_idx,
                 original_type: ps.original_type.clone(),
@@ -616,6 +609,7 @@ pub(super) fn collect_force_fields(
 ///      modifier, which embeds its 3-key ramp INLINE rather than
 ///      referencing a `NiColorData` block. Returns `Colors[0]` (birth) and
 ///      `Colors[2]` (death).
+///
 /// `None` when neither is present (→ fall back to the heuristic preset).
 ///
 /// First-pass scope per the issue body — this is a scene-level scan
@@ -717,7 +711,7 @@ pub(super) fn extract_emitter_params(
         && p.initial_radius.is_finite()
         && p.life_span.is_finite()
         && p.life_span_variation.is_finite()
-        && base_scale.map_or(true, f32::is_finite);
+        && base_scale.is_none_or(f32::is_finite);
     if !(all_finite && p.life_span > 0.0 && p.initial_radius >= 0.0) {
         log::debug!(
             "Rejecting NiPSysEmitter params (non-finite or non-positive): \
@@ -768,7 +762,7 @@ pub(super) fn extract_emitter_rate(scene: &NifScene) -> Option<f32> {
     fn sane(r: f32) -> Option<f32> {
         // `>= 3.0e38` matches the FLT_MAX-sentinel threshold used for shader
         // rimlight/backlight (blocks/shader.rs, nif.xml convention).
-        (r.is_finite() && r >= 0.0 && r < 3.0e38).then_some(r)
+        (r.is_finite() && (0.0..3.0e38).contains(&r)).then_some(r)
     }
 
     // Modern: controller → NiFloatInterpolator → (keyed data | constant).
@@ -804,21 +798,32 @@ pub(super) fn extract_emitter_rate(scene: &NifScene) -> Option<f32> {
         .and_then(sane)
 }
 
-/// Recursively walk the scene graph, accumulating world-space transforms (flat, no hierarchy).
+/// Long-lived context threaded through [`walk_node_flat`]'s recursion:
+/// the read-only scene + resolver, the mutable mesh/collision out-lists,
+/// the inherited-property accumulator, and the string pool. Bundling
+/// these keeps the per-call recursion signature focused on what varies
+/// between nodes (block index / parent transform / depth).
 ///
-/// When `collisions` is `Some`, also extracts collision data from NiNodes
-/// and stores them in world space.
+/// When `collisions` is `Some`, the walker also extracts collision data
+/// from NiNodes and stores it in world space.
+pub(super) struct FlatWalkCtx<'a> {
+    pub scene: &'a NifScene,
+    pub inherited_props: &'a mut Vec<BlockRef>,
+    pub out: &'a mut Vec<ImportedMesh>,
+    pub collisions: Option<&'a mut Vec<ImportedCollision>>,
+    pub pool: &'a mut StringPool,
+    pub resolver: Option<&'a dyn MeshResolver>,
+}
+
+/// Recursively walk the scene graph, accumulating world-space transforms (flat, no hierarchy).
 pub(super) fn walk_node_flat(
-    scene: &NifScene,
+    ctx: &mut FlatWalkCtx,
     block_idx: usize,
     parent_transform: &NiTransform,
-    inherited_props: &mut Vec<BlockRef>,
-    out: &mut Vec<ImportedMesh>,
-    mut collisions: Option<&mut Vec<ImportedCollision>>,
-    pool: &mut StringPool,
-    resolver: Option<&dyn MeshResolver>,
     depth: u32,
 ) {
+    let scene = ctx.scene;
+    let resolver = ctx.resolver;
     if depth > MAX_NIF_NODE_DEPTH {
         log::warn!(
             "walk_node_flat: depth cap {} hit at block {} — \
@@ -841,7 +846,7 @@ pub(super) fn walk_node_flat(
             return;
         }
         let world_transform = compose_transforms(parent_transform, &node.av.transform);
-        if let Some(ref mut coll_out) = collisions {
+        if let Some(ref mut coll_out) = ctx.collisions {
             if let Some((shape, body)) = extract_collision(scene, node.av.collision_ref) {
                 let t = &world_transform.translation;
                 let quat = zup_matrix_to_yup_quat(&world_transform.rotation);
@@ -854,22 +859,12 @@ pub(super) fn walk_node_flat(
                 });
             }
         }
-        let prev_len = inherited_props.len();
-        inherited_props.extend_from_slice(&node.av.properties);
+        let prev_len = ctx.inherited_props.len();
+        ctx.inherited_props.extend_from_slice(&node.av.properties);
         for idx in active_children {
-            walk_node_flat(
-                scene,
-                idx,
-                &world_transform,
-                inherited_props,
-                out,
-                collisions.as_deref_mut(),
-                pool,
-                resolver,
-                depth + 1,
-            );
+            walk_node_flat(ctx, idx, &world_transform, depth + 1);
         }
-        inherited_props.truncate(prev_len);
+        ctx.inherited_props.truncate(prev_len);
         return;
     }
 
@@ -900,7 +895,7 @@ pub(super) fn walk_node_flat(
         let world_transform = compose_transforms(parent_transform, &node.av.transform);
 
         // Extract collision data if requested and this node has a collision_ref.
-        if let Some(ref mut coll_out) = collisions {
+        if let Some(ref mut coll_out) = ctx.collisions {
             if let Some((shape, body)) = extract_collision(scene, node.av.collision_ref) {
                 let t = &world_transform.translation;
                 let quat = zup_matrix_to_yup_quat(&world_transform.rotation);
@@ -914,24 +909,14 @@ pub(super) fn walk_node_flat(
             }
         }
 
-        let prev_len = inherited_props.len();
-        inherited_props.extend_from_slice(&node.av.properties);
+        let prev_len = ctx.inherited_props.len();
+        ctx.inherited_props.extend_from_slice(&node.av.properties);
         for child_ref in &node.children {
             if let Some(idx) = child_ref.index() {
-                walk_node_flat(
-                    scene,
-                    idx,
-                    &world_transform,
-                    inherited_props,
-                    out,
-                    collisions.as_deref_mut(),
-                    pool,
-                    resolver,
-                    depth + 1,
-                );
+                walk_node_flat(ctx, idx, &world_transform, depth + 1);
             }
         }
-        inherited_props.truncate(prev_len);
+        ctx.inherited_props.truncate(prev_len);
         return;
     }
 
@@ -985,9 +970,9 @@ pub(super) fn walk_node_flat(
             return;
         }
         let world_transform = compose_transforms(parent_transform, &shape.av.transform);
-        push_shape_collision(scene, &mut collisions, shape.av.collision_ref, &world_transform);
-        if let Some(mesh) = extract_mesh(scene, shape, &world_transform, inherited_props, pool) {
-            out.push(mesh);
+        push_shape_collision(scene, &mut ctx.collisions, shape.av.collision_ref, &world_transform);
+        if let Some(mesh) = extract_mesh(scene, shape, &world_transform, ctx.inherited_props, ctx.pool) {
+            ctx.out.push(mesh);
         }
     }
 
@@ -1011,9 +996,9 @@ pub(super) fn walk_node_flat(
             return;
         }
         let world_transform = compose_transforms(parent_transform, &shape.av.transform);
-        push_shape_collision(scene, &mut collisions, shape.av.collision_ref, &world_transform);
-        if let Some(mesh) = extract_bs_tri_shape(scene, shape, &world_transform, pool) {
-            out.push(mesh);
+        push_shape_collision(scene, &mut ctx.collisions, shape.av.collision_ref, &world_transform);
+        if let Some(mesh) = extract_bs_tri_shape(scene, shape, &world_transform, ctx.pool) {
+            ctx.out.push(mesh);
         }
     }
 
@@ -1028,9 +1013,9 @@ pub(super) fn walk_node_flat(
             return;
         }
         let world_transform = compose_transforms(parent_transform, &shape.av.transform);
-        push_shape_collision(scene, &mut collisions, shape.av.collision_ref, &world_transform);
-        if let Some(mesh) = extract_mesh(scene, shape, &world_transform, inherited_props, pool) {
-            out.push(mesh);
+        push_shape_collision(scene, &mut ctx.collisions, shape.av.collision_ref, &world_transform);
+        if let Some(mesh) = extract_mesh(scene, shape, &world_transform, ctx.inherited_props, ctx.pool) {
+            ctx.out.push(mesh);
         }
     }
 
@@ -1042,9 +1027,9 @@ pub(super) fn walk_node_flat(
             return;
         }
         let world_transform = compose_transforms(parent_transform, &shape.av.transform);
-        push_shape_collision(scene, &mut collisions, shape.av.collision_ref, &world_transform);
-        if let Some(mesh) = extract_bs_geometry(scene, shape, &world_transform, pool, resolver) {
-            out.push(mesh);
+        push_shape_collision(scene, &mut ctx.collisions, shape.av.collision_ref, &world_transform);
+        if let Some(mesh) = extract_bs_geometry(scene, shape, &world_transform, ctx.pool, resolver) {
+            ctx.out.push(mesh);
         }
     }
 }

--- a/crates/nif/src/import/walk/tests.rs
+++ b/crates/nif/src/import/walk/tests.rs
@@ -595,16 +595,14 @@ mod recursion_depth_tests {
         let mut imported = empty_imported_scene();
         let mut pool = StringPool::new();
         let mut props_stack: Vec<BlockRef> = Vec::new();
-        walk_node_hierarchical(
-            &scene,
-            0,
-            None,
-            &mut props_stack,
-            &mut imported,
-            &mut pool,
-            None,
-            0,
-        );
+        let mut ctx = HierWalkCtx {
+            scene: &scene,
+            inherited_props: &mut props_stack,
+            out: &mut imported,
+            pool: &mut pool,
+            resolver: None,
+        };
+        walk_node_hierarchical(&mut ctx, 0, None, 0);
         // We imported some prefix of the chain but not the whole thing —
         // the cap fires somewhere on the way down.
         assert!(
@@ -627,17 +625,15 @@ mod recursion_depth_tests {
         let mut pool = StringPool::new();
         let mut props_stack: Vec<BlockRef> = Vec::new();
         // Pre-#1269 this would stack-overflow on a long-enough chain.
-        walk_node_flat(
-            &scene,
-            0,
-            &NiTransform::default(),
-            &mut props_stack,
-            &mut meshes,
-            None,
-            &mut pool,
-            None,
-            0,
-        );
+        let mut ctx = FlatWalkCtx {
+            scene: &scene,
+            inherited_props: &mut props_stack,
+            out: &mut meshes,
+            collisions: None,
+            pool: &mut pool,
+            resolver: None,
+        };
+        walk_node_flat(&mut ctx, 0, &NiTransform::default(), 0);
         // Nothing to assert on the mesh side (chain has no geometry);
         // success is "returned without overflowing the stack".
     }
@@ -651,16 +647,14 @@ mod recursion_depth_tests {
         let mut imported = empty_imported_scene();
         let mut pool = StringPool::new();
         let mut props_stack: Vec<BlockRef> = Vec::new();
-        walk_node_hierarchical(
-            &scene,
-            0,
-            None,
-            &mut props_stack,
-            &mut imported,
-            &mut pool,
-            None,
-            0,
-        );
+        let mut ctx = HierWalkCtx {
+            scene: &scene,
+            inherited_props: &mut props_stack,
+            out: &mut imported,
+            pool: &mut pool,
+            resolver: None,
+        };
+        walk_node_hierarchical(&mut ctx, 0, None, 0);
         assert_eq!(imported.nodes.len() as u32, chain_len);
     }
 }

--- a/crates/nif/src/kfm.rs
+++ b/crates/nif/src/kfm.rs
@@ -310,7 +310,7 @@ impl KfmCatalog {
 /// returns an empty string when the input is empty or all-separator.
 fn filename_stem_lower(path: &str) -> String {
     // Split on the LAST `\` or `/` — whichever comes later.
-    let last_sep = path.rfind(|c| c == '\\' || c == '/');
+    let last_sep = path.rfind(['\\', '/']);
     let leaf = match last_sep {
         Some(i) => &path[i + 1..],
         None => path,

--- a/crates/papyrus/src/ast.rs
+++ b/crates/papyrus/src/ast.rs
@@ -58,7 +58,10 @@ bitflags::bitflags! {
 pub enum ScriptItem {
     Import(Identifier),
     Variable(Variable),
-    Property(Property),
+    // Boxed — `Property` is by far the largest variant (~504 B vs the
+    // ~160 B runner-up), so inlining it bloated every `ScriptItem`.
+    // `clippy::large_enum_variant`.
+    Property(Box<Property>),
     Function(Function),
     Event(Event),
     State(State),

--- a/crates/papyrus/src/parser/expr.rs
+++ b/crates/papyrus/src/parser/expr.rs
@@ -46,10 +46,8 @@ impl Parser {
     fn parse_expr_bp_inner(&mut self, min_bp: u8) -> Result<Spanned<Expr>, ParseError> {
         let mut lhs = self.parse_prefix()?;
 
-        loop {
-            // Check for postfix / infix operators
-            let Some(tok) = self.peek() else { break };
-
+        // Check for postfix / infix operators each iteration.
+        while let Some(tok) = self.peek() {
             // Postfix: dot, index, call
             match tok {
                 Token::Dot if PREC_POSTFIX > min_bp => {

--- a/crates/papyrus/src/parser/script.rs
+++ b/crates/papyrus/src/parser/script.rs
@@ -36,6 +36,11 @@ use crate::token::Token;
 
 use super::Parser;
 
+/// Parsed `ScriptName <ident> [Extends <ident>] [flags…]` header:
+/// `(script name, optional parent, flags)`. Aliased to satisfy
+/// `clippy::type_complexity` on `parse_script_header`'s return.
+type ScriptHeader = (Spanned<Identifier>, Option<Spanned<Identifier>>, ScriptFlags);
+
 impl Parser {
     /// Parse a complete `.psc` source into a [`Script`]. The
     /// canonical M30.2 entry point.
@@ -86,9 +91,7 @@ impl Parser {
 
     /// Parse the `ScriptName <ident> [Extends <ident>] [flags…]`
     /// header line. Caller has already skipped leading newlines.
-    fn parse_script_header(
-        &mut self,
-    ) -> Result<(Spanned<Identifier>, Option<Spanned<Identifier>>, ScriptFlags), ParseError> {
+    fn parse_script_header(&mut self) -> Result<ScriptHeader, ParseError> {
         self.expect(&Token::KwScriptName, "ScriptName")?;
         let name = self.expect_ident("script name")?;
         let parent = if matches!(self.peek(), Some(Token::KwExtends)) {
@@ -202,7 +205,7 @@ impl Parser {
             Some(Token::KwProperty) => {
                 let prop = self.parse_property(ty)?;
                 let span = prop.name.span;
-                Ok(Spanned::new(ScriptItem::Property(prop), span))
+                Ok(Spanned::new(ScriptItem::Property(Box::new(prop)), span))
             }
             Some(Token::Ident(_)) => {
                 // Top-level variable declaration.

--- a/crates/papyrus/tests/r5_round_trip.rs
+++ b/crates/papyrus/tests/r5_round_trip.rs
@@ -49,7 +49,7 @@ fn parse_default_rumble_on_activate() {
         .body
         .iter()
         .filter_map(|i| match &i.node {
-            ScriptItem::Property(p) => Some(p),
+            ScriptItem::Property(p) => Some(p.as_ref()),
             _ => None,
         })
         .collect();

--- a/crates/physics/src/components.rs
+++ b/crates/physics/src/components.rs
@@ -32,10 +32,10 @@ impl Component for RapierHandles {
 ///     capsule collider with `RapierHandles`.
 ///   - Each frame `character_controller_system` integrates gravity
 ///     + jump, asks Rapier's `KinematicCharacterController.move_shape`
-///     for the collide-and-slide-corrected motion, and writes the
-///     resulting translation onto the kinematic body via
-///     `set_next_kinematic_translation`. Runtime state
-///     (`vertical_velocity`, `is_grounded`) is updated in-place.
+///       for the collide-and-slide-corrected motion, and writes the
+///       resulting translation onto the kinematic body via
+///       `set_next_kinematic_translation`. Runtime state
+///       (`vertical_velocity`, `is_grounded`) is updated in-place.
 ///   - `camera_follow_system` reads body position + `eye_height` to
 ///     place the active camera each frame after `physics_sync_system`
 ///     applies the kinematic step.

--- a/crates/physics/src/world.rs
+++ b/crates/physics/src/world.rs
@@ -407,8 +407,6 @@ impl PhysicsWorld {
         };
         use rapier3d::prelude::*;
 
-        let mut controller = KinematicCharacterController::default();
-        controller.up = Vector::y_axis();
         // M28.5 KCC offset — at Skyrim's 70 BU/m scale, 0.5 BU
         // was only 7 mm of skin between the capsule and any surface,
         // letting the KCC's swept cast graze TriMesh edges and tunnel
@@ -418,23 +416,28 @@ impl PhysicsWorld {
         // `ContactConfig::kcc_offset_bu` (default 4 BU ≈ 5.7 cm) and
         // is plumbed through `CharacterMoveParams` so a single resource
         // edit can re-tune every character.
-        controller.offset = CharacterLength::Absolute(params.kcc_offset_bu.max(0.0));
-        controller.slide = true;
-        controller.autostep = Some(CharacterAutostep {
-            max_height: CharacterLength::Absolute(params.step_height.max(0.0)),
-            min_width: CharacterLength::Absolute(params.step_min_width.max(0.1)),
-            include_dynamic_bodies: false,
-        });
-        controller.max_slope_climb_angle = params.max_slope_climb_deg.to_radians();
+        //
         // Min slide angle: half-way between climb limit and 90° — once
         // the slope is steeper than this, the controller starts
         // sliding the character down instead of trying to hold pose.
-        controller.min_slope_slide_angle =
-            ((params.max_slope_climb_deg + 90.0) * 0.5).to_radians();
-        controller.snap_to_ground = if params.snap_to_ground > 0.0 {
-            Some(CharacterLength::Absolute(params.snap_to_ground))
-        } else {
-            None
+        let controller = KinematicCharacterController {
+            up: Vector::y_axis(),
+            offset: CharacterLength::Absolute(params.kcc_offset_bu.max(0.0)),
+            slide: true,
+            autostep: Some(CharacterAutostep {
+                max_height: CharacterLength::Absolute(params.step_height.max(0.0)),
+                min_width: CharacterLength::Absolute(params.step_min_width.max(0.1)),
+                include_dynamic_bodies: false,
+            }),
+            max_slope_climb_angle: params.max_slope_climb_deg.to_radians(),
+            min_slope_slide_angle: ((params.max_slope_climb_deg + 90.0) * 0.5)
+                .to_radians(),
+            snap_to_ground: if params.snap_to_ground > 0.0 {
+                Some(CharacterLength::Absolute(params.snap_to_ground))
+            } else {
+                None
+            },
+            ..Default::default()
         };
 
         let shape = SharedShape::capsule_y(

--- a/crates/plugin/src/equip.rs
+++ b/crates/plugin/src/equip.rs
@@ -331,7 +331,7 @@ fn expand_leveled_inner(
     }
     // Direct base record — push and stop. Most outfit entries land
     // here on the first call.
-    if index.items.get(&form_id).is_some() {
+    if index.items.contains_key(&form_id) {
         out.push(form_id);
         return;
     }

--- a/crates/plugin/src/esm/cell/mod.rs
+++ b/crates/plugin/src/esm/cell/mod.rs
@@ -571,6 +571,7 @@ pub struct LightData {
     ///   * `k ≈ 1.0` (Skyrim default): near-linear, gentle near radius
     ///   * `k ≈ 2.0` (FO3/FNV common): quadratic, sharper edge
     ///   * `k → 0`:  almost flat in the middle, very sharp cutoff
+    ///
     /// Pre-fix this field was dropped on the floor and the shader
     /// used a hardcoded `1/(1 + 0.01*d)` linear term that ignored
     /// the radius entirely — small-radius FO lamps appeared to "pop

--- a/crates/plugin/src/esm/cell/walkers.rs
+++ b/crates/plugin/src/esm/cell/walkers.rs
@@ -340,7 +340,7 @@ pub(crate) fn parse_cell_group(
                         // 4-byte STRINGS-table case for localized
                         // plugins.
                         b"FULL" => display_name = Some(read_lstring_or_zstring(&sub.data)),
-                        b"DATA" if sub.data.len() >= 1 => is_interior = sub.data[0] & 1 != 0,
+                        b"DATA" if !sub.data.is_empty() => is_interior = sub.data[0] & 1 != 0,
                         b"XCLW" => {
                             // XCLW: f32 water plane height in world units
                             // (Z-up). Same layout across Oblivion / FO3 / FNV

--- a/crates/plugin/src/esm/cell/wrld.rs
+++ b/crates/plugin/src/esm/cell/wrld.rs
@@ -32,7 +32,7 @@ pub(crate) fn parse_wrld_group(
                     if let Some(ref name) = current_wrld_name {
                         let cells = all_exterior_cells
                             .entry(name.to_ascii_lowercase())
-                            .or_insert_with(HashMap::new);
+                            .or_default();
                         parse_wrld_children(reader, sub_end, cells)?;
                     } else {
                         reader.skip_group(&sub_group);

--- a/crates/plugin/src/esm/records/climate.rs
+++ b/crates/plugin/src/esm/records/climate.rs
@@ -23,6 +23,7 @@ pub struct ClimateWeather {
 
 /// Parsed CLMT record.
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct ClimateRecord {
     pub form_id: u32,
     pub editor_id: String,
@@ -38,20 +39,6 @@ pub struct ClimateRecord {
     pub sunset_end: u8,
 }
 
-impl Default for ClimateRecord {
-    fn default() -> Self {
-        Self {
-            form_id: 0,
-            editor_id: String::new(),
-            weathers: Vec::new(),
-            sun_texture: None,
-            sunrise_begin: 0,
-            sunrise_end: 0,
-            sunset_begin: 0,
-            sunset_end: 0,
-        }
-    }
-}
 
 /// Parse a CLMT record from its sub-records.
 ///

--- a/crates/plugin/src/esm/records/common.rs
+++ b/crates/plugin/src/esm/records/common.rs
@@ -26,7 +26,7 @@ thread_local! {
     /// correctly stacked. Consulted by [`read_lstring_or_zstring`]
     /// when resolving a 4-byte lstring index. See #989.
     static CURRENT_STRINGS_TABLE: RefCell<Option<Rc<StringTableSet>>> =
-        RefCell::new(None);
+        const { RefCell::new(None) };
 }
 
 /// Set the thread-local "this plugin uses lstring indirection" flag.

--- a/crates/plugin/src/esm/records/condition.rs
+++ b/crates/plugin/src/esm/records/condition.rs
@@ -171,6 +171,7 @@ impl Default for ConditionValue {
 /// Multiple `Condition`s on the same record form a [`ConditionList`]
 /// evaluated with the OR-precedence rule. See [`evaluate`].
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Default)]
 pub struct Condition {
     /// Function index (Bethesda's `~300` catalog; see `ConditionFunction`
     /// enum in `byroredux_scripting::condition`). Raw u32 here keeps
@@ -204,21 +205,6 @@ pub struct Condition {
     pub or_next: bool,
 }
 
-impl Default for Condition {
-    fn default() -> Self {
-        Self {
-            function_index: 0,
-            comparator: ComparisonOp::default(),
-            comparand: ConditionValue::default(),
-            param_1: 0,
-            param_2: 0,
-            run_on: RunOn::default(),
-            reference_form_id: 0,
-            extra_data_id: 0,
-            or_next: false,
-        }
-    }
-}
 
 /// A list of conditions, evaluated with OR-precedence (see [`evaluate`]).
 ///

--- a/crates/plugin/src/esm/records/index.rs
+++ b/crates/plugin/src/esm/records/index.rs
@@ -21,6 +21,10 @@ use super::{
 };
 use std::collections::HashMap;
 
+/// One entry in the [`EsmIndex::categories`] table: a display label paired
+/// with a closure that returns the live count for that category.
+pub type CategoryEntry = (&'static str, fn(&EsmIndex) -> usize);
+
 /// Aggregated index of every record category we currently parse.
 ///
 /// `cells` retains the existing structure used by the cell loader and
@@ -148,8 +152,8 @@ pub struct EsmIndex {
     /// container/door/NPC. SCRI cross-references resolve here instead
     /// of dangling.
     pub activators: HashMap<u32, ActiRecord>,
-    /// `TERM` terminal records — vault/military consoles. Menu items
-    /// + password + body text captured so a future terminal-interaction
+    /// `TERM` terminal records — vault/military consoles. Menu items,
+    /// password, and body text captured so a future terminal-interaction
     /// system doesn't have to re-parse them.
     pub terminals: HashMap<u32, TermRecord>,
     /// `FLST` FormID list records — flat arrays of form IDs referenced
@@ -360,7 +364,7 @@ impl EsmIndex {
     ///
     /// [`total`]: Self::total
     /// [`category_breakdown`]: Self::category_breakdown
-    pub fn categories() -> &'static [(&'static str, fn(&EsmIndex) -> usize)] {
+    pub fn categories() -> &'static [CategoryEntry] {
         // The closures below capture nothing and coerce to `fn(&EsmIndex)
         // -> usize` — no boxing, zero runtime overhead vs the inline sum.
         &[

--- a/crates/plugin/src/esm/records/misc/magic.rs
+++ b/crates/plugin/src/esm/records/misc/magic.rs
@@ -16,7 +16,7 @@ pub trait SubRecordSchema: Sized {
 
 /// Read a SubRecord using a schema implementer.
 pub fn read_sub<T: SubRecordSchema>(sub: &SubRecord) -> Result<T> {
-    if &sub.sub_type != &T::CODE {
+    if sub.sub_type != T::CODE {
         anyhow::bail!(
             "SubRecord type mismatch: expected {:?}, got {:?}",
             std::str::from_utf8(&T::CODE).unwrap_or("invalid UTF-8"),
@@ -513,8 +513,8 @@ pub fn parse_spel(form_id: u32, subs: &[SubRecord]) -> SpelRecord {
                     sub.data[0], sub.data[1], sub.data[2], sub.data[3],
                 ]);
             }
-            b"EFIT" if sub.data.len() >= 12 => {
-                if current_efid != 0 {
+            b"EFIT" if sub.data.len() >= 12
+                && current_efid != 0 => {
                     out.effects.push(MagicEffectItem {
                         effect_form_id: current_efid,
                         magnitude: f32::from_le_bytes([sub.data[0], sub.data[1], sub.data[2], sub.data[3]]),
@@ -523,7 +523,6 @@ pub fn parse_spel(form_id: u32, subs: &[SubRecord]) -> SpelRecord {
                     });
                     current_efid = 0;
                 }
-            }
             _ => {}
         }
     }
@@ -664,8 +663,8 @@ pub fn parse_ench(form_id: u32, subs: &[SubRecord]) -> EnchRecord {
                     sub.data[0], sub.data[1], sub.data[2], sub.data[3],
                 ]);
             }
-            b"EFIT" if sub.data.len() >= 12 => {
-                if current_efid != 0 {
+            b"EFIT" if sub.data.len() >= 12
+                && current_efid != 0 => {
                     out.effects.push(MagicEffectItem {
                         effect_form_id: current_efid,
                         magnitude: f32::from_le_bytes([sub.data[0], sub.data[1], sub.data[2], sub.data[3]]),
@@ -674,7 +673,6 @@ pub fn parse_ench(form_id: u32, subs: &[SubRecord]) -> EnchRecord {
                     });
                     current_efid = 0;
                 }
-            }
             _ => {}
         }
     }

--- a/crates/plugin/src/esm/records/scol.rs
+++ b/crates/plugin/src/esm/records/scol.rs
@@ -15,7 +15,7 @@
 //! - `ONAM` + `DATA` pairs (repeated):
 //!     - `ONAM` = 4 B base form ID of the child (STAT, MSTT, …)
 //!     - `DATA` = repeated 28 B placement records:
-//!         `pos[3 × f32] + rot[3 × f32] + scale[f32]`
+//!       `pos[3 × f32] + rot[3 × f32] + scale[f32]`
 //! - `FLTR` — filter form IDs (unused by the parser, kept optional)
 //!
 //! Every `DATA` block always follows an `ONAM`; a vanilla Fallout4.esm

--- a/crates/plugin/src/esm/records/weather.rs
+++ b/crates/plugin/src/esm/records/weather.rs
@@ -509,7 +509,7 @@ const SKYRIM_DATA_SIZE: usize = 19;
 /// shared array's slot 9 for "Effects Lighting" but the remaining 7
 /// groups are discarded for v1 because the renderer / weather_system
 /// has no consumer for them yet. Follow-up work covers the Sky Glare
-/// + Cloud LOD wiring when the renderer's M-glare / cloud-cover work
+/// and Cloud LOD wiring when the renderer's M-glare / cloud-cover work
 /// surfaces. See M33-04..07.
 ///
 /// **TOD synth**: Skyrim ships 4 TOD slots per group (sunrise / day /
@@ -608,13 +608,12 @@ fn parse_wthr_skyrim(form_id: u32, subs: &[SubRecord]) -> WeatherRecord {
             // Captured into `skyrim_ambient_cube`. Out-of-order or
             // extra entries clamp at 4 — Bethesda content always ships
             // exactly 4 in sunrise/day/sunset/night order per UESP.
-            b"DALC" if sub.data.len() >= SKYRIM_DALC_SIZE => {
-                if dalc_idx < dalc_buf.len() {
+            b"DALC" if sub.data.len() >= SKYRIM_DALC_SIZE
+                && dalc_idx < dalc_buf.len() => {
                     let cube = parse_skyrim_dalc(&sub.data);
                     dalc_buf[dalc_idx] = Some(cube);
                     dalc_idx += 1;
                 }
-            }
 
             // Other sub-records (LNAM, MNAM, NNAM, RNAM, QNAM, PNAM,
             // JNAM, NAM1, TNAM ×many, IMSP, 00TX..L0TX) carry data

--- a/crates/plugin/src/record.rs
+++ b/crates/plugin/src/record.rs
@@ -117,7 +117,7 @@ impl Record {
 /// ```
 /// # use byroredux_plugin::RecordType;
 /// assert_eq!(RecordType::WEAP.as_str(), "WEAP");
-/// assert_eq!(RecordType::from_str("NPC_"), RecordType::NPC_);
+/// assert_eq!(RecordType::from_4cc("NPC_"), RecordType::NPC_);
 /// ```
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RecordType(pub [u8; 4]);
@@ -323,7 +323,7 @@ impl RecordType {
     ///
     /// # Panics
     /// Panics if `s` is not exactly 4 bytes.
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_4cc(s: &str) -> Self {
         let bytes = s.as_bytes();
         assert_eq!(bytes.len(), 4, "RecordType must be exactly 4 ASCII bytes");
         Self([bytes[0], bytes[1], bytes[2], bytes[3]])
@@ -453,14 +453,14 @@ mod tests {
 
     #[test]
     fn record_type_from_str() {
-        assert_eq!(RecordType::from_str("WEAP"), RecordType::WEAP);
-        assert_eq!(RecordType::from_str("STAT"), RecordType::STAT);
-        assert_eq!(RecordType::from_str("CELL"), RecordType::CELL);
+        assert_eq!(RecordType::from_4cc("WEAP"), RecordType::WEAP);
+        assert_eq!(RecordType::from_4cc("STAT"), RecordType::STAT);
+        assert_eq!(RecordType::from_4cc("CELL"), RecordType::CELL);
     }
 
     #[test]
     fn record_type_unknown_type_works() {
-        let custom = RecordType::from_str("XYZW");
+        let custom = RecordType::from_4cc("XYZW");
         assert_eq!(custom.as_str(), "XYZW");
         assert_ne!(custom, RecordType::WEAP);
     }
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "exactly 4")]
     fn record_type_from_str_wrong_length_panics() {
-        RecordType::from_str("AB");
+        RecordType::from_4cc("AB");
     }
 
     // ── #renderlayer — RecordType::render_layer() classification table ──
@@ -573,7 +573,7 @@ mod tests {
         // Unknown FourCC — defensive default. Zero-bias means "no
         // visual change vs. pre-#renderlayer" for any caller that
         // accidentally passes a non-renderable record type.
-        assert_layer(RecordType::from_str("XYZW"), RenderLayer::Architecture);
+        assert_layer(RecordType::from_4cc("XYZW"), RenderLayer::Architecture);
         // Records that exist in the constants table but aren't in the
         // classifier match arms (e.g. ENCH, GLOB) also default to
         // Architecture — safe inert.

--- a/crates/renderer/src/mesh.rs
+++ b/crates/renderer/src/mesh.rs
@@ -4,6 +4,7 @@ use crate::deferred_destroy::{DeferredDestroyQueue, DEFAULT_COUNTDOWN};
 use crate::vertex::{UiVertex, Vertex};
 use crate::vulkan::allocator::SharedAllocator;
 use crate::vulkan::buffer::{GpuBuffer, StagingPool};
+use crate::vulkan::GpuUploadCtx;
 use anyhow::{bail, Result};
 use ash::vk;
 use std::collections::HashMap;
@@ -183,6 +184,12 @@ pub struct MeshRegistry {
     geometry_staging_pool: Option<StagingPool>,
 }
 
+impl Default for MeshRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MeshRegistry {
     pub fn new() -> Self {
         Self {
@@ -258,29 +265,26 @@ impl MeshRegistry {
     /// reintroduce ray self-hits.
     pub fn upload<V: Copy>(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         vertices: &[V],
         indices: &[u32],
         rt_enabled: bool,
         mut staging_pool: Option<&mut StagingPool>,
     ) -> Result<u32> {
         let vertex_buffer = GpuBuffer::create_vertex_buffer(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx.device,
+            ctx.allocator,
+            ctx.queue,
+            ctx.command_pool,
             vertices,
             rt_enabled,
             staging_pool.as_deref_mut(),
         )?;
         let index_buffer = GpuBuffer::create_index_buffer(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx.device,
+            ctx.allocator,
+            ctx.queue,
+            ctx.command_pool,
             indices,
             rt_enabled,
             staging_pool,
@@ -386,10 +390,7 @@ impl MeshRegistry {
 
     pub fn upload_scene_mesh(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         vertices: &[Vertex],
         indices: &[u32],
         rt_enabled: bool,
@@ -399,16 +400,7 @@ impl MeshRegistry {
 
         // Upload to per-mesh buffers (also the BLAS build input when
         // `rt_enabled`).
-        let id = self.upload(
-            device,
-            allocator,
-            queue,
-            command_pool,
-            vertices,
-            indices,
-            rt_enabled,
-            staging_pool,
-        )?;
+        let id = self.upload(ctx, vertices, indices, rt_enabled, staging_pool)?;
 
         // Store offsets.
         let mesh = self.meshes[id as usize]
@@ -497,27 +489,15 @@ impl MeshRegistry {
     /// since acquired it. See #879 / CELL-PERF-01.
     pub fn register_scene_mesh_keyed(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         vertices: &[Vertex],
         indices: &[u32],
         rt_enabled: bool,
         staging_pool: Option<&mut StagingPool>,
-        model_path: &str,
-        sub_mesh_index: u32,
+        cache_key: (&str, u32),
     ) -> Result<u32> {
-        let handle = self.upload_scene_mesh(
-            device,
-            allocator,
-            queue,
-            command_pool,
-            vertices,
-            indices,
-            rt_enabled,
-            staging_pool,
-        )?;
+        let (model_path, sub_mesh_index) = cache_key;
+        let handle = self.upload_scene_mesh(ctx, vertices, indices, rt_enabled, staging_pool)?;
         self.mesh_cache
             .insert((model_path.to_string(), sub_mesh_index), handle);
         Ok(handle)
@@ -678,21 +658,21 @@ impl MeshRegistry {
         // Create with STORAGE_BUFFER (RT reflection UV lookups) plus
         // VERTEX_BUFFER / INDEX_BUFFER so the draw loop can bind this
         // single global buffer instead of per-mesh rebinding. See #294.
-        self.global_vertex_buffer = Some(GpuBuffer::create_device_local_buffer(
+        let ctx = GpuUploadCtx {
             device,
             allocator,
             queue,
             command_pool,
+        };
+        self.global_vertex_buffer = Some(GpuBuffer::create_device_local_buffer(
+            ctx,
             vertex_size,
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::VERTEX_BUFFER,
             &self.pending_vertices,
             self.geometry_staging_pool.as_mut(),
         )?);
         self.global_index_buffer = Some(GpuBuffer::create_device_local_buffer(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx,
             index_size,
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::INDEX_BUFFER,
             &self.pending_indices,
@@ -770,6 +750,10 @@ impl MeshRegistry {
 
     pub fn len(&self) -> usize {
         self.meshes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.meshes.is_empty()
     }
 
     pub fn destroy_all(&mut self, device: &ash::Device, allocator: &SharedAllocator) {

--- a/crates/renderer/src/shader_constants_data.rs
+++ b/crates/renderer/src/shader_constants_data.rs
@@ -176,6 +176,7 @@ pub const DBG_VIZ_NORMALS: u32 = 0x4;
 ///   * green = tangent present (vertex shader fed authored or synthesized
 ///     data → Path 1 in `perturbNormal` fires).
 ///   * red = zero tangent → screen-space derivative fallback (Path 2).
+///
 /// Added under #783 follow-up.
 pub const DBG_VIZ_TANGENT: u32 = 0x8;
 
@@ -205,6 +206,7 @@ pub const DBG_RESERVED_20: u32 = 0x20;
 ///   * Clutter (1)      → cyan
 ///   * Actor (2)        → magenta
 ///   * Decal (3)        → yellow
+///
 /// The 2-bit layer is packed into `gpuInstance.flags` bits 4..5
 /// (`INSTANCE_RENDER_LAYER_SHIFT` / `_MASK` on the Rust side).
 pub const DBG_VIZ_RENDER_LAYER: u32 = 0x40;

--- a/crates/renderer/src/texture_registry.rs
+++ b/crates/renderer/src/texture_registry.rs
@@ -16,6 +16,7 @@
 
 use crate::vulkan::allocator::SharedAllocator;
 use crate::vulkan::buffer::StagingPool;
+use crate::vulkan::GpuUploadCtx;
 use crate::vulkan::sync::MAX_FRAMES_IN_FLIGHT;
 use crate::vulkan::texture::Texture;
 use anyhow::{Context, Result};
@@ -487,7 +488,13 @@ impl TextureRegistry {
         dds_bytes: &[u8],
     ) -> Result<TextureHandle> {
         // 3 = WRAP_S_WRAP_T per nif.xml — the legacy REPEAT/REPEAT.
-        self.load_dds_with_clamp(device, allocator, queue, command_pool, path, dds_bytes, 3)
+        let ctx = GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        };
+        self.load_dds_with_clamp(ctx, path, dds_bytes, 3)
     }
 
     /// Load a DDS texture with an explicit Gamebryo `TexClampMode`
@@ -505,10 +512,7 @@ impl TextureRegistry {
     /// almost-universal authoring pattern). See #610 / D4-NEW-02.
     pub fn load_dds_with_clamp(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         path: &str,
         dds_bytes: &[u8],
         clamp_mode: u8,
@@ -527,10 +531,10 @@ impl TextureRegistry {
         self.check_slot_available()?;
 
         let texture = Texture::from_dds(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx.device,
+            ctx.allocator,
+            ctx.queue,
+            ctx.command_pool,
             dds_bytes,
             self.samplers[clamp_mode as usize],
             self.staging_pool.as_mut(),
@@ -538,7 +542,7 @@ impl TextureRegistry {
         .with_context(|| format!("Failed to load DDS texture '{}'", path))?;
 
         let handle = self.textures.len() as TextureHandle;
-        self.write_texture_to_all_sets(device, handle, &texture);
+        self.write_texture_to_all_sets(ctx.device, handle, &texture);
         self.textures.push(TextureEntry {
             texture: Some(texture),
             pending_destroy: VecDeque::new(),
@@ -897,10 +901,7 @@ impl TextureRegistry {
     /// Register an RGBA texture directly (for dynamic UI textures).
     pub fn register_rgba(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         width: u32,
         height: u32,
         pixels: &[u8],
@@ -908,10 +909,7 @@ impl TextureRegistry {
         self.check_slot_available()?;
 
         let texture = Texture::from_rgba(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx,
             width,
             height,
             pixels,
@@ -921,7 +919,7 @@ impl TextureRegistry {
         .context("Failed to create dynamic RGBA texture")?;
 
         let handle = self.textures.len() as TextureHandle;
-        self.write_texture_to_all_sets(device, handle, &texture);
+        self.write_texture_to_all_sets(ctx.device, handle, &texture);
         self.textures.push(TextureEntry {
             texture: Some(texture),
             pending_destroy: VecDeque::new(),
@@ -1154,10 +1152,7 @@ impl TextureRegistry {
     /// `MAX_FRAMES_IN_FLIGHT` frames have elapsed. See issue #134.
     pub fn update_rgba(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         handle: TextureHandle,
         width: u32,
         height: u32,
@@ -1172,7 +1167,7 @@ impl TextureRegistry {
                 break;
             }
             if let Some((_, mut old)) = entry.pending_destroy.pop_front() {
-                old.destroy(device, allocator);
+                old.destroy(ctx.device, ctx.allocator);
             }
         }
 
@@ -1180,10 +1175,7 @@ impl TextureRegistry {
         // quietly revives it (bindless slot reactivates on the descriptor
         // write below).
         let new_texture = Texture::from_rgba(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            ctx,
             width,
             height,
             pixels,
@@ -1204,7 +1196,7 @@ impl TextureRegistry {
             .expect("entry was just populated above");
         let image_view = live.image_view;
         let sampler = live.sampler;
-        self.apply_descriptor_write(device, handle, image_view, sampler);
+        self.apply_descriptor_write(ctx.device, handle, image_view, sampler);
 
         Ok(())
     }
@@ -1212,6 +1204,11 @@ impl TextureRegistry {
     /// Number of loaded textures (including fallback).
     pub fn len(&self) -> usize {
         self.textures.len()
+    }
+
+    /// Whether no textures are loaded.
+    pub fn is_empty(&self) -> bool {
+        self.textures.is_empty()
     }
 
     /// Recreate descriptor sets for a new swapchain.

--- a/crates/renderer/src/vulkan/acceleration/blas_skinned.rs
+++ b/crates/renderer/src/vulkan/acceleration/blas_skinned.rs
@@ -14,7 +14,7 @@ use super::predicates::{
     align_scratch_address, scratch_alignment_padding, scratch_needs_growth,
     should_rebuild_skinned_blas_after, validate_refit_counts, validate_refit_flags,
 };
-use super::types::BlasEntry;
+use super::types::{BlasEntry, SkinnedBlasGeometry};
 use super::AccelerationManager;
 use crate::vertex::Vertex;
 use anyhow::{Context, Result};
@@ -386,11 +386,14 @@ impl AccelerationManager {
         device: &ash::Device,
         cmd: vk::CommandBuffer,
         entity_id: EntityId,
-        vertex_buffer: vk::Buffer,
-        vertex_count: u32,
-        index_buffer: vk::Buffer,
-        index_count: u32,
+        geometry: SkinnedBlasGeometry,
     ) -> Result<()> {
+        let SkinnedBlasGeometry {
+            vertex_buffer,
+            vertex_count,
+            index_buffer,
+            index_count,
+        } = geometry;
         // #983 / REN-D8-NEW-15 — Self-emitted scratch-serialize
         // barrier. The shared `blas_scratch_buffer` may have been
         // written by a cell-load `build_blas_batched` earlier this

--- a/crates/renderer/src/vulkan/acceleration/blas_static.rs
+++ b/crates/renderer/src/vulkan/acceleration/blas_static.rs
@@ -21,6 +21,18 @@ use crate::vertex::Vertex;
 use anyhow::{Context, Result};
 use ash::vk;
 
+/// One compacted static-BLAS entry produced by the compact pass:
+/// `(mesh_handle, compacted accel struct, compacted buffer, compacted size,
+/// vertex count, index count)`.
+type CompactedBlas = (
+    u32,
+    vk::AccelerationStructureKHR,
+    GpuBuffer,
+    vk::DeviceSize,
+    u32,
+    u32,
+);
+
 impl AccelerationManager {
     /// Queue a BLAS for deferred destruction.
     ///
@@ -29,7 +41,7 @@ impl AccelerationManager {
     /// destroy immediately — `drop_blas` is called by the cell loader on
     /// unload and the entry may still be in-flight. The entry moves to
     /// `pending_destroy_blas` and the actual `VkAccelerationStructureKHR`
-    /// + buffer destruction is delayed until the countdown expires in
+    /// and buffer destruction is delayed until the countdown expires in
     /// [`tick_deferred_destroy`](Self::tick_deferred_destroy).
     ///
     /// Also forces a full TLAS rebuild on both frame slots so no
@@ -49,10 +61,8 @@ impl AccelerationManager {
         // BLAS map mutated — bump generation so the next build_tlas
         // can short-circuit the per-instance zip-compare. #300.
         self.blas_map_generation = self.blas_map_generation.wrapping_add(1);
-        for tlas_slot in &mut self.tlas {
-            if let Some(ref mut t) = tlas_slot {
-                t.needs_full_rebuild = true;
-            }
+        for ref mut t in self.tlas.iter_mut().flatten() {
+            t.needs_full_rebuild = true;
         }
     }
 
@@ -126,16 +136,19 @@ impl AccelerationManager {
     /// avoid per-mesh GPU stalls. See #284 (C2-04).
     pub fn build_blas(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: crate::vulkan::GpuUploadCtx,
         transfer_fence: Option<&std::sync::Mutex<vk::Fence>>,
         mesh_handle: u32,
         mesh: &GpuMesh,
         vertex_count: u32,
         index_count: u32,
     ) -> Result<()> {
+        let crate::vulkan::GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        } = ctx;
         // #915 / REN-D8-NEW-05 — sibling of the `build_blas_batched`
         // pre-batch eviction at line ~1354. The batched path is the
         // M40 cell-loader hot path, so eviction lives there; the
@@ -504,8 +517,8 @@ impl AccelerationManager {
             // Mid-batch eviction check. Trigger only every N iterations
             // so the cost is amortized; the predicate itself is pure
             // arithmetic. #510.
-            if idx > 0 && idx % BATCH_EVICTION_CHECK_INTERVAL == 0 {
-                if should_evict_mid_batch(
+            if idx > 0 && idx % BATCH_EVICTION_CHECK_INTERVAL == 0
+                && should_evict_mid_batch(
                     self.static_blas_bytes,
                     pending_bytes,
                     self.blas_budget_bytes,
@@ -519,7 +532,6 @@ impl AccelerationManager {
                         self.evict_unused_blas(device, allocator);
                     }
                 }
-            }
 
             let primitive_count = index_count / 3;
 
@@ -752,18 +764,7 @@ impl AccelerationManager {
         // every Vulkan handle whose Drop relies on the explicit `destroy`
         // calls in phase 7. Mirrors the build/copy-phase cleanup pattern
         // at lines 733-745 / 815-832.
-        let alloc_compact = || -> Result<(
-            Vec<(
-                u32,
-                vk::AccelerationStructureKHR,
-                GpuBuffer,
-                vk::DeviceSize,
-                u32,
-                u32,
-            )>,
-            u64,
-            u64,
-        )> {
+        let alloc_compact = || -> Result<(Vec<CompactedBlas>, u64, u64)> {
             let mut compacted_sizes = vec![0u64; prepared.len()];
             unsafe {
                 device
@@ -1002,6 +1003,12 @@ impl AccelerationManager {
     /// `idle >= min_idle` and be destroyed under the GPU — at that point route
     /// eviction through `pending_destroy_blas` (as `drop_blas` already does),
     /// or gate the per-batch bump so it cannot outrun retired frames.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that the evicted BLAS are no longer referenced
+    /// by any in-flight command buffer or TLAS build.
     pub unsafe fn evict_unused_blas(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         if self.static_blas_bytes <= self.blas_budget_bytes {
             return;
@@ -1078,10 +1085,8 @@ impl AccelerationManager {
             // BLAS map mutated — see #300.
             self.blas_map_generation = self.blas_map_generation.wrapping_add(1);
             // Force full TLAS rebuild next frame since BLAS addresses changed.
-            for slot in &mut self.tlas {
-                if let Some(ref mut t) = slot {
-                    t.needs_full_rebuild = true;
-                }
+            for ref mut t in self.tlas.iter_mut().flatten() {
+                t.needs_full_rebuild = true;
             }
         }
     }

--- a/crates/renderer/src/vulkan/acceleration/constants.rs
+++ b/crates/renderer/src/vulkan/acceleration/constants.rs
@@ -116,8 +116,8 @@ pub(super) const SKINNED_BLAS_FLAGS: vk::BuildAccelerationStructureFlagsKHR =
     );
 
 /// Build flags for the static-BLAS BUILD call sites in `blas_static.rs`
-/// (`build_blas` single-shot + `build_blas_batched` per-mesh size-query
-/// + per-mesh record). Vulkan spec
+/// (`build_blas` single-shot plus `build_blas_batched` per-mesh size-query
+/// and per-mesh record). Vulkan spec
 /// `VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03801` requires the
 /// size-query and the record `BuildGeometryInfoKHR.flags` to match
 /// exactly; sharing the constant turns that VUID from convention into

--- a/crates/renderer/src/vulkan/acceleration/mod.rs
+++ b/crates/renderer/src/vulkan/acceleration/mod.rs
@@ -33,7 +33,7 @@ mod types;
 
 pub use constants::SKINNED_BLAS_REFIT_THRESHOLD;
 pub use predicates::build_instance_map;
-pub use types::{BlasEntry, TlasState};
+pub use types::{BlasEntry, SkinnedBlasGeometry, TlasState};
 
 // Surfaces a CPU-side scratch-shrink helper to sibling modules (notably
 // `vulkan::context::draw`, which calls it on the per-frame `Vec` it
@@ -235,6 +235,12 @@ impl AccelerationManager {
     }
 
     /// Destroy all acceleration structures and buffers.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that no acceleration structure or buffer owned
+    /// by this manager is still in use by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         // #639 / LIFE-H1: drain `pending_destroy_blas` first.
         // `drop_blas` queues entries with a 2-frame countdown that only
@@ -253,12 +259,10 @@ impl AccelerationManager {
         // into `drain_pending_destroys` so the App-level shutdown
         // sweep can call the same drain explicitly before `Drop`.
         self.drain_pending_destroys(device, allocator);
-        for entry in self.blas_entries.drain(..) {
-            if let Some(mut e) = entry {
-                self.accel_loader
-                    .destroy_acceleration_structure(e.accel, None);
-                e.buffer.destroy(device, allocator);
-            }
+        for mut e in self.blas_entries.drain(..).flatten() {
+            self.accel_loader
+                .destroy_acceleration_structure(e.accel, None);
+            e.buffer.destroy(device, allocator);
         }
         for slot in &mut self.tlas {
             if let Some(mut tlas) = slot.take() {

--- a/crates/renderer/src/vulkan/acceleration/predicates.rs
+++ b/crates/renderer/src/vulkan/acceleration/predicates.rs
@@ -327,7 +327,7 @@ pub fn shrink_scratch_if_oversized<T>(vec: &mut Vec<T>, working_set: usize, floo
 /// configured budget, so the batched-build Phase 1 should pause and
 /// evict previous-cell BLAS before creating more result buffers. The
 /// 90% threshold leaves headroom for the batch's final few allocations
-/// + the scratch buffer; the budget itself is VRAM/3 so a breach
+/// and the scratch buffer; the budget itself is VRAM/3 so a breach
 /// represents genuine residency pressure, not just a hot spike.
 ///
 /// Pulled out as a pure function so the unit test can pin the
@@ -444,7 +444,7 @@ pub(super) fn is_scratch_aligned(scratch_address: vk::DeviceAddress, align: u32)
     if align <= 1 {
         return true;
     }
-    scratch_address % align as vk::DeviceAddress == 0
+    scratch_address.is_multiple_of(align as vk::DeviceAddress)
 }
 
 /// Extra bytes a scratch buffer must reserve, beyond the build-scratch

--- a/crates/renderer/src/vulkan/acceleration/tlas.rs
+++ b/crates/renderer/src/vulkan/acceleration/tlas.rs
@@ -36,6 +36,13 @@ impl AccelerationManager {
     /// every RT hit downstream.
     ///
     /// Records commands into `cmd` — caller must ensure a memory barrier after.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`, the
+    /// referenced BLAS) are valid and live, `cmd` is in the recording state,
+    /// the device is not lost, and external synchronization rules for the
+    /// touched objects are upheld per the Vulkan spec.
     pub unsafe fn build_tlas(
         &mut self,
         device: &ash::Device,

--- a/crates/renderer/src/vulkan/acceleration/types.rs
+++ b/crates/renderer/src/vulkan/acceleration/types.rs
@@ -7,6 +7,21 @@
 use super::super::buffer::GpuBuffer;
 use ash::vk;
 
+/// Vertex/index buffer + count pair describing the skinned geometry a
+/// per-entity BLAS refit reads from. Groups the four GPU-geometry
+/// arguments that travel together into [`super::AccelerationManager::refit_skinned_blas`].
+#[derive(Clone, Copy)]
+pub struct SkinnedBlasGeometry {
+    /// Post-skinning vertex buffer (the skin-compute output).
+    pub vertex_buffer: vk::Buffer,
+    /// Number of vertices in `vertex_buffer`.
+    pub vertex_count: u32,
+    /// Index buffer for the skinned mesh.
+    pub index_buffer: vk::Buffer,
+    /// Number of indices in `index_buffer`.
+    pub index_count: u32,
+}
+
 /// A bottom-level acceleration structure for one mesh.
 pub struct BlasEntry {
     pub accel: vk::AccelerationStructureKHR,

--- a/crates/renderer/src/vulkan/allocator.rs
+++ b/crates/renderer/src/vulkan/allocator.rs
@@ -57,7 +57,7 @@ impl Resource for AllocatorResource {}
 /// sampler and any future budgeting heuristic can compute `used /
 /// budget` without round-tripping to `vkGetPhysicalDeviceMemoryProperties`
 /// on each read. Use [`Self::sample`] to construct from a live instance
-/// + physical-device handle. The values never change after device
+/// and physical-device handle. The values never change after device
 /// selection, so refreshing is unnecessary — this is a strict cache.
 pub struct GpuMemoryBudget {
     /// Sum of `VkMemoryHeap.size` across every `DEVICE_LOCAL` heap.

--- a/crates/renderer/src/vulkan/bloom.rs
+++ b/crates/renderer/src/vulkan/bloom.rs
@@ -375,6 +375,13 @@ impl BloomPipeline {
     /// One-time UNDEFINED → GENERAL layout transition for every mip
     /// in every frame slot. Call once after `new()`. Same shape as
     /// `SvgfPipeline::initialize_layouts`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the bloom images are not concurrently accessed by another
+    /// command buffer.
     pub unsafe fn initialize_layouts(
         &self,
         device: &ash::Device,
@@ -464,6 +471,13 @@ impl BloomPipeline {
     /// Dispatch bloom. [`Self::upload_params`] must have been called this
     /// frame BEFORE the pre-render-pass bulk barrier so the UBO writes are
     /// covered by that barrier's HOST→COMPUTE execution dependency.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the bloom images/buffers are not concurrently accessed by
+    /// another in-flight command buffer.
     pub unsafe fn dispatch(
         &mut self,
         device: &ash::Device,
@@ -520,8 +534,8 @@ impl BloomPipeline {
                 &[],
             );
             let extent = f.down_mips[i].extent;
-            let groups_x = (extent.width + WORKGROUP_X - 1) / WORKGROUP_X;
-            let groups_y = (extent.height + WORKGROUP_Y - 1) / WORKGROUP_Y;
+            let groups_x = extent.width.div_ceil(WORKGROUP_X);
+            let groups_y = extent.height.div_ceil(WORKGROUP_Y);
             device.cmd_dispatch(cmd, groups_x, groups_y, 1);
 
             // Make this mip's WRITE visible to the next iteration's
@@ -564,8 +578,8 @@ impl BloomPipeline {
                 &[],
             );
             let extent = f.up_mips[i].extent;
-            let groups_x = (extent.width + WORKGROUP_X - 1) / WORKGROUP_X;
-            let groups_y = (extent.height + WORKGROUP_Y - 1) / WORKGROUP_Y;
+            let groups_x = extent.width.div_ceil(WORKGROUP_X);
+            let groups_y = extent.height.div_ceil(WORKGROUP_Y);
             device.cmd_dispatch(cmd, groups_x, groups_y, 1);
 
             let post = vk::ImageMemoryBarrier::default()
@@ -607,6 +621,13 @@ impl BloomPipeline {
         self.frames.iter().map(|f| f.up_mips[0].view).collect()
     }
 
+    /// Destroy all bloom images, views, and allocations.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that none of the bloom resources are still in
+    /// use by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for mut frame in self.frames.drain(..) {
             for mip in frame.down_mips.drain(..).chain(frame.up_mips.drain(..)) {
@@ -700,11 +721,11 @@ impl BloomFrame {
         // Up mips share extents with down_mips[0..N-1] (no top mip
         // since we seed the up chain from down_mips[N-1] directly).
         let mut up_mips: Vec<BloomMip> = Vec::with_capacity(BLOOM_MIP_COUNT - 1);
-        for i in 0..(BLOOM_MIP_COUNT - 1) {
+        for (i, down) in down_mips.iter().take(BLOOM_MIP_COUNT - 1).enumerate() {
             let mip = create_mip(
                 device,
                 allocator,
-                down_mips[i].extent,
+                down.extent,
                 &format!("bloom_up_f{frame_idx}_mip{i}"),
             )?;
             up_mips.push(mip);

--- a/crates/renderer/src/vulkan/buffer.rs
+++ b/crates/renderer/src/vulkan/buffer.rs
@@ -2,6 +2,7 @@
 
 use super::allocator::SharedAllocator;
 use super::texture::with_one_time_commands;
+use super::GpuUploadCtx;
 use anyhow::{Context, Result};
 use ash::vk;
 use gpu_allocator::vulkan;
@@ -435,17 +436,19 @@ impl GpuBuffer {
         rt_enabled: bool,
         staging_pool: Option<&mut StagingPool>,
     ) -> Result<Self> {
-        let size = (std::mem::size_of::<T>() * data.len()) as vk::DeviceSize;
+        let size = std::mem::size_of_val(data) as vk::DeviceSize;
         let mut usage = vk::BufferUsageFlags::VERTEX_BUFFER;
         if rt_enabled {
             usage |= vk::BufferUsageFlags::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR
                 | vk::BufferUsageFlags::SHADER_DEVICE_ADDRESS;
         }
         Self::create_device_local_buffer(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            GpuUploadCtx {
+                device,
+                allocator,
+                queue,
+                command_pool,
+            },
             size,
             usage,
             data,
@@ -464,17 +467,19 @@ impl GpuBuffer {
         rt_enabled: bool,
         staging_pool: Option<&mut StagingPool>,
     ) -> Result<Self> {
-        let size = (std::mem::size_of::<u32>() * data.len()) as vk::DeviceSize;
+        let size = std::mem::size_of_val(data) as vk::DeviceSize;
         let mut usage = vk::BufferUsageFlags::INDEX_BUFFER;
         if rt_enabled {
             usage |= vk::BufferUsageFlags::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR
                 | vk::BufferUsageFlags::SHADER_DEVICE_ADDRESS;
         }
         Self::create_device_local_buffer(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            GpuUploadCtx {
+                device,
+                allocator,
+                queue,
+                command_pool,
+            },
             size,
             usage,
             data,
@@ -773,15 +778,18 @@ impl GpuBuffer {
 
     /// Create a DEVICE_LOCAL buffer and upload data via a CpuToGpu staging buffer.
     pub fn create_device_local_buffer<T: Copy>(
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         size: vk::DeviceSize,
         usage: vk::BufferUsageFlags,
         data: &[T],
         mut staging_pool: Option<&mut StagingPool>,
     ) -> Result<Self> {
+        let GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        } = ctx;
         // 1. Acquire staging buffer — from pool (reuse) or create fresh.
         let (staging_buffer, mut staging_alloc) = if let Some(pool) = staging_pool.as_deref_mut() {
             pool.acquire(size)?

--- a/crates/renderer/src/vulkan/composite.rs
+++ b/crates/renderer/src/vulkan/composite.rs
@@ -84,7 +84,7 @@ pub struct CompositeParams {
     /// - `y` = scroll V
     /// - `z` = tile scale (0.0 disables clouds — shader skips the sample)
     /// - `w` = bindless texture index for cloud_textures[0], stored via
-    ///         `f32::from_bits(idx as u32)`; reinterpreted as uint in the shader.
+    ///   `f32::from_bits(idx as u32)`; reinterpreted as uint in the shader.
     pub cloud_params: [f32; 4],
     /// Cloud layer 1 parameters (WTHR CNAM). Same packing as cloud_params.
     /// Drifts in the opposite U direction at 1.35× speed for parallax.
@@ -807,8 +807,12 @@ impl CompositePipeline {
     /// Begin composite render pass + draw fullscreen triangle + end.
     /// Call after the main render pass ends and before submit.
     ///
-    /// Safety: `cmd` must be a valid recording command buffer. Frame index
-    /// must be < MAX_FRAMES_IN_FLIGHT. Swapchain image index must be valid.
+    /// # Safety
+    ///
+    /// `cmd` must be a valid recording command buffer. Frame index must be
+    /// < `MAX_FRAMES_IN_FLIGHT`. Swapchain image index must be valid. The
+    /// device must not be lost and the touched images must not be in use by
+    /// another in-flight command buffer.
     pub unsafe fn dispatch(
         &self,
         device: &ash::Device,
@@ -930,10 +934,8 @@ impl CompositePipeline {
             unsafe { device.destroy_image(img, None) };
         }
         self.hdr_images.clear();
-        for alloc in self.hdr_allocations.drain(..) {
-            if let Some(a) = alloc {
-                allocator.lock().expect("allocator lock").free(a).ok();
-            }
+        for a in self.hdr_allocations.drain(..).flatten() {
+            allocator.lock().expect("allocator lock").free(a).ok();
         }
 
         self.width = width;
@@ -1104,10 +1106,8 @@ impl CompositePipeline {
                 unsafe { device.destroy_image(img, None) };
             }
             self.hdr_images.clear();
-            for alloc in self.hdr_allocations.drain(..) {
-                if let Some(a) = alloc {
-                    allocator.lock().expect("allocator lock").free(a).ok();
-                }
+            for a in self.hdr_allocations.drain(..).flatten() {
+                allocator.lock().expect("allocator lock").free(a).ok();
             }
         }
         result
@@ -1151,10 +1151,10 @@ impl CompositePipeline {
         hdr_layout: vk::ImageLayout,
     ) {
         debug_assert_eq!(hdr_views.len(), MAX_FRAMES_IN_FLIGHT);
-        for i in 0..MAX_FRAMES_IN_FLIGHT {
+        for (i, &hdr_view) in hdr_views.iter().enumerate() {
             let info = [vk::DescriptorImageInfo::default()
                 .sampler(self.hdr_sampler)
-                .image_view(hdr_views[i])
+                .image_view(hdr_view)
                 .image_layout(hdr_layout)];
             let write = write_combined_image_sampler(self.descriptor_sets[i], 0, &info);
             // SAFETY: descriptor set `i` owned by `self`; `info` references
@@ -1177,6 +1177,12 @@ impl CompositePipeline {
 
     /// Destroy all Vulkan objects. Must be called before the device/allocator
     /// are dropped. Safe to call on partially-initialized state.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that no object owned by `self` is still in use
+    /// by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         // SAFETY (whole function): caller of `destroy` (unsafe fn)
         // guarantees no in-flight command buffer references any object
@@ -1226,10 +1232,8 @@ impl CompositePipeline {
             unsafe { device.destroy_image(img, None) };
         }
         self.hdr_images.clear();
-        for alloc in self.hdr_allocations.drain(..) {
-            if let Some(a) = alloc {
-                allocator.lock().expect("allocator lock").free(a).ok();
-            }
+        for a in self.hdr_allocations.drain(..).flatten() {
+            allocator.lock().expect("allocator lock").free(a).ok();
         }
     }
 }

--- a/crates/renderer/src/vulkan/compute.rs
+++ b/crates/renderer/src/vulkan/compute.rs
@@ -281,6 +281,13 @@ impl ClusterCullPipeline {
     /// fans the per-cluster light scan out across one warp / wavefront
     /// (#652). Total threads = `CLUSTER_TILES_X × CLUSTER_TILES_Y × CLUSTER_SLICES_Z × 32 =
     /// 3456 × 32 = 110_592` per dispatch.
+    ///
+    /// # Safety
+    ///
+    /// `device` and `cmd` must be valid and live, `cmd` must be in the
+    /// recording state, `frame` must be < `MAX_FRAMES_IN_FLIGHT`, the device
+    /// must not be lost, and the bound buffers must not be in use by another
+    /// in-flight command buffer.
     pub unsafe fn dispatch(&self, device: &ash::Device, cmd: vk::CommandBuffer, frame: usize) {
         device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::COMPUTE, self.pipeline);
         device.cmd_bind_descriptor_sets(
@@ -316,6 +323,13 @@ impl ClusterCullPipeline {
             as vk::DeviceSize
     }
 
+    /// Destroy all pipeline objects and buffers.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that no object owned by `self` is still in use
+    /// by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for buf in &mut self.cluster_grid_buffers {
             buf.destroy(device, allocator);

--- a/crates/renderer/src/vulkan/context/draw.rs
+++ b/crates/renderer/src/vulkan/context/draw.rs
@@ -130,75 +130,106 @@ pub(super) struct DrawBatch {
     pub z_function: u8,
 }
 
+/// All per-frame inputs consumed by [`VulkanContext::draw_frame`].
+///
+/// Groups the (formerly 22) loose `draw_frame` arguments into one struct so
+/// the call stays under the argument-count lint. Construction is mechanical:
+/// every field is exactly the argument it replaces, in the same order.
+pub struct FrameInputs<'a> {
+    /// Clear color (RGBA) for the main render pass.
+    pub clear_color: [f32; 4],
+    /// Combined view-projection matrix as column-major `[f32; 16]`.
+    pub view_proj: &'a [f32; 16],
+    /// Per-object draw commands (mesh handle + model matrix + flags).
+    pub draw_commands: &'a [DrawCommand],
+    /// Scene lights for this frame.
+    pub lights: &'a [scene_buffer::GpuLight],
+    /// M29.5/M29.6 — per-frame bone-world matrices for the GPU palette
+    /// compute pass (`skin_palette.comp`). `bone_world[i]` is the per-slot
+    /// raw world transform sourced from `GlobalTransform`; indexed by
+    /// `skin_slot_id × MAX_BONES_PER_MESH` via the `SkinSlotPool`. The
+    /// matching `bind_inverses` for each slot live in the persistent SSBO
+    /// and are uploaded first-sight via `bind_inverse_pending_uploads`.
+    pub bone_world: &'a [[[f32; 4]; 4]],
+    /// M29.6 — first-sight `bind_inverses` uploads to schedule this frame.
+    /// Each entry is `(slot_id, per-mesh bind_inverses)`; the renderer writes
+    /// them into the persistent SSBO at the slot's offset before dispatching
+    /// `skin_palette.comp`. Empty on frames with no fresh skinned-mesh
+    /// first-sight (the steady-state case).
+    pub bind_inverse_pending_uploads: &'a [(u32, Vec<[[f32; 4]; 4]>)],
+    /// Per-frame materials.
+    pub materials: &'a [GpuMaterial],
+    /// Camera world position.
+    pub camera_pos: [f32; 3],
+    /// Ambient light color.
+    pub ambient_color: [f32; 3],
+    /// Linear fog color.
+    pub fog_color: [f32; 3],
+    /// Fog near distance.
+    pub fog_near: f32,
+    /// Fog far distance.
+    pub fog_far: f32,
+    /// XCLL FNV+ cubic-fog clip distance. `0.0` (with `fog_power == 0.0`)
+    /// falls back to the linear `fog_near..fog_far` ramp. See #865 /
+    /// FNV-D3-NEW-06.
+    pub fog_clip: f32,
+    /// XCLL FNV+ cubic-fog falloff exponent. `0.0` disables the curve.
+    pub fog_power: f32,
+    /// Optional UI overlay texture handle.
+    pub ui_texture_handle: Option<u32>,
+    /// Sky / weather parameters.
+    pub sky_params: &'a SkyParams,
+    /// Depth-of-field lens parameters. `dof.aperture == 0.0` = pinhole camera
+    /// (no DOF jitter). When non-zero, the camera position is displaced each
+    /// frame by a Halton(5,7)-sampled concentric disk of radius `aperture`;
+    /// TAA accumulates the samples into a spatially-varying bokeh blur.
+    pub dof: DofView,
+    /// Optional per-frame GPU timing sink.
+    pub timings: Option<&'a mut FrameTimings>,
+    /// Water-surface draws for this frame. Each entry must match a
+    /// `DrawCommand` with `is_water=true` that supplies the corresponding
+    /// `GpuInstance` SSBO slot. Empty slice = no water rendering this frame.
+    pub water_commands: &'a [WaterDrawCommand],
+    /// `xyz` = deep_color tint to blend the scene toward; `w` = camera depth
+    /// below the water surface in world units. `[0, 0, 0, 0]` disables
+    /// underwater FX.
+    pub underwater: [f32; 4],
+    /// #1195 / PERF-DIM7-01 — per-frame dirty set for the skin compute
+    /// dispatch + skinned-BLAS refit gate. Entities NOT in this set whose
+    /// slots already have `has_populated_output = true` AND a live BLAS skip
+    /// both compute dispatch and refit. First-sight (no populated output yet)
+    /// ignores the set and always dispatches. Paired with #1196.
+    pub pose_dirty: &'a std::collections::HashSet<EntityId>,
+}
+
 impl VulkanContext {
     /// Record and submit a frame.
     ///
-    /// `view_proj`: combined view-projection matrix as column-major [f32; 16].
-    /// `draw_commands`: per-object (mesh_handle, model_matrix) pairs.
-    pub fn draw_frame(
-        &mut self,
-        clear_color: [f32; 4],
-        view_proj: &[f32; 16],
-        draw_commands: &[DrawCommand],
-        lights: &[scene_buffer::GpuLight],
-        // M29.5/M29.6 — per-frame bone-world matrices for the GPU
-        // palette compute pass (`skin_palette.comp`). `bone_world[i]`
-        // is the per-slot raw world transform sourced from
-        // `GlobalTransform`; indexed by `skin_slot_id × MAX_BONES_PER_MESH`
-        // via the [`SkinSlotPool`]. The matching `bind_inverses` for
-        // each slot live in the persistent SSBO and are uploaded
-        // first-sight via `bind_inverse_pending_uploads` below.
-        bone_world: &[[[f32; 4]; 4]],
-        // M29.6 — first-sight `bind_inverses` uploads to schedule
-        // this frame. Each entry is `(slot_id, per-mesh bind_inverses)`;
-        // the renderer writes them into the persistent SSBO at the
-        // slot's offset before dispatching `skin_palette.comp`. Empty
-        // on frames with no fresh skinned-mesh first-sight (the
-        // steady-state case).
-        bind_inverse_pending_uploads: &[(u32, Vec<[[f32; 4]; 4]>)],
-        materials: &[GpuMaterial],
-        camera_pos: [f32; 3],
-        ambient_color: [f32; 3],
-        fog_color: [f32; 3],
-        fog_near: f32,
-        fog_far: f32,
-        // `fog_clip`/`fog_power` carry the XCLL FNV+ cubic-fog curve
-        // through to `CompositeParams.fog_params.z/w`. `0.0` on either
-        // = no curve; composite falls back to the linear
-        // `fog_near..fog_far` ramp. See #865 / FNV-D3-NEW-06.
-        fog_clip: f32,
-        fog_power: f32,
-        ui_texture_handle: Option<u32>,
-        sky_params: &SkyParams,
-        // Depth-of-field lens parameters. `dof.aperture == 0.0` = pinhole camera
-        // (no DOF jitter). When non-zero, the camera position is displaced each
-        // frame by a Halton(5,7)-sampled concentric disk of radius `aperture`;
-        // TAA accumulates the samples into a spatially-varying bokeh blur.
-        dof: DofView,
-        timings: Option<&mut FrameTimings>,
-        // `water_commands`: water-surface draws for this frame. Each
-        // entry must match a `DrawCommand` with `is_water=true` that
-        // supplies the corresponding `GpuInstance` SSBO slot. Built
-        // by the app's per-frame render code from `WaterPlane` ECS
-        // entities. Empty slice = no water rendering this frame.
-        water_commands: &[WaterDrawCommand],
-        // `underwater`: xyz = deep_color tint to blend the scene
-        // toward; w = camera depth below the water surface in world
-        // units. `[0, 0, 0, 0]` disables underwater FX. Computed by
-        // the app from the camera's `SubmersionState` component.
-        underwater: [f32; 4],
-        // #1195 / PERF-DIM7-01 — per-frame dirty set for the skin
-        // compute dispatch + skinned-BLAS refit gate. Entities NOT in
-        // this set whose slots already have `has_populated_output = true`
-        // AND a live BLAS skip both compute dispatch and refit. The
-        // set is populated by `build_skinned_palettes` via
-        // `SkinSlotPool::try_mark_pose_dirty`; an empty set on a frame
-        // with N skinned entities means every NPC is idle (no bones
-        // moved frame-to-frame) and N dispatches + N refits are
-        // suppressed. First-sight (no populated output yet) ignores
-        // the set and always dispatches. Paired with #1196.
-        pose_dirty: &std::collections::HashSet<EntityId>,
-    ) -> Result<bool> {
+    /// All per-frame inputs are bundled in [`FrameInputs`].
+    pub fn draw_frame(&mut self, inputs: FrameInputs) -> Result<bool> {
+        let FrameInputs {
+            clear_color,
+            view_proj,
+            draw_commands,
+            lights,
+            bone_world,
+            bind_inverse_pending_uploads,
+            materials,
+            camera_pos,
+            ambient_color,
+            fog_color,
+            fog_near,
+            fog_far,
+            fog_clip,
+            fog_power,
+            ui_texture_handle,
+            sky_params,
+            dof,
+            timings,
+            water_commands,
+            underwater,
+            pose_dirty,
+        } = inputs;
         // #1211 / REN-SAFETY — skip the frame when the main framebuffers
         // Vec is empty. `recreate_swapchain` destroys framebuffers up
         // front and only rebuilds them at the end (`resize.rs:564`);
@@ -516,7 +547,7 @@ impl VulkanContext {
         // of-2 ≥ 6) avoids the asymmetric Y-coverage gap that % 8 caused
         // (the 9th Halton(3) sample ≈ 0.889 was never reached with % 8).
         let (jx, jy) = if self.taa.is_some() {
-            let idx = (self.frame_counter % 16) as u32 + 1; // 1-indexed
+            let idx = (self.frame_counter % 16) + 1; // 1-indexed
             let hx = halton(idx, 2);
             let hy = halton(idx, 3);
             // Map [0,1] → [-0.5, 0.5] pixels, then to NDC.
@@ -539,7 +570,7 @@ impl VulkanContext {
         // 32-frame DOF period interleaves cleanly with the 16-frame TAA
         // period without correlated low-discrepancy gaps.
         let (effective_vp, effective_cam_pos) = if dof.aperture > 0.0 {
-            let idx = (self.frame_counter % 32) as u32 + 1;
+            let idx = (self.frame_counter % 32) + 1;
             let (disk_u, disk_v) =
                 concentric_disk_sample(halton(idx, 5), halton(idx, 7));
             let lens_u = disk_u * dof.aperture;
@@ -826,12 +857,14 @@ impl VulkanContext {
                         &self.device,
                         cmd,
                         frame,
-                        bone_world_buf,
-                        bone_byte_size,
-                        bind_inverse_buf,
-                        bind_inverse_size,
-                        palette_buf,
-                        palette_size,
+                        super::super::skin_compute::PaletteDispatchBuffers {
+                            bone_world_buffer: bone_world_buf,
+                            bone_world_buffer_size: bone_byte_size,
+                            bind_inverse_buffer: bind_inverse_buf,
+                            bind_inverse_buffer_size: bind_inverse_size,
+                            palette_buffer: palette_buf,
+                            palette_buffer_size: palette_size,
+                        },
                         super::super::skin_compute::SkinPalettePushConstants {
                             bone_count,
                         },
@@ -891,7 +924,7 @@ impl VulkanContext {
         // Skips entirely when `skin_compute` / `accel_manager` are None
         // (no RT) or no draws are skinned.
         let skin_t0 = Instant::now();
-        if let (Some(ref skin_pipeline), Some(ref mut accel)) =
+        if let (Some(skin_pipeline), Some(ref mut accel)) =
             (self.skin_compute.as_ref(), self.accel_manager.as_mut())
         {
             if let Some(ref alloc) = self.allocator {
@@ -1171,10 +1204,12 @@ impl VulkanContext {
                                     cmd,
                                     slot,
                                     frame,
-                                    input_buffer,
-                                    input_size,
-                                    bone_buf,
-                                    bone_buffer_size,
+                                    super::super::skin_compute::SkinDispatchBuffers {
+                                        input_buffer,
+                                        input_buffer_size: input_size,
+                                        bone_buffer: bone_buf,
+                                        bone_buffer_size,
+                                    },
                                     push,
                                 );
                                 // Flip the "populated" bit on the
@@ -1325,10 +1360,12 @@ impl VulkanContext {
                                     &self.device,
                                     cmd,
                                     entity_id,
-                                    slot.output_buffer.buffer,
-                                    vertex_count,
-                                    idx_buffer,
-                                    idx_count,
+                                    crate::vulkan::acceleration::SkinnedBlasGeometry {
+                                        vertex_buffer: slot.output_buffer.buffer,
+                                        vertex_count,
+                                        index_buffer: idx_buffer,
+                                        index_count: idx_count,
+                                    },
                                 ) {
                                     Ok(()) => {
                                         self.last_skin_coverage_frame.refits_succeeded += 1;
@@ -3069,10 +3106,12 @@ impl VulkanContext {
                         .lock()
                         .unwrap_or_else(|e| e.into_inner());
                     if let Err(e) = pass.dispatch(
-                        &self.device,
-                        cmd,
-                        *queue_guard,
-                        self.transfer_pool,
+                        crate::vulkan::egui_pass::EguiDispatchCtx {
+                            device: &self.device,
+                            cmd,
+                            queue: *queue_guard,
+                            upload_command_pool: self.transfer_pool,
+                        },
                         img as u32,
                         &egui_ctx,
                         output,

--- a/crates/renderer/src/vulkan/context/helpers.rs
+++ b/crates/renderer/src/vulkan/context/helpers.rs
@@ -44,17 +44,43 @@ pub(super) fn find_depth_format(
     anyhow::bail!("No supported depth format found (tried D32, D32S8, D24S8, D16)")
 }
 
+/// The eight attachment formats the main render pass writes — the seven
+/// G-buffer color targets plus depth. Groups the formats that travel
+/// together into [`create_render_pass`].
+#[derive(Clone, Copy)]
+pub(super) struct GBufferFormats {
+    /// HDR color (attachment 0).
+    pub color_format: vk::Format,
+    /// Octahedral world-space normal (attachment 1).
+    pub normal_format: vk::Format,
+    /// Screen-space motion vector (attachment 2).
+    pub motion_format: vk::Format,
+    /// Per-instance mesh ID (attachment 3).
+    pub mesh_id_format: vk::Format,
+    /// Raw indirect lighting (attachment 4).
+    pub raw_indirect_format: vk::Format,
+    /// Albedo (attachment 5).
+    pub albedo_format: vk::Format,
+    /// Reservoir (attachment 6).
+    pub reservoir_format: vk::Format,
+    /// Depth attachment.
+    pub depth_format: vk::Format,
+}
+
 pub(super) fn create_render_pass(
     device: &ash::Device,
-    color_format: vk::Format,
-    normal_format: vk::Format,
-    motion_format: vk::Format,
-    mesh_id_format: vk::Format,
-    raw_indirect_format: vk::Format,
-    albedo_format: vk::Format,
-    reservoir_format: vk::Format,
-    depth_format: vk::Format,
+    formats: GBufferFormats,
 ) -> Result<vk::RenderPass> {
+    let GBufferFormats {
+        color_format,
+        normal_format,
+        motion_format,
+        mesh_id_format,
+        raw_indirect_format,
+        albedo_format,
+        reservoir_format,
+        depth_format,
+    } = formats;
     // Main render pass writes to 7 color attachments + depth.
     // Formats are the authoritative constants in `vulkan/gbuffer.rs`; the
     // list below names them for orientation.
@@ -235,19 +261,42 @@ pub(super) fn create_render_pass(
 /// albedo + reservoir views, plus the shared depth view.
 ///
 /// All the color view slices must have the same length (MAX_FRAMES_IN_FLIGHT).
+/// The per-frame G-buffer color views (parallel slices, each of length
+/// `MAX_FRAMES_IN_FLIGHT`) bound by [`create_main_framebuffers`].
+#[derive(Clone, Copy)]
+pub(super) struct GBufferViews<'a> {
+    /// HDR color views (attachment 0).
+    pub hdr_views: &'a [vk::ImageView],
+    /// Normal views (attachment 1).
+    pub normal_views: &'a [vk::ImageView],
+    /// Motion-vector views (attachment 2).
+    pub motion_views: &'a [vk::ImageView],
+    /// Mesh-ID views (attachment 3).
+    pub mesh_id_views: &'a [vk::ImageView],
+    /// Raw-indirect views (attachment 4).
+    pub raw_indirect_views: &'a [vk::ImageView],
+    /// Albedo views (attachment 5).
+    pub albedo_views: &'a [vk::ImageView],
+    /// Reservoir views (attachment 6).
+    pub reservoir_views: &'a [vk::ImageView],
+}
+
 pub(super) fn create_main_framebuffers(
     device: &ash::Device,
     render_pass: vk::RenderPass,
-    hdr_views: &[vk::ImageView],
-    normal_views: &[vk::ImageView],
-    motion_views: &[vk::ImageView],
-    mesh_id_views: &[vk::ImageView],
-    raw_indirect_views: &[vk::ImageView],
-    albedo_views: &[vk::ImageView],
-    reservoir_views: &[vk::ImageView],
+    views: GBufferViews,
     depth_view: vk::ImageView,
     extent: vk::Extent2D,
 ) -> Result<Vec<vk::Framebuffer>> {
+    let GBufferViews {
+        hdr_views,
+        normal_views,
+        motion_views,
+        mesh_id_views,
+        raw_indirect_views,
+        albedo_views,
+        reservoir_views,
+    } = views;
     debug_assert_eq!(hdr_views.len(), normal_views.len());
     debug_assert_eq!(hdr_views.len(), motion_views.len());
     debug_assert_eq!(hdr_views.len(), mesh_id_views.len());

--- a/crates/renderer/src/vulkan/context/mod.rs
+++ b/crates/renderer/src/vulkan/context/mod.rs
@@ -862,6 +862,12 @@ pub struct ScreenshotHandle {
     pub result: Arc<Mutex<Option<Vec<u8>>>>,
 }
 
+impl Default for ScreenshotHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScreenshotHandle {
     pub fn new() -> Self {
         Self {
@@ -1447,11 +1453,13 @@ impl VulkanContext {
 
         // 8. Swapchain
         let swapchain_state = swapchain::create_swapchain(
-            &vk_instance,
-            &device,
-            physical_device,
-            &surface_loader,
-            vk_surface,
+            swapchain::SwapchainSurfaceCtx {
+                instance: &vk_instance,
+                device: &device,
+                physical_device,
+                surface_loader: &surface_loader,
+                surface: vk_surface,
+            },
             queue_indices,
             window_size,
             vk::SwapchainKHR::null(), // no old swapchain on initial creation
@@ -1469,14 +1477,16 @@ impl VulkanContext {
         // raw_indirect + albedo + reservoir) + depth.
         let render_pass = create_render_pass(
             &device,
-            HDR_FORMAT,
-            NORMAL_FORMAT,
-            MOTION_FORMAT,
-            MESH_ID_FORMAT,
-            RAW_INDIRECT_FORMAT,
-            ALBEDO_FORMAT,
-            RESERVOIR_FORMAT,
-            depth_format,
+            helpers::GBufferFormats {
+                color_format: HDR_FORMAT,
+                normal_format: NORMAL_FORMAT,
+                motion_format: MOTION_FORMAT,
+                mesh_id_format: MESH_ID_FORMAT,
+                raw_indirect_format: RAW_INDIRECT_FORMAT,
+                albedo_format: ALBEDO_FORMAT,
+                reservoir_format: RESERVOIR_FORMAT,
+                depth_format,
+            },
         )?;
 
         // 10. Command pools: one for per-frame draw commands (RESET_COMMAND_BUFFER),
@@ -1508,10 +1518,12 @@ impl VulkanContext {
         // the first pool entry that would otherwise linger for the rest
         // of the session.
         let fallback_texture = Texture::from_rgba(
-            &device,
-            &gpu_allocator,
-            &graphics_queue,
-            transfer_pool,
+            super::GpuUploadCtx {
+                device: &device,
+                allocator: &gpu_allocator,
+                queue: &graphics_queue,
+                command_pool: transfer_pool,
+            },
             256,
             256,
             &checkerboard,
@@ -1528,10 +1540,12 @@ impl VulkanContext {
         // checker × those terms.
         let white_pixel: [u8; 4] = [0xFF, 0xFF, 0xFF, 0xFF];
         let neutral_texture = Texture::from_rgba(
-            &device,
-            &gpu_allocator,
-            &graphics_queue,
-            transfer_pool,
+            super::GpuUploadCtx {
+                device: &device,
+                allocator: &gpu_allocator,
+                queue: &graphics_queue,
+                command_pool: transfer_pool,
+            },
             1,
             1,
             &white_pixel,
@@ -1812,7 +1826,7 @@ impl VulkanContext {
         // uninitialised; safe because Phase D's shader-side read is
         // gated on `sunDirection.w > 0` and won't fire during the
         // scaffold-only window.
-        if let (Some(ref w), Some(ref accum)) = (water.as_ref(), water_caustic_accum.as_ref()) {
+        if let (Some(w), Some(accum)) = (water.as_ref(), water_caustic_accum.as_ref()) {
             let views: Vec<vk::ImageView> = (0..super::sync::MAX_FRAMES_IN_FLIGHT)
                 .map(|i| accum.storage_view(i))
                 .collect();
@@ -1928,10 +1942,12 @@ impl VulkanContext {
             &device,
             &gpu_allocator,
             pipeline_cache,
-            &raw_indirect_views,
-            &motion_views_seed,
-            &mesh_id_views_seed,
-            &normal_views_for_svgf,
+            super::svgf::SvgfInputViews {
+                raw_indirect_views: &raw_indirect_views,
+                motion_views: &motion_views_seed,
+                mesh_id_views: &mesh_id_views_seed,
+                normal_views: &normal_views_for_svgf,
+            },
             swapchain_state.extent.width,
             swapchain_state.extent.height,
         ) {
@@ -2133,9 +2149,11 @@ impl VulkanContext {
             &device,
             &gpu_allocator,
             pipeline_cache,
-            &hdr_views_owned,
-            &motion_views_seed,
-            &mesh_id_views_seed,
+            super::taa::TaaInputViews {
+                hdr_views: &hdr_views_owned,
+                motion_views: &motion_views_seed,
+                mesh_id_views: &mesh_id_views_seed,
+            },
             swapchain_state.extent.width,
             swapchain_state.extent.height,
         ) {
@@ -2157,7 +2175,7 @@ impl VulkanContext {
         // Swap composite's HDR binding to TAA output so tone-map samples
         // the anti-aliased image. When TAA is disabled composite keeps its
         // original raw-HDR descriptors.
-        if let (Some(ref t), Some(ref mut c)) = (taa.as_ref(), composite.as_mut()) {
+        if let (Some(t), Some(ref mut c)) = (taa.as_ref(), composite.as_mut()) {
             let taa_views: Vec<vk::ImageView> = (0..n_frames).map(|i| t.output_view(i)).collect();
             c.rebind_hdr_views(&device, &taa_views, vk::ImageLayout::GENERAL);
         }
@@ -2175,13 +2193,15 @@ impl VulkanContext {
         let framebuffers = create_main_framebuffers(
             &device,
             render_pass,
-            hdr_views,
-            &normal_views,
-            &motion_views,
-            &mesh_id_views,
-            &raw_indirect_views,
-            &albedo_views,
-            &reservoir_views,
+            helpers::GBufferViews {
+                hdr_views,
+                normal_views: &normal_views,
+                motion_views: &motion_views,
+                mesh_id_views: &mesh_id_views,
+                raw_indirect_views: &raw_indirect_views,
+                albedo_views: &albedo_views,
+                reservoir_views: &reservoir_views,
+            },
             depth_image_view,
             swapchain_state.extent,
         )?;
@@ -2384,11 +2404,13 @@ impl VulkanContext {
             return Ok(pipe);
         }
         let pipe = pipeline::create_blend_pipeline(
-            &self.device,
-            self.render_pass,
-            self.swapchain_state.extent,
-            self.pipeline_cache,
-            self.pipeline_layout,
+            pipeline::BlendPipelineCtx {
+                device: &self.device,
+                render_pass: self.render_pass,
+                extent: self.swapchain_state.extent,
+                pipeline_cache: self.pipeline_cache,
+                pipeline_layout: self.pipeline_layout,
+            },
             src,
             dst,
             wireframe,
@@ -2626,6 +2648,7 @@ impl VulkanContext {
 
 // Method implementations split across submodules:
 mod draw;
+pub use draw::FrameInputs;
 mod helpers;
 mod resize;
 mod resources;

--- a/crates/renderer/src/vulkan/context/resize.rs
+++ b/crates/renderer/src/vulkan/context/resize.rs
@@ -10,7 +10,7 @@ use super::super::sync::MAX_FRAMES_IN_FLIGHT;
 use super::super::{pipeline, swapchain};
 use super::helpers::{
     create_depth_resources, create_main_framebuffers, create_render_pass, destroy_depth_resources,
-    destroy_main_framebuffers, destroy_render_pass_pipelines,
+    destroy_main_framebuffers, destroy_render_pass_pipelines, GBufferFormats, GBufferViews,
 };
 use super::VulkanContext;
 use anyhow::{Context, Result};
@@ -102,11 +102,13 @@ impl VulkanContext {
         let old_swapchain = self.swapchain_state.swapchain;
 
         self.swapchain_state = swapchain::create_swapchain(
-            &self.instance,
-            &self.device,
-            self.physical_device,
-            &self.surface_loader,
-            self.surface,
+            swapchain::SwapchainSurfaceCtx {
+                instance: &self.instance,
+                device: &self.device,
+                physical_device: self.physical_device,
+                surface_loader: &self.surface_loader,
+                surface: self.surface,
+            },
             self.queue_indices,
             window_size,
             old_swapchain, // atomic handoff — avoids flicker during resize
@@ -192,14 +194,16 @@ impl VulkanContext {
             // + albedo + reservoir) + depth.
             self.render_pass = create_render_pass(
                 &self.device,
-                HDR_FORMAT,
-                NORMAL_FORMAT,
-                MOTION_FORMAT,
-                MESH_ID_FORMAT,
-                RAW_INDIRECT_FORMAT,
-                ALBEDO_FORMAT,
-                RESERVOIR_FORMAT,
-                self.depth_format,
+                GBufferFormats {
+                    color_format: HDR_FORMAT,
+                    normal_format: NORMAL_FORMAT,
+                    motion_format: MOTION_FORMAT,
+                    mesh_id_format: MESH_ID_FORMAT,
+                    raw_indirect_format: RAW_INDIRECT_FORMAT,
+                    albedo_format: ALBEDO_FORMAT,
+                    reservoir_format: RESERVOIR_FORMAT,
+                    depth_format: self.depth_format,
+                },
             )?;
 
             // Recreate pipelines against the new render pass, reusing
@@ -357,16 +361,21 @@ impl VulkanContext {
         // images to GENERAL.
         if let Some(ref mut svgf) = self.svgf {
             svgf.recreate_on_resize(
-                &self.device,
-                self.allocator
-                    .as_ref()
-                    .expect("allocator missing during resize"),
-                &self.graphics_queue,
-                self.transfer_pool,
-                &raw_indirect_views,
-                &motion_views_in,
-                &mesh_id_views_in,
-                &normal_views_in,
+                crate::vulkan::GpuUploadCtx {
+                    device: &self.device,
+                    allocator: self
+                        .allocator
+                        .as_ref()
+                        .expect("allocator missing during resize"),
+                    queue: &self.graphics_queue,
+                    command_pool: self.transfer_pool,
+                },
+                crate::vulkan::svgf::SvgfInputViews {
+                    raw_indirect_views: &raw_indirect_views,
+                    motion_views: &motion_views_in,
+                    mesh_id_views: &mesh_id_views_in,
+                    normal_views: &normal_views_in,
+                },
                 self.swapchain_state.extent.width,
                 self.swapchain_state.extent.height,
             )?;
@@ -454,7 +463,7 @@ impl VulkanContext {
         // Rebind WaterPipeline's set 2 to the new accumulator views
         // (the recreate above produced fresh `vk::ImageView` handles
         // per FIF slot). Skipped when either side dropped out above.
-        if let (Some(ref w), Some(ref accum)) =
+        if let (Some(w), Some(accum)) =
             (self.water.as_ref(), self.water_caustic_accum.as_ref())
         {
             let views: Vec<vk::ImageView> = (0..MAX_FRAMES_IN_FLIGHT)
@@ -592,15 +601,20 @@ impl VulkanContext {
         // `recreate_on_resize` (#1031).
         if let Some(ref mut taa) = self.taa {
             taa.recreate_on_resize(
-                &self.device,
-                self.allocator
-                    .as_ref()
-                    .expect("allocator missing during resize"),
-                &self.graphics_queue,
-                self.transfer_pool,
-                &hdr_views_owned,
-                &motion_views_in,
-                &mesh_id_views_in,
+                crate::vulkan::GpuUploadCtx {
+                    device: &self.device,
+                    allocator: self
+                        .allocator
+                        .as_ref()
+                        .expect("allocator missing during resize"),
+                    queue: &self.graphics_queue,
+                    command_pool: self.transfer_pool,
+                },
+                crate::vulkan::taa::TaaInputViews {
+                    hdr_views: &hdr_views_owned,
+                    motion_views: &motion_views_in,
+                    mesh_id_views: &mesh_id_views_in,
+                },
                 self.swapchain_state.extent.width,
                 self.swapchain_state.extent.height,
             )?;
@@ -635,13 +649,15 @@ impl VulkanContext {
         self.framebuffers = create_main_framebuffers(
             &self.device,
             self.render_pass,
-            hdr_views,
-            &normal_views,
-            &motion_views,
-            &mesh_id_views,
-            &raw_indirect_views,
-            &albedo_views,
-            &reservoir_views,
+            GBufferViews {
+                hdr_views,
+                normal_views: &normal_views,
+                motion_views: &motion_views,
+                mesh_id_views: &mesh_id_views,
+                raw_indirect_views: &raw_indirect_views,
+                albedo_views: &albedo_views,
+                reservoir_views: &reservoir_views,
+            },
             self.depth_image_view,
             self.swapchain_state.extent,
         )?;

--- a/crates/renderer/src/vulkan/context/resources.rs
+++ b/crates/renderer/src/vulkan/context/resources.rs
@@ -112,10 +112,12 @@ impl VulkanContext {
         };
         let allocator = self.allocator.as_ref().expect("allocator missing");
         if let Err(e) = accel.build_blas(
-            &self.device,
-            allocator,
-            &self.graphics_queue,
-            self.transfer_pool,
+            crate::vulkan::GpuUploadCtx {
+                device: &self.device,
+                allocator,
+                queue: &self.graphics_queue,
+                command_pool: self.transfer_pool,
+            },
             Some(&self.transfer_fence),
             mesh_handle,
             mesh,
@@ -167,10 +169,12 @@ impl VulkanContext {
         let (vertices, indices) = crate::mesh::fullscreen_quad_ui_vertices();
         let allocator = self.allocator.as_ref().expect("allocator missing");
         let handle = self.mesh_registry.upload(
-            &self.device,
-            allocator,
-            &self.graphics_queue,
-            self.transfer_pool,
+            crate::vulkan::GpuUploadCtx {
+                device: &self.device,
+                allocator,
+                queue: &self.graphics_queue,
+                command_pool: self.transfer_pool,
+            },
             &vertices,
             &indices,
             false, // UI quad doesn't need RT
@@ -190,10 +194,12 @@ impl VulkanContext {
         let (vertices, indices) = crate::mesh::quad_vertices();
         let allocator = self.allocator.as_ref().expect("allocator missing");
         let handle = self.mesh_registry.upload(
-            &self.device,
-            allocator,
-            &self.graphics_queue,
-            self.transfer_pool,
+            crate::vulkan::GpuUploadCtx {
+                device: &self.device,
+                allocator,
+                queue: &self.graphics_queue,
+                command_pool: self.transfer_pool,
+            },
             &vertices,
             &indices,
             false, // particles skip TLAS

--- a/crates/renderer/src/vulkan/dds.rs
+++ b/crates/renderer/src/vulkan/dds.rs
@@ -10,7 +10,6 @@ const DX10_EXT_SIZE: usize = 20;
 // DDS_PIXELFORMAT flags
 const DDPF_FOURCC: u32 = 0x4;
 const DDPF_RGB: u32 = 0x40;
-const DDPF_ALPHAPIXELS: u32 = 0x1;
 
 // FourCC values
 const FOURCC_DXT1: u32 = u32::from_le_bytes(*b"DXT1");
@@ -123,11 +122,7 @@ pub fn parse_dds(data: &[u8]) -> Result<DdsMetadata> {
             "Unsupported uncompressed DDS: {} bpp (only 32-bit RGBA supported)",
             bpp
         );
-        let format = if pf_flags & DDPF_ALPHAPIXELS != 0 {
-            vk::Format::R8G8B8A8_SRGB
-        } else {
-            vk::Format::R8G8B8A8_SRGB
-        };
+        let format = vk::Format::R8G8B8A8_SRGB;
         Ok(DdsMetadata {
             width,
             height,
@@ -150,8 +145,8 @@ pub fn mip_size(width: u32, height: u32, mip_level: u32, block_size: u32, compre
     let w = (width >> mip_level).max(1);
     let h = (height >> mip_level).max(1);
     if compressed {
-        let blocks_x = (w + 3) / 4;
-        let blocks_y = (h + 3) / 4;
+        let blocks_x = w.div_ceil(4);
+        let blocks_y = h.div_ceil(4);
         blocks_x * blocks_y * block_size
     } else {
         w * h * block_size
@@ -242,6 +237,9 @@ fn read_u32(data: &[u8], offset: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// DDS_PIXELFORMAT alpha-pixels flag (test header construction only).
+    const DDPF_ALPHAPIXELS: u32 = 0x1;
 
     /// Build a minimal valid DDS header for testing.
     fn make_dds_header(width: u32, height: u32, mip_count: u32, fourcc: &[u8; 4]) -> Vec<u8> {

--- a/crates/renderer/src/vulkan/descriptors.rs
+++ b/crates/renderer/src/vulkan/descriptors.rs
@@ -25,6 +25,7 @@
 //!   and `image_barrier_transfer_dst_to_shader_read`) explicitly set
 //!   `VK_QUEUE_FAMILY_IGNORED` to match the long-standing
 //!   `texture::from_rgba` / `record_dds_upload` convention.
+//!
 //! Tightening barrier helpers to all-IGNORED is a separate change that
 //! needs RenderDoc validation; mixing styles here preserves byte-
 //! equivalence with the pre-#1046 inline code.

--- a/crates/renderer/src/vulkan/device.rs
+++ b/crates/renderer/src/vulkan/device.rs
@@ -95,7 +95,7 @@ pub struct DeviceCapabilities {
     /// debug-UI's "VRAM usage" line has to fall back to
     /// `gpu_allocator::generate_report` (which reports our own
     /// allocations, not the driver's view including swapchain images
-    /// + descriptor pools + every other Vulkan-internal residency
+    /// plus descriptor pools plus every other Vulkan-internal residency
     /// cost). Universally supported on shipped desktop drivers since
     /// 2018; the gate exists so device creation doesn't fail when a
     /// SoC / software rasteriser doesn't advertise it.

--- a/crates/renderer/src/vulkan/egui_pass.rs
+++ b/crates/renderer/src/vulkan/egui_pass.rs
@@ -30,6 +30,21 @@ use egui::{Context as EguiContext, FullOutput, TextureId};
 use egui_ash_renderer::{Options, Renderer};
 use gpu_allocator::vulkan::Allocator;
 
+/// The Vulkan handles [`EguiPass::dispatch`] records and uploads against.
+/// Groups `device`, the frame's command buffer, the graphics queue, and
+/// the one-shot upload command pool that travel together into dispatch.
+#[derive(Clone, Copy)]
+pub struct EguiDispatchCtx<'a> {
+    /// Logical device the overlay records against.
+    pub device: &'a ash::Device,
+    /// The current frame's command buffer (already recording).
+    pub cmd: vk::CommandBuffer,
+    /// Graphics queue used for the synchronous egui texture upload.
+    pub queue: vk::Queue,
+    /// Command pool the egui texture-upload one-shot buffer comes from.
+    pub upload_command_pool: vk::CommandPool,
+}
+
 /// Owns the egui-ash-renderer instance plus the render-pass +
 /// framebuffer chain that targets the swapchain.
 pub struct EguiPass {
@@ -126,14 +141,17 @@ impl EguiPass {
     /// no shapes when the overlay is hidden or contains no widgets.
     pub fn dispatch(
         &mut self,
-        device: &ash::Device,
-        cmd: vk::CommandBuffer,
-        queue: vk::Queue,
-        upload_command_pool: vk::CommandPool,
+        ctx: EguiDispatchCtx,
         swapchain_image_index: u32,
         egui_ctx: &EguiContext,
         output: FullOutput,
     ) -> Result<()> {
+        let EguiDispatchCtx {
+            device,
+            cmd,
+            queue,
+            upload_command_pool,
+        } = ctx;
         // 1. Process previous frame's deferred frees first — by now
         // the fence at the top of `draw_frame` has waited on the
         // previous frame's command buffer, so the textures aren't

--- a/crates/renderer/src/vulkan/gbuffer.rs
+++ b/crates/renderer/src/vulkan/gbuffer.rs
@@ -174,10 +174,8 @@ impl Attachment {
             unsafe { device.destroy_image(img, None) };
         }
         self.images.clear();
-        for alloc in self.allocations.drain(..) {
-            if let Some(a) = alloc {
-                allocator.lock().expect("allocator lock").free(a).ok();
-            }
+        for a in self.allocations.drain(..).flatten() {
+            allocator.lock().expect("allocator lock").free(a).ok();
         }
     }
 }
@@ -463,6 +461,12 @@ impl GBuffer {
     }
 
     /// Destroy all images, views, and allocations. Safe to call multiple times.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that none of the G-buffer images are still in
+    /// use by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         // SAFETY: forwarding the unsafe-fn contract — the caller of
         // `GBuffer::destroy` is responsible for ensuring no in-flight

--- a/crates/renderer/src/vulkan/gpu_timers.rs
+++ b/crates/renderer/src/vulkan/gpu_timers.rs
@@ -111,8 +111,8 @@ pub struct GpuTimerSnapshot {
     pub skin_blas_refit_ms: f32,
     pub taa_ms: f32,
     /// Wall-clock time for the main geometry render pass —
-    /// G-buffer fill + per-fragment RT loop (shadow rays + GI ray
-    /// + metal reflection + glass IOR). Expected dominant cost on
+    /// G-buffer fill + per-fragment RT loop (shadow rays, GI ray,
+    /// metal reflection, glass IOR). Expected dominant cost on
     /// interior cells with cluster-light count near `MAX_LIGHTS_PER_CLUSTER`.
     pub main_render_ms: f32,
     /// TLAS build / refit time. First-cell-load frames spike (full
@@ -443,7 +443,7 @@ impl GpuPerFrameTimers {
 
     /// Write the main-render-pass END timestamp. `BOTTOM_OF_PIPE`
     /// on end so the timestamp waits for the last fragment shader
-    /// + color-attachment write to retire (the actual cost the
+    /// and color-attachment write to retire (the actual cost the
     /// bracket is measuring).
     pub fn cmd_main_render_end(
         &mut self,

--- a/crates/renderer/src/vulkan/instance.rs
+++ b/crates/renderer/src/vulkan/instance.rs
@@ -6,10 +6,7 @@ use raw_window_handle::RawDisplayHandle;
 use std::ffi::{CStr, CString};
 
 /// Required validation layers (debug builds only).
-const VALIDATION_LAYERS: &[&CStr] = &[
-    // SAFETY: null-terminated literal
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"VK_LAYER_KHRONOS_validation\0") },
-];
+const VALIDATION_LAYERS: &[&CStr] = &[c"VK_LAYER_KHRONOS_validation"];
 
 /// Creates a Vulkan instance with the appropriate extensions for the given
 /// display handle, and validation layers in debug builds.

--- a/crates/renderer/src/vulkan/mod.rs
+++ b/crates/renderer/src/vulkan/mod.rs
@@ -29,3 +29,22 @@ pub mod texture;
 pub mod volumetrics;
 pub mod water;
 pub mod water_caustic;
+
+use allocator::SharedAllocator;
+
+/// Bundle of the four Vulkan handles every one-time GPU upload needs.
+///
+/// Groups `device`, `allocator`, `queue`, and `command_pool` — the handles
+/// that travel together through the texture/mesh upload helpers — so those
+/// helpers stay under the argument-count lint without changing behaviour.
+#[derive(Clone, Copy)]
+pub struct GpuUploadCtx<'a> {
+    /// Logical device the upload records against.
+    pub device: &'a ash::Device,
+    /// Shared GPU allocator backing staging + device-local buffers.
+    pub allocator: &'a SharedAllocator,
+    /// Queue the one-time command buffer is submitted on.
+    pub queue: &'a std::sync::Mutex<ash::vk::Queue>,
+    /// Command pool the one-time command buffer is allocated from.
+    pub command_pool: ash::vk::CommandPool,
+}

--- a/crates/renderer/src/vulkan/pipeline.rs
+++ b/crates/renderer/src/vulkan/pipeline.rs
@@ -15,7 +15,7 @@ pub const UI_FRAG_SPV: &[u8] = include_bytes!("../../shaders/ui.frag.spv");
 pub fn load_shader_module(device: &ash::Device, spv: &[u8]) -> Result<vk::ShaderModule> {
     // ash requires the data as &[u32]. SPIR-V is always 4-byte aligned.
     assert!(
-        spv.len() % 4 == 0,
+        spv.len().is_multiple_of(4),
         "SPIR-V binary size must be a multiple of 4"
     );
 
@@ -432,16 +432,36 @@ fn triangle_pipeline_inner(
 /// attachment (0) blends — G-buffer attachments (normal/motion/mesh_id/
 /// raw_indirect/albedo) overwrite, matching the behaviour the old
 /// `Alpha` / `Additive` static pipelines had.
+/// The shared Vulkan state a blend-pipeline build reuses from the opaque
+/// pipelines: device, render pass, extent, pipeline cache, and layout.
+/// Groups the handles that travel together into [`create_blend_pipeline`].
+#[derive(Clone, Copy)]
+pub struct BlendPipelineCtx<'a> {
+    /// Logical device the pipeline is created on.
+    pub device: &'a ash::Device,
+    /// Render pass the pipeline is compatible with.
+    pub render_pass: vk::RenderPass,
+    /// Viewport/scissor extent baked into the pipeline state.
+    pub extent: vk::Extent2D,
+    /// Pipeline cache the build draws from / writes to.
+    pub pipeline_cache: vk::PipelineCache,
+    /// Pipeline layout shared with the opaque pipelines.
+    pub pipeline_layout: vk::PipelineLayout,
+}
+
 pub fn create_blend_pipeline(
-    device: &ash::Device,
-    render_pass: vk::RenderPass,
-    extent: vk::Extent2D,
-    pipeline_cache: vk::PipelineCache,
-    pipeline_layout: vk::PipelineLayout,
+    ctx: BlendPipelineCtx,
     src: u8,
     dst: u8,
     wireframe: bool,
 ) -> Result<vk::Pipeline> {
+    let BlendPipelineCtx {
+        device,
+        render_pass,
+        extent,
+        pipeline_cache,
+        pipeline_layout,
+    } = ctx;
     let vert_module = load_shader_module(device, TRIANGLE_VERT_SPV)?;
     let frag_module = load_shader_module(device, TRIANGLE_FRAG_SPV)?;
 

--- a/crates/renderer/src/vulkan/reflect.rs
+++ b/crates/renderer/src/vulkan/reflect.rs
@@ -62,7 +62,7 @@ struct DecoInfo {
 /// declares. Non-descriptor `OpVariable`s (inputs, outputs, push constants,
 /// private workgroup data) are skipped.
 pub fn reflect_bindings(spirv_bytes: &[u8]) -> Result<Vec<ReflectedBinding>> {
-    if spirv_bytes.len() % 4 != 0 {
+    if !spirv_bytes.len().is_multiple_of(4) {
         bail!(
             "SPIR-V byte length {} is not a multiple of 4",
             spirv_bytes.len()
@@ -168,7 +168,7 @@ pub fn reflect_bindings(spirv_bytes: &[u8]) -> Result<Vec<ReflectedBinding>> {
 /// per-frame corruption with no validation-layer coverage. Asserting the
 /// block size against `size_of::<GpuStruct>()` catches exactly that drift.
 pub fn uniform_block_size_by_name(spirv_bytes: &[u8], name: &str) -> Result<Option<u32>> {
-    if spirv_bytes.len() % 4 != 0 {
+    if !spirv_bytes.len().is_multiple_of(4) {
         bail!(
             "SPIR-V byte length {} is not a multiple of 4",
             spirv_bytes.len()

--- a/crates/renderer/src/vulkan/scene_buffer/buffers.rs
+++ b/crates/renderer/src/vulkan/scene_buffer/buffers.rs
@@ -622,7 +622,7 @@ fn create_scene_descriptors(
     };
 
     // ── Write descriptors ─────────────────────────────────────────────────
-    for i in 0..MAX_FRAMES_IN_FLIGHT {
+    for (i, &set) in descriptor_sets.iter().enumerate() {
         let light_buf_info = [vk::DescriptorBufferInfo {
             buffer: bufs.light_buffers[i].buffer,
             offset: 0,
@@ -673,7 +673,6 @@ fn create_scene_descriptors(
             offset: 0,
             range: bufs.dalc_buf_size,
         }];
-        let set = descriptor_sets[i];
         let writes = [
             write_storage_buffer(set, 0, &light_buf_info),
             write_uniform_buffer(set, 1, &camera_buf_info),

--- a/crates/renderer/src/vulkan/scene_buffer/descriptors.rs
+++ b/crates/renderer/src/vulkan/scene_buffer/descriptors.rs
@@ -149,6 +149,13 @@ impl super::buffers::SceneBuffers {
     /// `.clear()` calls drop each `GpuBuffer` immediately so the
     /// allocator unwrap sees a smaller strong count by the time it
     /// runs.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that none of the scene buffers are still in
+    /// use by an in-flight command buffer. The buffers must not be used
+    /// after this call.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for buf in &mut self.light_buffers {
             buf.destroy(device, allocator);
@@ -216,7 +223,7 @@ impl super::buffers::SceneBuffers {
 pub(super) fn hash_material_slice(materials: &[super::super::material::GpuMaterial]) -> u64 {
     use std::hash::Hasher;
     let mut hasher = rustc_hash::FxHasher::default();
-    let byte_size = std::mem::size_of::<super::super::material::GpuMaterial>() * materials.len();
+    let byte_size = std::mem::size_of_val(materials);
     // SAFETY: `GpuMaterial` is `#[repr(C)]` with f32/u32 fields and
     // explicit padding fields the producer always initialises (see
     // `GpuMaterial::as_bytes` doc at vulkan/material.rs:281-294).
@@ -241,7 +248,7 @@ pub(super) fn hash_material_slice(materials: &[super::super::material::GpuMateri
 pub(super) fn hash_instance_slice(instances: &[super::gpu_types::GpuInstance]) -> u64 {
     use std::hash::Hasher;
     let mut hasher = rustc_hash::FxHasher::default();
-    let byte_size = std::mem::size_of::<super::gpu_types::GpuInstance>() * instances.len();
+    let byte_size = std::mem::size_of_val(instances);
     // SAFETY: see hash_material_slice — same invariant on the producer
     // side. The layout test pins the byte-size against a known constant
     // so an unintended padding insert would surface there first.

--- a/crates/renderer/src/vulkan/skin_compute.rs
+++ b/crates/renderer/src/vulkan/skin_compute.rs
@@ -198,13 +198,29 @@ pub fn skin_slot_capacity_stale(slot_vertex_count: u32, mesh_vertex_count: u32) 
 /// cached per-FIF on each [`SkinSlot`] via
 /// `SkinSlot::descriptor_bindings`. `dispatch` compares the live
 /// `(input, palette)` pair against the cached key for `frame_index`;
-/// on match it skips `vkUpdateDescriptorSets` entirely — bind + push
-/// + dispatch is the entire critical path in steady state. On
+/// on match it skips `vkUpdateDescriptorSets` entirely — bind, push,
+/// and dispatch are the entire critical path in steady state. On
 /// mismatch (cold first-dispatch per FIF or cell-transition global
 /// vertex SSBO rebuild) we emit all three writes and record the new
 /// key. See #1197 / PERF-DIM7-03; pre-fix the dispatch unconditionally
 /// emitted three writes per slot per frame, costing ~1-3 µs per
 /// invocation on NVIDIA regardless of writes-per-call.
+///
+/// The input-vertex SSBO and bone-palette buffer (plus their sizes) bound by
+/// [`SkinComputePipeline::dispatch`]. Groups the buffer/size pairs that travel
+/// together into the dispatch call.
+#[derive(Clone, Copy)]
+pub struct SkinDispatchBuffers {
+    /// Pre-skinning input vertex SSBO.
+    pub input_buffer: vk::Buffer,
+    /// Byte size of `input_buffer`.
+    pub input_buffer_size: vk::DeviceSize,
+    /// Per-frame bone palette buffer.
+    pub bone_buffer: vk::Buffer,
+    /// Byte size of `bone_buffer`.
+    pub bone_buffer_size: vk::DeviceSize,
+}
+
 pub struct SkinComputePipeline {
     pipeline: vk::Pipeline,
     pipeline_layout: vk::PipelineLayout,
@@ -506,12 +522,15 @@ impl SkinComputePipeline {
         cmd: vk::CommandBuffer,
         slot: &mut SkinSlot,
         frame_index: usize,
-        input_buffer: vk::Buffer,
-        input_buffer_size: vk::DeviceSize,
-        bone_buffer: vk::Buffer,
-        bone_buffer_size: vk::DeviceSize,
+        buffers: SkinDispatchBuffers,
         push: SkinPushConstants,
     ) {
+        let SkinDispatchBuffers {
+            input_buffer,
+            input_buffer_size,
+            bone_buffer,
+            bone_buffer_size,
+        } = buffers;
         let descriptor_set = slot.descriptor_sets[frame_index];
         // #1197 — only the (input, palette) pair varies across the
         // slot's lifetime. `output` is a function of the slot itself
@@ -601,6 +620,12 @@ impl SkinComputePipeline {
     /// sets from the pool; destroying the pool while sets are
     /// outstanding triggers a Vulkan validation error). The renderer
     /// pairs this with `device_wait_idle` in the Drop chain.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// and that no object owned by `self` (pipeline, layouts, descriptor pool,
+    /// or outstanding slots) is still in use by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device) {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);
@@ -642,6 +667,26 @@ const SKIN_PALETTE_PUSH_CONSTANTS_SIZE: u32 =
 /// warm-up. The per-frame fence at `draw_frame`'s top guarantees
 /// previous-frame use of `descriptor_sets[frame]` is complete before
 /// we rewrite, so no external sync is needed.
+///
+/// The three buffer/size pairs ([bone-world], [bind-inverse], [palette]) bound
+/// by [`SkinPaletteComputePipeline::dispatch`]. Groups the buffer arguments
+/// that travel together into the dispatch call.
+#[derive(Clone, Copy)]
+pub struct PaletteDispatchBuffers {
+    /// Per-frame bone world-transform buffer.
+    pub bone_world_buffer: vk::Buffer,
+    /// Byte size of `bone_world_buffer`.
+    pub bone_world_buffer_size: vk::DeviceSize,
+    /// Bind-pose inverse-bind-matrix buffer.
+    pub bind_inverse_buffer: vk::Buffer,
+    /// Byte size of `bind_inverse_buffer`.
+    pub bind_inverse_buffer_size: vk::DeviceSize,
+    /// Output bone-palette buffer.
+    pub palette_buffer: vk::Buffer,
+    /// Byte size of `palette_buffer`.
+    pub palette_buffer_size: vk::DeviceSize,
+}
+
 pub struct SkinPaletteComputePipeline {
     pipeline: vk::Pipeline,
     pipeline_layout: vk::PipelineLayout,
@@ -825,14 +870,17 @@ impl SkinPaletteComputePipeline {
         device: &ash::Device,
         cmd: vk::CommandBuffer,
         frame_index: usize,
-        bone_world_buffer: vk::Buffer,
-        bone_world_buffer_size: vk::DeviceSize,
-        bind_inverse_buffer: vk::Buffer,
-        bind_inverse_buffer_size: vk::DeviceSize,
-        palette_buffer: vk::Buffer,
-        palette_buffer_size: vk::DeviceSize,
+        buffers: PaletteDispatchBuffers,
         push: SkinPalettePushConstants,
     ) {
+        let PaletteDispatchBuffers {
+            bone_world_buffer,
+            bone_world_buffer_size,
+            bind_inverse_buffer,
+            bind_inverse_buffer_size,
+            palette_buffer,
+            palette_buffer_size,
+        } = buffers;
         let descriptor_set = self.descriptor_sets[frame_index];
         // #1197 — compare against cached binding triple. Steady-state
         // hits this cache every frame post-warm-up because all three
@@ -916,6 +964,12 @@ impl SkinPaletteComputePipeline {
     /// descriptor sets themselves are freed implicitly by destroying
     /// the pool (no FREE_DESCRIPTOR_SET flag here — there are no
     /// per-slot allocations to free individually).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// and that no object owned by `self` is still in use by an in-flight
+    /// command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device) {
         device.destroy_pipeline(self.pipeline, None);
         device.destroy_pipeline_layout(self.pipeline_layout, None);

--- a/crates/renderer/src/vulkan/ssao.rs
+++ b/crates/renderer/src/vulkan/ssao.rs
@@ -429,6 +429,13 @@ impl SsaoPipeline {
     /// SHADER_READ_ONLY_OPTIMAL and clear them to white (1.0 = no occlusion).
     /// Must be called once after creation so the fragment shader sees a valid
     /// image on the first frame (before the first SSAO dispatch has run).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the AO images are not concurrently accessed by another
+    /// command buffer.
     pub unsafe fn initialize_ao_images(
         &self,
         device: &ash::Device,
@@ -502,6 +509,13 @@ impl SsaoPipeline {
     /// must be written and transitioned to READ_ONLY). The AO output image
     /// is written in GENERAL layout, transitioned to SHADER_READ_ONLY, and
     /// sampled by this frame's fragment shader.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the depth/AO images and bound buffers are not in use by
+    /// another in-flight command buffer.
     pub unsafe fn dispatch(
         &mut self,
         device: &ash::Device,
@@ -575,8 +589,8 @@ impl SsaoPipeline {
             &[],
         );
 
-        let groups_x = (self.width + 7) / 8;
-        let groups_y = (self.height + 7) / 8;
+        let groups_x = self.width.div_ceil(8);
+        let groups_y = self.height.div_ceil(8);
         device.cmd_dispatch(cmd, groups_x, groups_y, 1);
 
         // Transition AO image to SHADER_READ_ONLY for fragment shader sampling.
@@ -600,6 +614,13 @@ impl SsaoPipeline {
         Ok(())
     }
 
+    /// Destroy all SSAO images, views, and allocations.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that none of the SSAO resources are still in
+    /// use by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for &view in &self.ao_image_views {
             device.destroy_image_view(view, None);
@@ -609,10 +630,8 @@ impl SsaoPipeline {
             device.destroy_image(img, None);
         }
         self.ao_images.clear();
-        for alloc in self.ao_allocations.drain(..) {
-            if let Some(a) = alloc {
-                allocator.lock().expect("allocator lock").free(a).ok();
-            }
+        for a in self.ao_allocations.drain(..).flatten() {
+            allocator.lock().expect("allocator lock").free(a).ok();
         }
         for buf in &mut self.param_buffers {
             buf.destroy(device, allocator);

--- a/crates/renderer/src/vulkan/svgf.rs
+++ b/crates/renderer/src/vulkan/svgf.rs
@@ -53,6 +53,7 @@
 
 use super::allocator::SharedAllocator;
 use super::buffer::GpuBuffer;
+use super::GpuUploadCtx;
 use super::descriptors::{
     image_barrier_undef_to_general, write_combined_image_sampler, write_storage_image,
     write_uniform_buffer, DescriptorPoolBuilder,
@@ -240,34 +241,37 @@ pub struct SvgfPipeline {
     dispatched_this_frame: [bool; MAX_FRAMES_IN_FLIGHT],
 }
 
+/// The four per-frame G-buffer view slices SVGF samples — raw indirect,
+/// motion, mesh-ID, and normal (each of length `MAX_FRAMES_IN_FLIGHT`).
+/// Groups the view arguments that travel together into the SVGF
+/// constructor and resize path.
+#[derive(Clone, Copy)]
+pub struct SvgfInputViews<'a> {
+    /// Raw indirect-lighting views (the denoiser input).
+    pub raw_indirect_views: &'a [vk::ImageView],
+    /// Motion-vector views (reprojection).
+    pub motion_views: &'a [vk::ImageView],
+    /// Mesh-ID views (disocclusion test).
+    pub mesh_id_views: &'a [vk::ImageView],
+    /// Normal views (edge-stopping weight).
+    pub normal_views: &'a [vk::ImageView],
+}
+
 impl SvgfPipeline {
     pub fn new(
         device: &ash::Device,
         allocator: &SharedAllocator,
         pipeline_cache: vk::PipelineCache,
-        raw_indirect_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
-        normal_views: &[vk::ImageView],
+        views: SvgfInputViews,
         width: u32,
         height: u32,
     ) -> Result<Self> {
-        debug_assert_eq!(raw_indirect_views.len(), MAX_FRAMES_IN_FLIGHT);
-        debug_assert_eq!(motion_views.len(), MAX_FRAMES_IN_FLIGHT);
-        debug_assert_eq!(mesh_id_views.len(), MAX_FRAMES_IN_FLIGHT);
-        debug_assert_eq!(normal_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.raw_indirect_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.motion_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.mesh_id_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.normal_views.len(), MAX_FRAMES_IN_FLIGHT);
 
-        let result = Self::new_inner(
-            device,
-            allocator,
-            pipeline_cache,
-            raw_indirect_views,
-            motion_views,
-            mesh_id_views,
-            normal_views,
-            width,
-            height,
-        );
+        let result = Self::new_inner(device, allocator, pipeline_cache, views, width, height);
         if let Err(ref e) = result {
             log::debug!("SVGF pipeline creation failed at: {e}");
         }
@@ -278,13 +282,16 @@ impl SvgfPipeline {
         device: &ash::Device,
         allocator: &SharedAllocator,
         pipeline_cache: vk::PipelineCache,
-        raw_indirect_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
-        normal_views: &[vk::ImageView],
+        views: SvgfInputViews,
         width: u32,
         height: u32,
     ) -> Result<Self> {
+        let SvgfInputViews {
+            raw_indirect_views,
+            motion_views,
+            mesh_id_views,
+            normal_views,
+        } = views;
         let mut partial = Self {
             pipeline: vk::Pipeline::null(),
             pipeline_layout: vk::PipelineLayout::null(),
@@ -734,6 +741,13 @@ impl SvgfPipeline {
     /// One-time layout transition UNDEFINED → GENERAL for every history
     /// image, so the first dispatch and first descriptor sampling see a
     /// valid layout. Call once after `new()`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the history images are not concurrently accessed by another
+    /// command buffer.
     pub unsafe fn initialize_layouts(
         &self,
         device: &ash::Device,
@@ -778,6 +792,12 @@ impl SvgfPipeline {
     /// uniform-read execution dependency for this UBO so [`Self::dispatch`]
     /// no longer needs to emit its own. Mirrors the composite-UBO fold
     /// landed in #909 / REN-D1-NEW-03. See #961 / REN-D10-NEW-04.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// the target frame's params UBO is not in use by an in-flight command
+    /// buffer, and `frame` is < `MAX_FRAMES_IN_FLIGHT`.
     pub unsafe fn upload_params(
         &mut self,
         device: &ash::Device,
@@ -827,6 +847,13 @@ impl SvgfPipeline {
     /// that barrier covers the UBO host-write → uniform-read execution
     /// dependency so this method no longer emits its own (#961 /
     /// REN-D10-NEW-04, mirror of #909 / REN-D1-NEW-03).
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the history images and bound buffers are not in use by
+    /// another in-flight command buffer.
     pub unsafe fn dispatch(
         &mut self,
         device: &ash::Device,
@@ -887,8 +914,8 @@ impl SvgfPipeline {
             &[],
         );
 
-        let gx = (self.width + 7) / 8;
-        let gy = (self.height + 7) / 8;
+        let gx = self.width.div_ceil(8);
+        let gy = self.height.div_ceil(8);
         device.cmd_dispatch(cmd, gx, gy, 1);
 
         // Barrier: compute write → composite's fragment shader sampling.
@@ -964,17 +991,23 @@ impl SvgfPipeline {
     /// error on the first post-resize frame.
     pub fn recreate_on_resize(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
-        raw_indirect_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
-        normal_views: &[vk::ImageView],
+        ctx: GpuUploadCtx,
+        views: SvgfInputViews,
         width: u32,
         height: u32,
     ) -> Result<()> {
+        let GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        } = ctx;
+        let SvgfInputViews {
+            raw_indirect_views,
+            motion_views,
+            mesh_id_views,
+            normal_views,
+        } = views;
         for mut slot in self.indirect_history.drain(..) {
             // SAFETY: `recreate_on_resize` runs from the fenced
             // swapchain-resize path (`VulkanContext::recreate_swapchain`
@@ -1060,6 +1093,13 @@ impl SvgfPipeline {
         Ok(())
     }
 
+    /// Destroy all SVGF images, views, buffers, and pipeline objects.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that no object owned by `self` is still in use
+    /// by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         // SAFETY (whole function): caller of `destroy` (unsafe fn)
         // guarantees no in-flight command buffer references any object

--- a/crates/renderer/src/vulkan/swapchain.rs
+++ b/crates/renderer/src/vulkan/swapchain.rs
@@ -18,16 +18,36 @@ pub struct SwapchainState {
 /// `old_swapchain`: pass the previous swapchain handle for atomic handoff
 /// during recreation (avoids flicker on some platforms). Pass `null()` for
 /// initial creation.
+/// The instance/device/surface handles a swapchain build queries against.
+/// Groups the five Vulkan handles that travel together into
+/// [`create_swapchain`].
+#[derive(Clone, Copy)]
+pub struct SwapchainSurfaceCtx<'a> {
+    /// Vulkan instance.
+    pub instance: &'a ash::Instance,
+    /// Logical device the swapchain is created on.
+    pub device: &'a ash::Device,
+    /// Physical device the surface capabilities are queried from.
+    pub physical_device: vk::PhysicalDevice,
+    /// Surface extension loader.
+    pub surface_loader: &'a ash::khr::surface::Instance,
+    /// The window surface the swapchain presents to.
+    pub surface: vk::SurfaceKHR,
+}
+
 pub fn create_swapchain(
-    instance: &ash::Instance,
-    device: &ash::Device,
-    physical_device: vk::PhysicalDevice,
-    surface_loader: &ash::khr::surface::Instance,
-    surface: vk::SurfaceKHR,
+    ctx: SwapchainSurfaceCtx,
     indices: QueueFamilyIndices,
     window_size: [u32; 2],
     old_swapchain: vk::SwapchainKHR,
 ) -> Result<SwapchainState> {
+    let SwapchainSurfaceCtx {
+        instance,
+        device,
+        physical_device,
+        surface_loader,
+        surface,
+    } = ctx;
     let capabilities = unsafe {
         surface_loader
             .get_physical_device_surface_capabilities(physical_device, surface)
@@ -231,6 +251,12 @@ impl SwapchainState {
     /// destroy calls so a hypothetical second `destroy` (e.g. a future
     /// panic-cleanup path) is a no-op against `VK_NULL_HANDLE` rather
     /// than a double-free of every view + the swapchain itself.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// and that none of the swapchain images or views are still in use by an
+    /// in-flight command buffer or pending present.
     pub unsafe fn destroy(&mut self, device: &ash::Device) {
         for &view in &self.image_views {
             device.destroy_image_view(view, None);

--- a/crates/renderer/src/vulkan/sync.rs
+++ b/crates/renderer/src/vulkan/sync.rs
@@ -189,6 +189,12 @@ impl FrameSync {
     /// them, and it sidesteps the missing `vkSignalFence` API. Cost
     /// is two `vkDestroyFence` + two `vkCreateFence` per resize —
     /// negligible.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// and that the existing semaphores/fences being recreated are not in use
+    /// by any in-flight command buffer or pending present.
     pub unsafe fn recreate_for_swapchain(
         &mut self,
         device: &ash::Device,
@@ -322,6 +328,13 @@ impl FrameSync {
         Ok(())
     }
 
+    /// Destroy all semaphores and fences.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` is valid and live, the device is not lost,
+    /// and that none of the semaphores or fences are still in use by an
+    /// in-flight command buffer or pending present.
     pub unsafe fn destroy(&self, device: &ash::Device) {
         for &sem in &self.image_available {
             device.destroy_semaphore(sem, None);

--- a/crates/renderer/src/vulkan/taa.rs
+++ b/crates/renderer/src/vulkan/taa.rs
@@ -30,6 +30,7 @@
 
 use super::allocator::SharedAllocator;
 use super::buffer::GpuBuffer;
+use super::GpuUploadCtx;
 use super::descriptors::{
     image_barrier_undef_to_general, write_combined_image_sampler, write_storage_image,
     write_uniform_buffer, DescriptorPoolBuilder,
@@ -142,31 +143,34 @@ pub struct TaaPipeline {
     dispatched_this_frame: bool,
 }
 
+/// The three per-frame G-buffer view slices TAA samples — HDR color,
+/// motion, and mesh-ID (each of length `MAX_FRAMES_IN_FLIGHT`). Groups the
+/// view arguments that travel together into the TAA constructor and resize
+/// path.
+#[derive(Clone, Copy)]
+pub struct TaaInputViews<'a> {
+    /// HDR color views (the TAA resolve input).
+    pub hdr_views: &'a [vk::ImageView],
+    /// Motion-vector views (reprojection).
+    pub motion_views: &'a [vk::ImageView],
+    /// Mesh-ID views (disocclusion test).
+    pub mesh_id_views: &'a [vk::ImageView],
+}
+
 impl TaaPipeline {
     pub fn new(
         device: &ash::Device,
         allocator: &SharedAllocator,
         pipeline_cache: vk::PipelineCache,
-        hdr_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
+        views: TaaInputViews,
         width: u32,
         height: u32,
     ) -> Result<Self> {
-        debug_assert_eq!(hdr_views.len(), MAX_FRAMES_IN_FLIGHT);
-        debug_assert_eq!(motion_views.len(), MAX_FRAMES_IN_FLIGHT);
-        debug_assert_eq!(mesh_id_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.hdr_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.motion_views.len(), MAX_FRAMES_IN_FLIGHT);
+        debug_assert_eq!(views.mesh_id_views.len(), MAX_FRAMES_IN_FLIGHT);
 
-        let result = Self::new_inner(
-            device,
-            allocator,
-            pipeline_cache,
-            hdr_views,
-            motion_views,
-            mesh_id_views,
-            width,
-            height,
-        );
+        let result = Self::new_inner(device, allocator, pipeline_cache, views, width, height);
         if let Err(ref e) = result {
             log::debug!("TAA pipeline creation failed at: {e}");
         }
@@ -177,12 +181,15 @@ impl TaaPipeline {
         device: &ash::Device,
         allocator: &SharedAllocator,
         pipeline_cache: vk::PipelineCache,
-        hdr_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
+        views: TaaInputViews,
         width: u32,
         height: u32,
     ) -> Result<Self> {
+        let TaaInputViews {
+            hdr_views,
+            motion_views,
+            mesh_id_views,
+        } = views;
         let mut partial = Self {
             pipeline: vk::Pipeline::null(),
             pipeline_layout: vk::PipelineLayout::null(),
@@ -721,8 +728,8 @@ impl TaaPipeline {
             &[],
         );
 
-        let gx = (self.width + 7) / 8;
-        let gy = (self.height + 7) / 8;
+        let gx = self.width.div_ceil(8);
+        let gy = self.height.div_ceil(8);
         device.cmd_dispatch(cmd, gx, gy, 1);
 
         // Expose the result to composite's fragment shader read.
@@ -778,16 +785,22 @@ impl TaaPipeline {
     /// (VUID-vkCmdDispatch-None-04115).
     pub fn recreate_on_resize(
         &mut self,
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
-        hdr_views: &[vk::ImageView],
-        motion_views: &[vk::ImageView],
-        mesh_id_views: &[vk::ImageView],
+        ctx: GpuUploadCtx,
+        views: TaaInputViews,
         width: u32,
         height: u32,
     ) -> Result<()> {
+        let GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        } = ctx;
+        let TaaInputViews {
+            hdr_views,
+            motion_views,
+            mesh_id_views,
+        } = views;
         for slot in self.history.drain(..) {
             // SAFETY: `recreate_on_resize` is called from the swapchain-
             // resize path which fences both frames-in-flight first

--- a/crates/renderer/src/vulkan/texture.rs
+++ b/crates/renderer/src/vulkan/texture.rs
@@ -2,6 +2,7 @@
 
 use super::allocator::SharedAllocator;
 use super::buffer::{StagingGuard, StagingPool};
+use super::GpuUploadCtx;
 use super::descriptors::{
     color_subresource_mips, image_barrier_transfer_dst_to_shader_read,
     image_barrier_undef_to_transfer_dst,
@@ -50,10 +51,7 @@ impl Texture {
     /// authored mip chain because `from_rgba` hard-coded `mip_levels(1)`
     /// where `from_dds_with_mip_chain` would have respected the chain).
     pub fn from_rgba(
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         width: u32,
         height: u32,
         pixels: &[u8],
@@ -74,16 +72,7 @@ impl Texture {
             compressed: false,
             data_offset: 0, // unused: caller passes the pixel slice directly
         };
-        let texture = Self::from_dds_with_mip_chain(
-            device,
-            allocator,
-            queue,
-            command_pool,
-            &meta,
-            pixels,
-            sampler,
-            staging_pool,
-        )?;
+        let texture = Self::from_dds_with_mip_chain(ctx, &meta, pixels, sampler, staging_pool)?;
         log::debug!("Texture uploaded: {}x{} RGBA", width, height);
         Ok(texture)
     }
@@ -102,15 +91,18 @@ impl Texture {
     /// then aliased visibly under minification because the sampler
     /// could only ever read mip 0.
     pub fn from_dds_with_mip_chain(
-        device: &ash::Device,
-        allocator: &SharedAllocator,
-        queue: &std::sync::Mutex<vk::Queue>,
-        command_pool: vk::CommandPool,
+        ctx: GpuUploadCtx,
         meta: &super::dds::DdsMetadata,
         pixel_data: &[u8],
         sampler: vk::Sampler,
         mut staging_pool: Option<&mut StagingPool>,
     ) -> Result<Self> {
+        let GpuUploadCtx {
+            device,
+            allocator,
+            queue,
+            command_pool,
+        } = ctx;
         // Self-contained wrapper around [`Self::record_dds_upload`].
         // Records the upload into a one-time command buffer, submits +
         // fence-waits ONCE, then releases the staging buffer. Used by
@@ -189,7 +181,7 @@ impl Texture {
         meta: &super::dds::DdsMetadata,
         pixel_data: &[u8],
         sampler: vk::Sampler,
-        mut staging_pool: Option<&mut StagingPool>,
+        staging_pool: Option<&mut StagingPool>,
     ) -> Result<(Self, StagingGuard, vk::DeviceSize)> {
         use super::dds;
 
@@ -208,7 +200,7 @@ impl Texture {
         let image_size = total_size as vk::DeviceSize;
 
         // 1. Staging buffer — from pool (reuse) or fresh. See #239.
-        let (staging_buffer, mut staging_alloc) = if let Some(pool) = staging_pool.as_deref_mut() {
+        let (staging_buffer, mut staging_alloc) = if let Some(pool) = staging_pool {
             pool.acquire(image_size)?
         } else {
             let staging_buffer_info = vk::BufferCreateInfo::default()
@@ -433,10 +425,12 @@ impl Texture {
         let pixel_data = &dds_bytes[meta.data_offset..];
 
         Self::from_dds_with_mip_chain(
-            device,
-            allocator,
-            queue,
-            command_pool,
+            GpuUploadCtx {
+                device,
+                allocator,
+                queue,
+                command_pool,
+            },
             &meta,
             pixel_data,
             sampler,
@@ -685,7 +679,7 @@ pub fn generate_checkerboard(width: u32, height: u32, cell_size: u32) -> Vec<u8>
     let mut pixels = Vec::with_capacity((width * height * 4) as usize);
     for y in 0..height {
         for x in 0..width {
-            let checker = ((x / cell_size) + (y / cell_size)) % 2 == 0;
+            let checker = ((x / cell_size) + (y / cell_size)).is_multiple_of(2);
             let (r, g, b) = if checker {
                 (220u8, 220, 220)
             } else {

--- a/crates/renderer/src/vulkan/volumetrics.rs
+++ b/crates/renderer/src/vulkan/volumetrics.rs
@@ -681,6 +681,13 @@ impl VolumetricsPipeline {
     /// makes the composite formula `final = scene * vol.a + vol.rgb`
     /// collapse the scene to black on the first frame volumetrics is
     /// enabled (#1082). Call once after `new()`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the froxel images are not concurrently accessed by another
+    /// command buffer.
     pub unsafe fn initialize_layouts(
         &self,
         device: &ash::Device,
@@ -777,6 +784,13 @@ impl VolumetricsPipeline {
     /// SVGF have already scheduled their reads against the G-buffer)
     /// and BEFORE composite (so the integrated volume is ready to
     /// sample). Natural slot: between caustic and TAA in `draw.rs`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all passed Vulkan handles (`device`, `cmd`) are
+    /// valid and live, `cmd` is in the recording state, the device is not
+    /// lost, and the froxel images and bound buffers are not in use by
+    /// another in-flight command buffer.
     pub unsafe fn dispatch(
         &mut self,
         device: &ash::Device,
@@ -847,9 +861,9 @@ impl VolumetricsPipeline {
             &[self.descriptor_sets[frame]],
             &[],
         );
-        let inj_groups_x = (FROXEL_WIDTH + WORKGROUP_X - 1) / WORKGROUP_X;
-        let inj_groups_y = (FROXEL_HEIGHT + WORKGROUP_Y - 1) / WORKGROUP_Y;
-        let inj_groups_z = (FROXEL_DEPTH + WORKGROUP_Z - 1) / WORKGROUP_Z;
+        let inj_groups_x = FROXEL_WIDTH.div_ceil(WORKGROUP_X);
+        let inj_groups_y = FROXEL_HEIGHT.div_ceil(WORKGROUP_Y);
+        let inj_groups_z = FROXEL_DEPTH.div_ceil(WORKGROUP_Z);
         device.cmd_dispatch(cmd, inj_groups_x, inj_groups_y, inj_groups_z);
 
         // ── Stage D: barrier between injection and integration ──────
@@ -901,8 +915,8 @@ impl VolumetricsPipeline {
         );
         // 2D dispatch: one thread per (x, y) column; each thread Z-marches
         // all FROXEL_DEPTH slices internally.
-        let int_groups_x = (FROXEL_WIDTH + WORKGROUP_X - 1) / WORKGROUP_X;
-        let int_groups_y = (FROXEL_HEIGHT + WORKGROUP_Y - 1) / WORKGROUP_Y;
+        let int_groups_x = FROXEL_WIDTH.div_ceil(WORKGROUP_X);
+        let int_groups_y = FROXEL_HEIGHT.div_ceil(WORKGROUP_Y);
         device.cmd_dispatch(cmd, int_groups_x, int_groups_y, 1);
 
         // ── Stage F: post-integration barrier ────────────────────────
@@ -965,6 +979,13 @@ impl VolumetricsPipeline {
         self.tlas_written[frame] = true;
     }
 
+    /// Destroy all froxel images, views, buffers, and pipeline objects.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `device` and `allocator` are valid and live, the
+    /// device is not lost, and that no object owned by `self` is still in use
+    /// by an in-flight command buffer.
     pub unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for slot in self
             .lighting_volumes

--- a/crates/scripting/src/translate/archetype.rs
+++ b/crates/scripting/src/translate/archetype.rs
@@ -47,16 +47,21 @@ pub struct RecognizeCtx<'a> {
     pub owning_quest: Option<u32>,
 }
 
+/// Boxed component-insertion closure captured by a recognizer. Boxed
+/// (not a bare `fn` like [`crate::ScriptSpawnFn`]) because recognizers
+/// capture the constants they extracted. Aliased to satisfy
+/// `clippy::type_complexity`.
+pub type SpawnFn = Box<dyn Fn(&mut World, EntityId) + Send + Sync>;
+
 /// The output of a successful recognition: a name (for diagnostics) and a
 /// closure that inserts the canonical component(s) onto the script-bearing
-/// entity. A boxed closure (not a bare `fn` like [`crate::ScriptSpawnFn`])
-/// because recognizers capture the constants they extracted.
+/// entity.
 pub struct Recognized {
     /// `archetype@editor_id`, surfaced in logs + the `script.*` console.
     pub archetype: String,
     /// Inserts the canonical components onto `entity`. Called once at
     /// REFR spawn / script attach.
-    pub spawn: Box<dyn Fn(&mut World, EntityId) + Send + Sync>,
+    pub spawn: SpawnFn,
 }
 
 impl Recognized {

--- a/crates/scripting/src/translate/recognizers/quest_stage_gate.rs
+++ b/crates/scripting/src/translate/recognizers/quest_stage_gate.rs
@@ -224,7 +224,7 @@ fn method_call<'a>(
     let Expr::MemberAccess { object, member } = &callee.node else {
         return None;
     };
-    member.node.eq_ignore_case(method).then(|| (&object.node, args.as_slice()))
+    member.node.eq_ignore_case(method).then_some((&object.node, args.as_slice()))
 }
 
 /// The integer value of positional argument `idx`.

--- a/crates/spt/src/stream.rs
+++ b/crates/spt/src/stream.rs
@@ -33,6 +33,11 @@ impl<'a> SptStream<'a> {
         self.bytes.len()
     }
 
+    /// Whether the underlying byte buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
     /// Number of bytes left to read.
     pub fn remaining(&self) -> usize {
         self.bytes.len().saturating_sub(self.pos)

--- a/crates/spt/src/tag.rs
+++ b/crates/spt/src/tag.rs
@@ -37,6 +37,7 @@ pub enum SptTagKind {
     /// (per `spt_transitions` histogram analysis):
     /// - `10002` ships an `(u32 N + N bytes)` blob (stride 1).
     /// - `10003` ships an `(u32 N + N × 8 bytes)` blob (stride 8).
+    ///
     /// Stride is per-tag, encoded in the dispatch.
     ArrayBytes { stride: u8 },
     /// Tag is recognised but its layout is non-uniform or under


### PR DESCRIPTION
…D warnings`

CI's `cargo clippy --workspace -- -D warnings` was failing on pre-existing lint debt that a newer clippy (1.96) surfaces as hard errors. Clippy only analyzes a crate once its deps compile, so fixing the leaf crates cascaded the count up to ~150 findings across core, debug-protocol, bsa, papyrus, physics, debug-server, plugin, scripting, debug-ui, spt, renderer, nif, and the byroredux bin.

Every finding is fixed PROPERLY — no `#[allow]` attributes, no behavior changes, no shader edits. By category:

- missing_safety_doc: `# Safety` sections on the renderer's unsafe ash/Vulkan wrappers documenting the handle-validity / external-sync contract.
- too_many_arguments: related args grouped into small params structs (GpuUploadCtx, FrameInputs, GBufferFormats/Views, terrain/transition/ debug-load request structs, NIF walk contexts, …); call sites updated, including the byroredux-bin sites for the renderer's changed pub signatures.
- doc_lazy_continuation / doc_overindented: doc-comment reflow — blank-line paragraph separators, fixed indentation, and rephrasing lines that began with a `+`/`-`/`*` CommonMark list marker.
- type_complexity: `type` aliases for boxed-closure and tuple types (ComponentDescriptor accessors, ScriptHeader, SpawnFn, SkyrimShaderBase, …).
- large_enum_variant: boxed ScriptItem::Property and BSGeometryMeshKind::Internal.
- plus needless_range_loop, manual_clamp, manual_checked_ops, unnecessary_sort_by, needless_borrow(s), redundant_guards, ptr_arg, len_without_is_empty, new_without_default, derivable_impls, field_reassign_with_default, if_same_then_else, wildcard_in_or_patterns, unnecessary_get_then_check, should_implement_trait (RecordType::from_str → from_4cc), and a few more.

Verified: `cargo clippy --workspace -- -D warnings` exits 0, `cargo build --workspace` clean, full `cargo test --workspace` green (2819 passed, 0 failed).