### PR TITLE
fix(fo4): derive BGSM metalness from spec chromaticity, not luminance

### DIFF
--- a/byroredux/src/asset_provider.rs
+++ b/byroredux/src/asset_provider.rs
@@ -1097,23 +1097,43 @@ pub(crate) fn merge_bgsm_into_mesh(
         //
         // The renderer consumes a single PBR contract: `albedo`,
         // `metalness`, `roughness`, `F0 = mix(0.04, albedo, metalness)`.
-        // BGSM authors a DIFFERENT contract: `specular_color * mult`
-        // IS F0 directly (dielectric ≈ 0.04, conductor ≈ albedo-tinted).
-        // Bethesda's runtime translates this internally; we do the same
-        // translation HERE, in the merge layer, so the renderer never
-        // needs to know which game's format a material came from. See
-        // `feedback_format_translation.md`.
+        // BGSM authors a DIFFERENT contract; how `specular_color * mult`
+        // relates to metalness depends on the BGSM's `pbr` flag:
         //
-        // Translation derivation (LEAF BGSM only — template chain
-        // resolution for spec-color is intentionally child-only since
-        // the leaf author's choice is the authoritative one; parents
-        // are background defaults the artist explicitly overrode if
-        // they set a different value):
-        //   * leaf_spec_lum = luminance(spec_color * mult)
-        //   * metalness = saturate((leaf_spec_lum - 0.04) / 0.96)
-        //     — 0 for dielectric (F0 ≈ 0.04), ~1 for conductor (F0 ≈ 0.95)
-        //   * roughness = clamp(1 - smoothness, 0.04, 1.0)
-        //     — direct authoring; no glossiness round-trip.
+        // * `pbr == true` (rare — 0 of 793 sampled vanilla FO4 BGSMs set
+        //   it; almost exclusively modded content): the material was
+        //   authored in a metallic-roughness workflow and `spec_color *
+        //   mult` IS F0 directly (dielectric ≈ 0.04, conductor ≈ tinted).
+        //   Luminance → metalness is correct here.
+        //
+        // * `pbr == false` (legacy spec-glossiness — essentially all
+        //   vanilla FO4 architecture/clutter): `spec_color` is the Blinn
+        //   highlight TINT, not F0. It is ~white `[1,1,1]` for every
+        //   dielectric (concrete, wood, plaster, painted metal) and the
+        //   `mult` only scales highlight strength. Keying metalness off
+        //   luminance is not just wrong but BACKWARDS: vanilla
+        //   `paintpeelingconcrete` authors `spec=[1,1,1] mult=1.0`
+        //   (lum 1.0 → metalness 1.0, mirror-chrome concrete) while real
+        //   metals author LOWER, often TINTED spec — `metalrubberductpipe`
+        //   `[1,1,1] mult=0.73`, `metallocker` `[1,0.85,0.70] mult=0.45`.
+        //   The only legacy signal that actually distinguishes a conductor
+        //   is spec CHROMATICITY (conductor F0 is tinted; dielectric F0 is
+        //   achromatic grey), so we derive metalness from spec-color
+        //   saturation, which is invariant to `mult`. White spec → 0
+        //   (concrete is dielectric); tinted spec → metallic (brass/gold/
+        //   copper keep their look). Pure-white-spec steel reads dielectric
+        //   — a minor under-read, but never the pervasive chrome the old
+        //   luminance path produced. (Per-texel metalness from the spec
+        //   map would recover white-spec steel; deferred — needs a
+        //   metalness-map shader binding. See `feedback_format_translation`.)
+        //
+        // Roughness is `1 - smoothness` either way (the per-texel
+        // `gloss_map` then modulates it in-shader: `mix(1, roughness,
+        // glossSample)`), so the scalar is only the smooth-end of the lobe.
+        //
+        // Derivation is LEAF-only — the leaf author's choice is
+        // authoritative; template parents are background defaults the
+        // artist explicitly overrode if they set a different value.
         //
         // For metallic materials, also tint `mesh.diffuse_color` toward
         // the authored spec_color so the per-pixel `F0 = mix(0.04,
@@ -1126,8 +1146,27 @@ pub(crate) fn merge_bgsm_into_mesh(
         let spec_r = leaf.specular_color[0] * leaf.specular_mult;
         let spec_g = leaf.specular_color[1] * leaf.specular_mult;
         let spec_b = leaf.specular_color[2] * leaf.specular_mult;
-        let spec_lum = 0.2126 * spec_r + 0.7152 * spec_g + 0.0722 * spec_b;
-        let metalness = ((spec_lum - 0.04) / 0.96).clamp(0.0, 1.0);
+        let metalness = if leaf.pbr {
+            // True metallic-roughness authoring: spec*mult is F0.
+            let spec_lum = 0.2126 * spec_r + 0.7152 * spec_g + 0.0722 * spec_b;
+            ((spec_lum - 0.04) / 0.96).clamp(0.0, 1.0)
+        } else {
+            // Legacy spec-glossiness: only chromatic specular is a
+            // conductor. Saturation = (max-min)/max of spec_color is
+            // mult-invariant, so highlight strength doesn't leak into
+            // metalness — achromatic `[1,1,1]` concrete → 0.
+            let mx = leaf.specular_color[0]
+                .max(leaf.specular_color[1])
+                .max(leaf.specular_color[2]);
+            let mn = leaf.specular_color[0]
+                .min(leaf.specular_color[1])
+                .min(leaf.specular_color[2]);
+            if mx > 1.0e-4 {
+                ((mx - mn) / mx).clamp(0.0, 1.0)
+            } else {
+                0.0
+            }
+        };
         let roughness = (1.0 - leaf.smoothness).clamp(0.04, 1.0);
         mesh.metalness_override = Some(metalness);
         mesh.roughness_override = Some(roughness);

--- a/crates/bgsm/examples/dump_bgsm.rs
+++ b/crates/bgsm/examples/dump_bgsm.rs
@@ -1,0 +1,42 @@
+//! Extract a BGSM from a BA2 and dump its specular/smoothness/PBR fields.
+//! Throwaway diagnostic for the FO4 "chrome concrete" investigation.
+//!
+//! Usage: dump_bgsm <Materials.ba2> <substring>
+
+use byroredux_bgsm::{parse, MaterialFile};
+use byroredux_bsa::Ba2Archive;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let arch = Ba2Archive::open(&args[1]).expect("open BA2");
+    let needle = args[2].to_lowercase();
+    for f in arch.list_files() {
+        if !f.to_lowercase().contains(&needle) || !f.to_lowercase().ends_with(".bgsm") {
+            continue;
+        }
+        let bytes = match arch.extract(f) {
+            Ok(b) => b,
+            Err(e) => {
+                println!("{f}: extract error {e}");
+                continue;
+            }
+        };
+        match parse(&bytes) {
+            Ok(MaterialFile::Bgsm(m)) => {
+                // Authored fields only — the spec-gloss → metal/rough
+                // translation lives in `asset_provider::merge_bgsm_into_mesh`
+                // (gated on `pbr`); don't duplicate it here or it drifts.
+                let mx = m.specular_color[0].max(m.specular_color[1]).max(m.specular_color[2]);
+                let mn = m.specular_color[0].min(m.specular_color[1]).min(m.specular_color[2]);
+                let saturation = if mx > 1.0e-4 { (mx - mn) / mx } else { 0.0 };
+                println!(
+                    "{f}\n  v={} pbr={} spec_enabled={} spec_color={:?} spec_mult={:.3} smoothness={:.3}\n  spec_saturation={:.3} (legacy metalness signal)  template={:?}",
+                    m.base.version, m.pbr, m.specular_enabled, m.specular_color, m.specular_mult,
+                    m.smoothness, saturation, m.root_material_path
+                );
+            }
+            Ok(_) => println!("{f}: BGEM"),
+            Err(e) => println!("{f}: parse error {e}"),
+        }
+    }
+}


### PR DESCRIPTION
Vanilla FO4 interiors rendered as polished chrome — every concrete, plaster, and wood surface mirrored the room. Root cause was in the BGSM spec-glossiness → metallic-roughness translation in merge_bgsm_into_mesh.

The translation treated `specular_color * mult` as PBR F0 and mapped its luminance to metalness. That is only valid for true metallic-roughness BGSMs (`pbr == true`), which 0 of 793 sampled vanilla FO4 materials set. For the legacy spec-glossiness materials that make up essentially all vanilla architecture, `specular_color` is the Blinn highlight TINT, not F0 — it is ~white `[1,1,1]` for every dielectric and the `mult` only scales highlight strength. Keying metalness off luminance was not just wrong but backwards: parsing the real files shows `paintpeelingconcrete` authors `spec=[1,1,1] mult=1.0` → lum 1.0 → metalness 1.0 (chrome), while genuine metals author LOWER, often tinted spec — `metalrubberductpipe` `[1,1,1] mult=0.73`, `metallocker` `[1,0.85,0.70] mult=0.45`.

The only legacy signal that distinguishes a conductor is spec CHROMATICITY (conductor F0 is tinted; dielectric F0 is achromatic grey). So for `pbr == false` we now derive metalness from spec-color saturation (mult-invariant): white spec → 0 (concrete/wood/plaster are dielectric), tinted spec → metallic (brass/gold/copper keep their look). The luminance→F0 path is preserved for `pbr == true`. Pure-white-spec steel now reads dielectric — a minor under-read recoverable later via a per- texel metalness map, but never the pervasive chrome the old path produced.

Verified on the Dugout Inn (DmndDugoutInn01): paintpeelingconcrete metalness 1.00 → 0.00; walls render as matte concrete. 430 byroredux tests pass. Adds `dump_bgsm` example (sibling to r5_check_ba2) used to read the authored values during the diagnosis.