### PR TITLE
Fix #1516: correct inverted bitangent sign on inline tangent paths

### DIFF
--- a/.claude/issues/1516/ISSUE.md
+++ b/.claude/issues/1516/ISSUE.md
@@ -1,0 +1,42 @@
+**Severity**: MEDIUM
+**Dimension**: Tangent-Space & Normal Maps (M-NORMALS)
+**Status**: NEW / CONFIRMED
+**Source**: `docs/audits/AUDIT_RENDERER_2026-06-14.md` (REN-D16-01)
+**Location**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs:1001-1011` and `crates/nif/src/import/mesh/sse_recon.rs:351-372`
+
+## Description
+
+The renderer fixes one global convention: `Vertex.tangent.xyz = ∂P/∂U`, and the shader reconstructs `B = vertexTangent.w * cross(N, T)` (`triangle.frag:1225`). For `B` to land on the true `∂P/∂V`, the authored `w` must equal `sign(dot(∂P/∂V, cross(N, ∂P/∂U)))`. That is exactly the formula used by `extract_tangents_from_extra_data` (`tangent.rs:101-108`) and `synthesize_tangents`, and it is the convention pinned by `tangent_convention_tests.rs` (textbook right-handed winding ⇒ sign = +1).
+
+The two **inline** packed-vertex paths compute the triple product with the two operand vectors **swapped**: they take `cross(N, t_xyz)` where `t_xyz` is the on-disk tangent triplet = `∂P/∂V`, then dot it with `[bx,by,bz]` = the bitangent triplet = `∂P/∂U` (the value stored in `tangent.xyz`):
+
+```rust
+// bs_tri_shape.rs:1006-1010  (identical shape in sse_recon.rs:365-369)
+let cnx = n[1]*t_xyz[2] - n[2]*t_xyz[1]; ...   // cross(N, ∂P/∂V)
+let dot_b_cross = bx*cnx + by*cny + bz*cnz;     // dot(∂P/∂U, cross(N, ∂P/∂V))
+let sign = if dot_b_cross >= 0.0 { 1.0 } else { -1.0 };
+```
+
+Since the scalar triple product is antisymmetric under swapping two of its three vectors (`det[∂P/∂V, N, ∂P/∂U] = -det[∂P/∂U, N, ∂P/∂V]`), the inline paths emit the **opposite** sign from the authored/synthesized paths for the same geometry. The comments at `bs_tri_shape.rs:1005` / `sse_recon.rs:353` claim parity with `extract_tangents_from_extra_data`, but T and B are interchanged relative to that function.
+
+## Evidence
+
+Numeric reproduction on the textbook RH fixture (N=+Z, ∂P/∂U=+X, ∂P/∂V=+Y) — the same case `tangent_convention_tests.rs` pins at +1:
+- authored/synthesized `dot(∂P/∂V, cross(N, ∂P/∂U))` = +1.0 → sign **+1** (B reconstructs to +∂P/∂V, correct)
+- inline `dot(∂P/∂U, cross(N, ∂P/∂V))` = −1.0 → sign **−1** (B reconstructs to −∂P/∂V, inverted)
+
+Re-derived: `cross(N, ∂P/∂V) = −∂P/∂U` for a right-handed orthonormal frame, so `dot(∂P/∂U, −∂P/∂U) < 0`. No unit test exercises the inline/SSE sign — the convention tests only call `synthesize_tangents{,_yup}`, so the inversion has never been pinned. The inline `w` reaches the shader untouched (`bs_tangents_zup_to_yup` preserves `t[3]`); both arrays land non-empty in `Vertex.tangent`, so the shader takes its Path-1 branch (`triangle.frag:1217`).
+
+## Impact
+
+The reconstructed bitangent B is negated for every BSTriShape mesh shipping inline `VF_TANGENTS` (common case for **Skyrim SE / FO4 / FO76**) and every SSE skin-reconstructed body/creature. The tangent-space normal map's V (green) channel is read with flipped handedness → detail leans the wrong way along V; reads as a consistent "inside-out groove" on directional carved normals. It also makes handedness **disagree between sibling paths**: a mesh with baked inline tangents renders inverted while an identical mesh that falls through to `synthesize_tangents` renders correctly. Blast radius: all Skyrim+/FO4/FO76 BSTriShape + SSE-reconstructed geometry. (Rated MEDIUM — consistent global flip on a subtle channel, not corruption — but arguably HIGH for the affected games given it is their primary geometry path.)
+
+## Suggested Fix
+
+Swap the operands so the inline/SSE formula matches the pinned convention — compute `sign(dot(t_xyz /*∂P/∂V*/, cross(N, [bx,by,bz] /*∂P/∂U*/)))`, or equivalently negate the existing `dot_b_cross`. Then add an inline-path case to `tangent_convention_tests.rs` (RH fixture ⇒ +1) so both packed paths are pinned to the same canonical sign as `synthesize_tangents`.
+
+## Completeness Checks
+- [ ] **SIBLING**: Both inline sites fixed (`bs_tri_shape.rs` AND `sse_recon.rs`); grep for any other in-tree bitangent-sign computation to confirm no third copy drifts.
+- [ ] **CANONICAL-BOUNDARY**: Fix stays in the NIF import/tangent-extraction layer — convention must match `extract_tangents_from_extra_data` / `synthesize_tangents`; do not introduce a per-game branch downstream.
+- [ ] **TESTS**: Add an inline + SSE case to `tangent_convention_tests.rs` (RH fixture ⇒ +1, mirrored-UV ⇒ −1) so both packed paths are pinned alongside the synthesized path.
+- [ ] **VISUAL**: Spot-check a Skyrim SE / FO4 mesh with directional carved normals before/after to confirm the green-channel handedness flips as expected.

--- a/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
+++ b/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
@@ -998,16 +998,14 @@ pub(crate) fn decode_bs_vertex_stream(
             tangent_xyz,
             normal_xyz,
         ) {
-            // sign(dot(B, cross(N, T))) — disambiguates left/
-            // right-handed TBN. Operates on raw Z-up values;
-            // determinant is preserved across the proper
-            // rotation Z-up → Y-up so the sign is correct
-            // post-conversion. Mirrors `extract_tangents_from_extra_data`.
-            let cnx = n[1] * t_xyz[2] - n[2] * t_xyz[1];
-            let cny = n[2] * t_xyz[0] - n[0] * t_xyz[2];
-            let cnz = n[0] * t_xyz[1] - n[1] * t_xyz[0];
-            let dot_b_cross = bx * cnx + by * cny + bz * cnz;
-            let sign = if dot_b_cross >= 0.0 { 1.0 } else { -1.0 };
+            // sign(dot(B, cross(N, T))) — disambiguates left/right-
+            // handed TBN. T is the tangent we STORE (∂P/∂U = the
+            // bitangent triplet [bx,by,bz]); B is the on-disk tangent
+            // triplet (∂P/∂V = t_xyz). Shared with the authored + SSE
+            // producers so the antisymmetric operand order can't drift
+            // (see `bitangent_sign` / #1516). Raw Z-up values; the sign
+            // is invariant under the Z-up → Y-up rotation.
+            let sign = crate::types::bitangent_sign(n, [bx, by, bz], t_xyz);
             tangents.push([bx, by, bz, sign]);
         }
 

--- a/crates/nif/src/import/mesh/sse_recon.rs
+++ b/crates/nif/src/import/mesh/sse_recon.rs
@@ -350,11 +350,15 @@ pub fn decode_sse_packed_buffer(buffer: &SseSkinGlobalBuffer) -> Option<DecodedP
 
         // Assemble the per-vertex tangent record (Bethesda bitangent
         // triplet → our tangent.xyz; sign from on-disk tangent
-        // (∂P/∂V) per `sign(dot(B, cross(N, T)))`). Operates on raw
-        // Z-up values and applies the same `(x, y, z) → (x, z, -y)`
-        // axis swap as the inline parser's importer-side helper. Sign
-        // is rotation-invariant so the swap doesn't flip it. See
-        // #796 / SK-D1-04.
+        // (∂P/∂V) per `sign(dot(B, cross(N, T)))`). T is the stored
+        // tangent (∂P/∂U = [bx,by,bz]); B is the on-disk tangent
+        // (∂P/∂V = t_xyz). Operand order must match
+        // `extract_tangents_from_extra_data` — cross(N, ∂P/∂U) dotted
+        // with ∂P/∂V — since the triple product is antisymmetric.
+        // Operates on raw Z-up values and applies the same
+        // `(x, y, z) → (x, z, -y)` axis swap as the inline parser's
+        // importer-side helper. Sign is rotation-invariant so the
+        // swap doesn't flip it. See #796 / SK-D1-04 and #1516.
         if let (Some(bx), Some(by), Some(bz), Some(t_xyz), Some(n)) = (
             bitangent_x,
             bitangent_y,
@@ -362,11 +366,7 @@ pub fn decode_sse_packed_buffer(buffer: &SseSkinGlobalBuffer) -> Option<DecodedP
             tangent_xyz,
             normal_zup,
         ) {
-            let cnx = n[1] * t_xyz[2] - n[2] * t_xyz[1];
-            let cny = n[2] * t_xyz[0] - n[0] * t_xyz[2];
-            let cnz = n[0] * t_xyz[1] - n[1] * t_xyz[0];
-            let dot_b_cross = bx * cnx + by * cny + bz * cnz;
-            let sign = if dot_b_cross >= 0.0 { 1.0 } else { -1.0 };
+            let sign = crate::types::bitangent_sign(n, [bx, by, bz], t_xyz);
             // Z-up → Y-up on the bitangent triplet (xyz). Sign passes
             // through unchanged.
             tangents.push([bx, bz, -by, sign]);

--- a/crates/nif/src/import/mesh/tangent.rs
+++ b/crates/nif/src/import/mesh/tangent.rs
@@ -92,20 +92,12 @@ pub fn extract_tangents_from_extra_data(
             let n_yup = [n_zup.x, n_zup.z, -n_zup.y];
 
             // Bitangent sign: sign(dot(B, cross(N, T))). With T = ∂P/∂U
-            // and B = ∂P/∂V on a standard right-handed UV winding,
-            // `cross(N, T) ≈ ∂P/∂V` so `dot(B, cross_nt) > 0` and the
-            // sign lands at +1 — the textbook case. UV-mirrored shells
-            // produce `< 0`, flipping the shader's bitangent so the
-            // tangent-space normal sample stays consistent across the
-            // mirror seam. Zero (degenerate) defaults to +1.
-            let cross_nt = [
-                n_yup[1] * t_yup[2] - n_yup[2] * t_yup[1],
-                n_yup[2] * t_yup[0] - n_yup[0] * t_yup[2],
-                n_yup[0] * t_yup[1] - n_yup[1] * t_yup[0],
-            ];
-            let dot_b_cross =
-                b_yup[0] * cross_nt[0] + b_yup[1] * cross_nt[1] + b_yup[2] * cross_nt[2];
-            let sign = if dot_b_cross < 0.0 { -1.0 } else { 1.0 };
+            // and B = ∂P/∂V on a standard right-handed UV winding the
+            // sign lands at +1 — the textbook case; UV-mirrored shells
+            // flip it so the shader's bitangent stays consistent across
+            // the mirror seam. Shared with the inline + SSE producers so
+            // the operand order can't drift (see `bitangent_sign` / #1516).
+            let sign = crate::types::bitangent_sign(n_yup, t_yup, b_yup);
 
             tangents.push([t_yup[0], t_yup[1], t_yup[2], sign]);
         }
@@ -318,16 +310,9 @@ pub fn synthesize_tangents(
                 (t_yup, b_yup)
             };
 
-        // Bitangent sign: sign(dot(B, cross(N, T))).
-        let cross_nt = [
-            n_yup[1] * tangent_yup[2] - n_yup[2] * tangent_yup[1],
-            n_yup[2] * tangent_yup[0] - n_yup[0] * tangent_yup[2],
-            n_yup[0] * tangent_yup[1] - n_yup[1] * tangent_yup[0],
-        ];
-        let dot_b_cross = bitangent_yup[0] * cross_nt[0]
-            + bitangent_yup[1] * cross_nt[1]
-            + bitangent_yup[2] * cross_nt[2];
-        let sign = if dot_b_cross < 0.0 { -1.0 } else { 1.0 };
+        // Bitangent sign: sign(dot(B, cross(N, T))) — shared helper so the
+        // operand order stays pinned across every tangent producer (#1516).
+        let sign = crate::types::bitangent_sign(n_yup, tangent_yup, bitangent_yup);
 
         out.push([tangent_yup[0], tangent_yup[1], tangent_yup[2], sign]);
     }
@@ -496,15 +481,9 @@ pub fn synthesize_tangents_yup(
                 (t_yup, b_yup)
             };
 
-        let cross_nt = [
-            n_yup[1] * tangent_yup[2] - n_yup[2] * tangent_yup[1],
-            n_yup[2] * tangent_yup[0] - n_yup[0] * tangent_yup[2],
-            n_yup[0] * tangent_yup[1] - n_yup[1] * tangent_yup[0],
-        ];
-        let dot_b_cross = bitangent_yup[0] * cross_nt[0]
-            + bitangent_yup[1] * cross_nt[1]
-            + bitangent_yup[2] * cross_nt[2];
-        let sign = if dot_b_cross < 0.0 { -1.0 } else { 1.0 };
+        // Bitangent sign: sign(dot(B, cross(N, T))) — shared helper so the
+        // operand order stays pinned across every tangent producer (#1516).
+        let sign = crate::types::bitangent_sign(n_yup, tangent_yup, bitangent_yup);
 
         out.push([tangent_yup[0], tangent_yup[1], tangent_yup[2], sign]);
     }

--- a/crates/nif/src/types.rs
+++ b/crates/nif/src/types.rs
@@ -133,6 +133,38 @@ impl BlockRef {
     }
 }
 
+/// Bitangent handedness sign for the renderer's `B = w * cross(N, T)`
+/// reconstruction. `t` is the tangent we store in `Vertex.tangent.xyz`
+/// (∂P/∂U); `b` is the surface's other tangent derivative (∂P/∂V).
+/// Returns `+1.0` for a standard right-handed UV winding (and for the
+/// degenerate zero case) and `-1.0` for a mirrored shell.
+///
+/// **Operand order is load-bearing.** The scalar triple product is
+/// antisymmetric, so `sign(dot(b, cross(n, t)))` and
+/// `sign(dot(t, cross(n, b)))` are negatives of each other — passing the
+/// stored tangent and the other derivative in the wrong slots silently
+/// inverts every normal-map V channel (see #1516). All three tangent
+/// producers — `extract_tangents_from_extra_data`, the BSTriShape inline
+/// decode, and the SSE skin reconstruction — must call through here so the
+/// convention stays pinned in one place.
+///
+/// Coordinate-frame agnostic: `n`, `t`, `b` must share a frame, but the
+/// result is invariant under the proper Z-up → Y-up rotation, so callers
+/// may pass raw Z-up or converted Y-up triples interchangeably.
+pub(crate) fn bitangent_sign(n: [f32; 3], t: [f32; 3], b: [f32; 3]) -> f32 {
+    let cross_nt = [
+        n[1] * t[2] - n[2] * t[1],
+        n[2] * t[0] - n[0] * t[2],
+        n[0] * t[1] - n[1] * t[0],
+    ];
+    let dot = b[0] * cross_nt[0] + b[1] * cross_nt[1] + b[2] * cross_nt[2];
+    if dot < 0.0 {
+        -1.0
+    } else {
+        1.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,5 +206,51 @@ mod tests {
         assert_eq!(c.r, 1.0);
         assert_eq!(c.g, 1.0);
         assert_eq!(c.b, 1.0);
+    }
+
+    // #1516 — pins the bitangent-sign convention shared by all three
+    // tangent producers. Textbook right-handed basis (N=+Z, T=∂P/∂U=+X,
+    // B=∂P/∂V=+Y) must yield +1; the operand-swapped call must yield -1,
+    // guarding against re-introducing the antisymmetric inversion the
+    // BSTriShape inline + SSE-recon paths shipped before #1516.
+    #[test]
+    fn bitangent_sign_right_handed_is_positive() {
+        let n = [0.0, 0.0, 1.0];
+        let t = [1.0, 0.0, 0.0]; // ∂P/∂U (stored tangent)
+        let b = [0.0, 1.0, 0.0]; // ∂P/∂V
+        assert_eq!(bitangent_sign(n, t, b), 1.0);
+    }
+
+    #[test]
+    fn bitangent_sign_swapped_operands_invert() {
+        let n = [0.0, 0.0, 1.0];
+        let t = [1.0, 0.0, 0.0];
+        let b = [0.0, 1.0, 0.0];
+        // Passing ∂P/∂V as the tangent and ∂P/∂U as the other derivative
+        // is exactly the pre-#1516 bug — antisymmetry flips the sign.
+        assert_eq!(bitangent_sign(n, b, t), -1.0);
+    }
+
+    #[test]
+    fn bitangent_sign_mirrored_uv_is_negative() {
+        // V flipped: ∂P/∂V points -Y, so cross(N, T)=+Y opposes it.
+        let n = [0.0, 0.0, 1.0];
+        let t = [1.0, 0.0, 0.0];
+        let b = [0.0, -1.0, 0.0];
+        assert_eq!(bitangent_sign(n, t, b), -1.0);
+    }
+
+    #[test]
+    fn bitangent_sign_degenerate_defaults_positive() {
+        assert_eq!(bitangent_sign([0.0; 3], [0.0; 3], [0.0; 3]), 1.0);
+    }
+
+    #[test]
+    fn bitangent_sign_rotation_invariant_zup_vs_yup() {
+        // Same basis expressed Z-up and after the (x,z,-y) Y-up swap must
+        // give the same sign — callers pass either frame interchangeably.
+        let zup = bitangent_sign([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
+        let yup = bitangent_sign([0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, -1.0]);
+        assert_eq!(zup, yup);
     }
 }

--- a/docs/audits/AUDIT_RENDERER_2026-06-14.md
+++ b/docs/audits/AUDIT_RENDERER_2026-06-14.md
@@ -1,0 +1,154 @@
+# Renderer Audit — 2026-06-14
+
+**Scope**: Focused single-dimension run — `--focus 16` (Tangent-Space & Normal
+Maps, M-NORMALS). Depth: **deep** (data-flow trace + numeric invariant
+validation). Other 22 renderer dimensions were not run this session.
+
+**Orchestrator verification**: the one reported finding was independently
+re-derived by the orchestrator (scalar-triple-product antisymmetry traced
+through both inline paths against the pinned canonical convention) before
+inclusion — it is not a pattern-match.
+
+---
+
+## Executive Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | 0 |
+| HIGH     | 0 |
+| MEDIUM   | 1 |
+| LOW      | 0 |
+
+One NEW correctness finding: an **inverted bitangent-sign convention** on the
+two inline packed-vertex tangent paths (FO4 / Skyrim SE / FO76 BSTriShape and
+SSE skin-reconstruction). The sign disagrees with the authored-blob and
+synthesized paths and is unpinned by any test. Seven of the eight checklist
+items verified correct; the DBG_* catalog "drift" is checklist staleness, not a
+code bug (code/pins pass 15/15).
+
+## Rasterization / Normal-Mapping Assessment
+
+The tangent-space pipeline is in good shape overall: the authored-blob decoder
+honors Bethesda's CalcTangentSpace ∂P/∂V↔∂P/∂U swap (#786), the synthesized
+fallback produces unit-length Gram-Schmidt tangents pinned by
+`tangent_convention_tests.rs`, Z-up→Y-up conversion is applied to T, B and N in
+lockstep, `perturbNormal` is correctly default-on with the `DBG_BYPASS_NORMAL_MAP`
+opt-out wired, and the DBG_* bit catalog is generated from a single Rust
+source-of-truth with both positive/negative pin tests passing.
+
+The single gap is that the **inline** packed-vertex sign formula was never
+brought under the same pin as the synthesized path, and it carries a swapped
+scalar-triple-product operand order that negates the result. Because it affects
+the primary geometry path for three games and silently disagrees with a sibling
+path on identical content, it is the priority fix.
+
+## RT Pipeline Assessment
+
+Not in scope this run (Dimensions 8–10, 20 not executed).
+
+---
+
+## Findings
+
+### REN-D16-01: BSTriShape inline + SSE-reconstruction tangent paths use an inverted bitangent-sign convention
+- **Severity**: MEDIUM
+- **Dimension**: Tangent-Space & Normal Maps (M-NORMALS)
+- **Location**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs:1001-1011` and `crates/nif/src/import/mesh/sse_recon.rs:351-372`
+- **Status**: NEW
+- **Description**:
+  The renderer fixes one global convention: `Vertex.tangent.xyz = ∂P/∂U`, and the
+  shader reconstructs `B = vertexTangent.w * cross(N, T)` (`triangle.frag:1225`).
+  For `B` to land on the true `∂P/∂V`, the authored `w` must equal
+  `sign(dot(∂P/∂V, cross(N, ∂P/∂U)))`. That is exactly the formula used by
+  `extract_tangents_from_extra_data` (`tangent.rs:101-108`) and `synthesize_tangents`,
+  and it is the convention pinned by `tangent_convention_tests.rs` (textbook
+  right-handed winding ⇒ sign = +1).
+
+  The two inline packed-vertex paths compute the triple product with the two
+  operand vectors **swapped**: they take `cross(N, t_xyz)` where `t_xyz` is the
+  on-disk tangent triplet = `∂P/∂V`, then dot it with `[bx,by,bz]` = the
+  bitangent triplet = `∂P/∂U` (the value stored in `tangent.xyz`). Since the
+  scalar triple product is antisymmetric under swapping two of its three vectors
+  (`det[∂P/∂V, N, ∂P/∂U] = -det[∂P/∂U, N, ∂P/∂V]`), the inline paths emit the
+  **opposite** sign for the same geometry. The comments at `bs_tri_shape.rs:1005`
+  and `sse_recon.rs:353` claim parity with `extract_tangents_from_extra_data`,
+  but T and B are interchanged relative to that function.
+- **Evidence**:
+  Numeric reproduction on the textbook RH fixture (N=+Z, ∂P/∂U=+X, ∂P/∂V=+Y) —
+  the same case `tangent_convention_tests.rs` pins at +1:
+  - authored/synthesized `dot(∂P/∂V, cross(N, ∂P/∂U))` = +1.0 → sign **+1** (B reconstructs to +∂P/∂V, correct)
+  - inline `dot(∂P/∂U, cross(N, ∂P/∂V))` = −1.0 → sign **−1** (B reconstructs to −∂P/∂V, inverted)
+
+  Independently re-derived by the orchestrator: `cross(N, ∂P/∂V) = −∂P/∂U` for a
+  right-handed orthonormal frame, so `dot(∂P/∂U, −∂P/∂U) < 0`. No unit test
+  exercises the inline/SSE sign — the convention tests only call
+  `synthesize_tangents{,_yup}`, so the inversion has never been pinned. The
+  inline `w` reaches the shader untouched (`bs_tangents_zup_to_yup` preserves
+  `t[3]`); both inline and SSE arrays land non-empty in `Vertex.tangent`, so the
+  shader takes its Path-1 branch (`dot(vertexTangent.xyz) > 1e-4`,
+  `triangle.frag:1217`).
+- **Impact**:
+  The reconstructed bitangent B is negated for every BSTriShape mesh shipping
+  inline `VF_TANGENTS` (the common case for Skyrim SE / FO4 / FO76) and every
+  SSE skin-reconstructed body/creature. The tangent-space normal map's V (green)
+  channel is read with flipped handedness → normal-map detail leans the wrong way
+  along V. Subtle on flat/symmetric detail; on directional carved normals it
+  reads as a consistent "inside-out groove" / mis-lit look. It also makes
+  handedness **disagree between sibling paths**: a mesh with baked inline tangents
+  renders inverted while an otherwise-identical mesh that falls through to
+  `synthesize_tangents` renders correctly. Blast radius: all Skyrim+/FO4/FO76
+  BSTriShape + SSE-reconstructed geometry. (Rated MEDIUM — consistent global
+  flip on a subtle channel, not corruption/crash — but arguably HIGH for the
+  affected games given it is their primary geometry path.)
+- **Suggested Fix**:
+  Swap the operands so the inline/SSE formula matches the pinned convention —
+  compute `sign(dot(t_xyz /*∂P/∂V*/, cross(N, [bx,by,bz] /*∂P/∂U*/)))`, or
+  equivalently negate the existing `dot_b_cross`. Then add an inline-path case to
+  `tangent_convention_tests.rs` (RH fixture ⇒ +1) so both packed paths are pinned
+  to the same canonical sign as `synthesize_tangents`.
+
+---
+
+## Prioritized Fix Order
+
+1. **REN-D16-01** (MEDIUM, correctness) — negate/swap the inline + SSE
+   bitangent-sign operands and add a pin test. Single-site logic fix on each of
+   two functions plus one new test; no API or struct change.
+
+## Verification Log (no-finding items)
+
+All confirmed against current code; none produced a finding:
+
+1. Authored-blob path (`extract_tangents_from_extra_data`) — honors the
+   CalcTangentSpace ∂P/∂V↔∂P/∂U swap and the #786 handedness fix; size-mismatch
+   guard warns and skips. **Correct.**
+2. FO4+ inline decode gating — keyed on the vertex-descriptor `VF_TANGENTS`/
+   `VF_NORMALS` flags, not BSVER, so it fires for FO4/FO76/SSE alike (the sign
+   bug is orthogonal to gating). **Gating correct.**
+3. Synthesized fallback — unit-length Gram-Schmidt tangents, degenerate
+   fallback, canonical sign; pinned by 4 tests. **Correct.**
+5. Z-up→Y-up conversion applied to T, B and the sign-N in lockstep; no path
+   converts N without T. **Correct.**
+6. `perturbNormal` default-on; `DBG_BYPASS_NORMAL_MAP = 0x10` opt-out wired
+   (`triangle.frag:1493`). **Correct.**
+7. DBG_* catalog — Rust source-of-truth ↔ generated GLSL header in lockstep for
+   all bits; both positive/negative pin tests iterate the shared catalog;
+   `cargo test -p byroredux-renderer shader_constants` → 15/15 pass. The
+   checklist's documented `0x200` ceiling is stale (catalog has grown to
+   `0x1000`); the **checklist** is the stale party, matching open doc issue
+   #1501/REN2-16. **Code correct.**
+8. "Chrome posterized walls" red herring — not used to manufacture a finding;
+   REN-D16-01 rests on a numeric proof, not a visual artifact.
+
+### Dedup notes
+- #1104 (Path-2 screen-space UV-mirror handedness): FIXED-VERIFIED per
+  AUDIT_RENDERER_2026-05-26_DIM16 (`38ba5506`). Not re-raised.
+- #1086 / #1232 (BSGeometry UDEC3 / `synthesize_tangents_yup` fallback): FIXED.
+  Not re-raised.
+- #1501 / REN2-16 (DBG bit doc-count drift): pre-existing OPEN doc issue; the
+  code/pins are correct, so no new finding.
+- REN-D16-01 is NEW: prior audits (AUDIT_FO4_2026-05-18, AUDIT_NIF_2026-05-12,
+  AUDIT_FO4_2026-05-15) assert the inline #795/#796 path is "intact/correct" but
+  none verified the sign formula's parity with the authored convention; the
+  inversion has no test and no prior issue.


### PR DESCRIPTION
## Summary

The BSTriShape inline packed-vertex decode (`bs_tri_shape.rs`) and the SSE skin-reconstruction path (`sse_recon.rs`) computed the bitangent handedness sign with the two operand vectors **swapped** relative to the authored-blob and synthesized producers:

- canonical: `sign(dot(∂P/∂V, cross(N, ∂P/∂U)))`
- inline (buggy): `sign(dot(∂P/∂U, cross(N, ∂P/∂V)))`

The scalar triple product is antisymmetric under that swap, so the inline paths emitted the **opposite** sign — for a textbook right-handed UV winding they yielded `-1` where the canonical convention yields `+1`.

The shader reconstructs `B = vertexTangent.w * cross(N, T)`, so the flipped sign negates the reconstructed bitangent for every BSTriShape mesh shipping inline `VF_TANGENTS` (the common case for **Skyrim SE / FO4 / FO76**) and every SSE skin-reconstructed mesh, reading the normal map's V (green) channel with inverted handedness. It also made handedness disagree between sibling meshes depending only on whether tangents were baked into the NIF vs synthesized.

## Changes

- Consolidate all **five** sign-computation sites (authored decode, both `synthesize_tangents{,_yup}` variants, and the two inline paths) onto one shared `types::bitangent_sign` helper, so the antisymmetric operand order is pinned in a single place and can't drift per-path again.
- Add 5 regression tests: right-handed (+1), operand-swap inversion (-1, the pre-fix bug), mirrored-UV (-1), degenerate default (+1), and Z-up/Y-up rotation invariance.

## Testing

- `cargo test -p byroredux-nif` — all green
- `cargo test` (full workspace) — all green, zero warnings

Found by `/audit-renderer` (REN-D16-01), report at `docs/audits/AUDIT_RENDERER_2026-06-14.md`.

Fixes #1516.