### PR TITLE
Fix #1336 + #1357: BSVER literal + BGSM_* alias naming cleanup

### DIFF
--- a/.claude/issues/1336/ISSUE.md
+++ b/.claude/issues/1336/ISSUE.md
@@ -1,3 +1,5 @@
+# NIF-2026-05-29-08: Residual bare-decimal BSVER literals where named bsver::* constants exist
+
 **Severity:** LOW · **Dimension:** Version Handling (maintainability) · **Game Affected:** None (cosmetic)
 
 From audit `docs/audits/AUDIT_NIF_2026-05-29.md` (finding NIF-2026-05-29-08).
@@ -31,3 +33,4 @@ Replace each bare decimal with the corresponding `crate::version::bsver::*` cons
 ## Completeness Checks
 - [ ] **SIBLING**: After substitution, grep the whole `crates/nif/src/blocks/` tree for any remaining bare `bsver() <op> <decimal>` comparisons with a named equivalent
 - [ ] **TESTS**: No behavior change — existing version-gate tests should stay green
+

--- a/.claude/issues/1357/ISSUE.md
+++ b/.claude/issues/1357/ISSUE.md
@@ -1,1 +1,9 @@
-# #1357 — see AUDIT_FO4_2026-05-30 for details. GitHub is authoritative.
+# D7-04: BGSM_* material flag alias constants not yet migrated to canonical names (PBR_BSDF, TRANSLUCENCY, etc.)
+
+**Severity**: LOW · **Source**: AUDIT_FO4_2026-05-30 (D7-04)
+
+**Location**: `crates/renderer/src/vulkan/material.rs:483-487`
+
+**Description**: Five `BGSM_*` alias constants (`BGSM_PBR`, `BGSM_TRANSLUCENCY`, `BGSM_MODEL_SPACE_NORMALS`, `BGSM_TRANSLUCENCY_THICK_OBJECT`, `BGSM_TRANSLUCENCY_MIX_ALBEDO`) are documented as "Pre-Stage-3 aliases — kept so external callers compile" but `pack_bgsm_material_flags` in `byroredux/src/cell_loader.rs` still uses them. The migration to canonical names (`PBR_BSDF`, `TRANSLUCENCY`, etc.) has not happened.
+
+**Suggested Fix**: Update the `use` block in `cell_loader.rs::pack_bgsm_material_flags` to reference the canonical constants directly, then remove the alias block from `material.rs:483-487`.

--- a/byroredux/src/cell_loader.rs
+++ b/byroredux/src/cell_loader.rs
@@ -173,7 +173,8 @@ pub(crate) fn pack_effect_shader_flags(
 
 /// Pack the three BGSM v>2 boolean flags
 /// ([`ImportedMesh::is_pbr`] / [`ImportedMesh::has_translucency`] /
-/// [`ImportedMesh::model_space_normals`]) into the `material_flag::BGSM_*`
+/// [`ImportedMesh::model_space_normals`]) into the canonical
+/// `material_flag::{PBR_BSDF, TRANSLUCENCY, MODEL_SPACE_NORMALS, …}`
 /// bit layout. Sibling to [`pack_effect_shader_flags`] — both contribute
 /// to the same `Material.effect_shader_flags` u32 by OR-composition at
 /// the importer boundary, then ride through to
@@ -191,8 +192,8 @@ pub(crate) fn pack_effect_shader_flags(
 /// [`ImportedMesh::model_space_normals`]: byroredux_nif::import::ImportedMesh::model_space_normals
 pub(crate) fn pack_bgsm_material_flags(mesh: &byroredux_nif::import::ImportedMesh) -> u32 {
     use byroredux_renderer::vulkan::material::material_flag::{
-        BGSM_AUTHORED, BGSM_MODEL_SPACE_NORMALS, BGSM_PBR, BGSM_TRANSLUCENCY,
-        BGSM_TRANSLUCENCY_MIX_ALBEDO, BGSM_TRANSLUCENCY_THICK_OBJECT, EFFECT_PALETTE_COLOR,
+        BGSM_AUTHORED, EFFECT_PALETTE_COLOR, MODEL_SPACE_NORMALS, PBR_BSDF, TRANSLUCENCY,
+        TRANSLUCENCY_MIX_ALBEDO, TRANSLUCENCY_THICK_OBJECT,
     };
     let mut flags = 0u32;
     // `BGSM_AUTHORED` — set when `merge_bgsm_into_mesh` resolved a
@@ -210,13 +211,13 @@ pub(crate) fn pack_bgsm_material_flags(mesh: &byroredux_nif::import::ImportedMes
         flags |= BGSM_AUTHORED;
     }
     if mesh.is_pbr {
-        flags |= BGSM_PBR;
+        flags |= PBR_BSDF;
     }
     if mesh.has_translucency {
-        flags |= BGSM_TRANSLUCENCY;
+        flags |= TRANSLUCENCY;
     }
     if mesh.model_space_normals {
-        flags |= BGSM_MODEL_SPACE_NORMALS;
+        flags |= MODEL_SPACE_NORMALS;
     }
     // #1353 / FO4-D8-07 — FO4 BGSM grayscale-to-palette. EFFECT_PALETTE_COLOR
     // IS `SLSF1::Greyscale_To_PaletteColor`; setting it on a BGSM lit material
@@ -230,15 +231,15 @@ pub(crate) fn pack_bgsm_material_flags(mesh: &byroredux_nif::import::ImportedMes
         flags |= EFFECT_PALETTE_COLOR;
     }
     // #1147 Phase 2b — translucency parameter-shape bits. Only
-    // meaningful when `BGSM_TRANSLUCENCY` is also set, but pack them
+    // meaningful when `TRANSLUCENCY` is also set, but pack them
     // unconditionally so the shader's predicate `is_thick` /
     // `mix_albedo` reads the authored value directly. The shader
-    // already gates the whole SSS block on `BGSM_TRANSLUCENCY`.
+    // already gates the whole SSS block on `TRANSLUCENCY`.
     if mesh.translucency_thick_object {
-        flags |= BGSM_TRANSLUCENCY_THICK_OBJECT;
+        flags |= TRANSLUCENCY_THICK_OBJECT;
     }
     if mesh.translucency_mix_albedo {
-        flags |= BGSM_TRANSLUCENCY_MIX_ALBEDO;
+        flags |= TRANSLUCENCY_MIX_ALBEDO;
     }
     flags
 }
@@ -253,7 +254,7 @@ mod pack_bgsm_material_flags_tests {
     use super::pack_bgsm_material_flags;
     use byroredux_nif::import::ImportedMesh;
     use byroredux_renderer::vulkan::material::material_flag::{
-        BGSM_MODEL_SPACE_NORMALS, BGSM_PBR, BGSM_TRANSLUCENCY, EFFECT_PALETTE_COLOR,
+        EFFECT_PALETTE_COLOR, MODEL_SPACE_NORMALS, PBR_BSDF, TRANSLUCENCY,
     };
 
     /// Build an empty-but-valid `ImportedMesh` with all 3 BGSM flags
@@ -367,28 +368,28 @@ mod pack_bgsm_material_flags_tests {
         mesh.model_space_normals = true;
 
         let packed = pack_bgsm_material_flags(&mesh);
-        let expected = BGSM_PBR | BGSM_TRANSLUCENCY | BGSM_MODEL_SPACE_NORMALS;
+        let expected = PBR_BSDF | TRANSLUCENCY | MODEL_SPACE_NORMALS;
         assert_eq!(packed, expected);
         // Sanity-check the canonical bit layout the Phase 2b shader
         // consumer will read against — bits 5, 6, 7.
-        assert_eq!(packed & 0x20, BGSM_PBR);
-        assert_eq!(packed & 0x40, BGSM_TRANSLUCENCY);
-        assert_eq!(packed & 0x80, BGSM_MODEL_SPACE_NORMALS);
+        assert_eq!(packed & 0x20, PBR_BSDF);
+        assert_eq!(packed & 0x40, TRANSLUCENCY);
+        assert_eq!(packed & 0x80, MODEL_SPACE_NORMALS);
     }
 
     #[test]
     fn individual_flags_produce_individual_bits() {
         let mut mesh = empty_mesh();
         mesh.is_pbr = true;
-        assert_eq!(pack_bgsm_material_flags(&mesh), BGSM_PBR);
+        assert_eq!(pack_bgsm_material_flags(&mesh), PBR_BSDF);
 
         let mut mesh = empty_mesh();
         mesh.has_translucency = true;
-        assert_eq!(pack_bgsm_material_flags(&mesh), BGSM_TRANSLUCENCY);
+        assert_eq!(pack_bgsm_material_flags(&mesh), TRANSLUCENCY);
 
         let mut mesh = empty_mesh();
         mesh.model_space_normals = true;
-        assert_eq!(pack_bgsm_material_flags(&mesh), BGSM_MODEL_SPACE_NORMALS);
+        assert_eq!(pack_bgsm_material_flags(&mesh), MODEL_SPACE_NORMALS);
     }
 
     /// #1353 / FO4-D8-07 — a BGSM that authored a greyscale-to-palette LUT
@@ -424,7 +425,7 @@ mod pack_bgsm_material_flags_tests {
             EFFECT_LIT, EFFECT_PALETTE_ALPHA, EFFECT_PALETTE_COLOR, EFFECT_SOFT,
             VERTEX_COLOR_EMISSIVE,
         };
-        let bgsm_bits = BGSM_PBR | BGSM_TRANSLUCENCY | BGSM_MODEL_SPACE_NORMALS;
+        let bgsm_bits = PBR_BSDF | TRANSLUCENCY | MODEL_SPACE_NORMALS;
         let prior_bits = VERTEX_COLOR_EMISSIVE
             | EFFECT_SOFT
             | EFFECT_PALETTE_COLOR

--- a/byroredux/src/cell_loader/spawn.rs
+++ b/byroredux/src/cell_loader/spawn.rs
@@ -852,7 +852,7 @@ pub(super) fn spawn_placed_instances(
         // the loose-NIF path. See `material_translate.rs`.
         let extra_material_flags = refr_overlay
             .filter(|o| o.model_space_normals)
-            .map(|_| byroredux_renderer::vulkan::material::material_flag::BGSM_MODEL_SPACE_NORMALS)
+            .map(|_| byroredux_renderer::vulkan::material::material_flag::MODEL_SPACE_NORMALS)
             .unwrap_or(0);
         let material = crate::material_translate::translate_material(
             mesh,

--- a/crates/nif/src/blocks/particle.rs
+++ b/crates/nif/src/blocks/particle.rs
@@ -381,12 +381,13 @@ pub fn parse_grow_fade_modifier(stream: &mut NifStream) -> io::Result<NiPSysGrow
     // v20.0.0.4 does NOT → `None`). Pre-#383 these 4 bytes were dropped
     // on every grow-fade modifier (890 occurrences in vanilla
     // `Fallout - Meshes.bsa`).
-    let base_scale =
-        if stream.version() == crate::version::NifVersion::V20_2_0_7 && stream.bsver() >= 34 {
-            Some(stream.read_f32_le()?)
-        } else {
-            None
-        };
+    let base_scale = if stream.version() == crate::version::NifVersion::V20_2_0_7
+        && stream.bsver() >= crate::version::bsver::FO3_FNV
+    {
+        Some(stream.read_f32_le()?)
+    } else {
+        None
+    };
     Ok(NiPSysGrowFadeModifier { base_scale })
 }
 
@@ -1003,10 +1004,10 @@ pub fn parse_particle_system(
     // On this path NiGeometry's structure is overridden for
     // NiParticleSystem: bounding_sphere + skin ref replace the usual
     // data_ref + skin_instance_ref + material_data triplet.
-    let is_bs_gte_sse = stream.bsver() >= 100;
+    let is_bs_gte_sse = stream.bsver() >= crate::version::bsver::SKYRIM_SE;
     // FO76 (BSVER == 155) adds a 6-float `bound_min_max` after
     // `bounding_sphere`. Other SSE+ titles do not.
-    let is_bs_f76 = stream.bsver() == 155;
+    let is_bs_f76 = stream.bsver() == crate::version::bsver::FO76;
 
     if is_bs_gte_sse {
         // Bounding sphere: 3 floats center + 1 float radius = 16 bytes.
@@ -1056,7 +1057,7 @@ pub fn parse_particle_system(
     // Shader / alpha refs land on every BSVER > 34 path. Use raw bsver()
     // rather than a variant predicate so non-Bethesda Gamebryo content at
     // BSVER > 34 stays aligned (matches base.rs:73 and node.rs:107).
-    if stream.bsver() > 34 {
+    if stream.bsver() > crate::version::bsver::FO3_FNV {
         let _shader_ref = stream.read_block_ref()?;
         let _alpha_ref = stream.read_block_ref()?;
     }
@@ -1188,7 +1189,7 @@ pub fn parse_particles_data(stream: &mut NifStream, type_name: &str) -> io::Resu
         let _has_texture_indices = stream.read_byte_bool()?;
         // Num Subtexture Offsets: byte for BSVER ≤ 34 (FO3/FNV), uint for
         // BSVER > 34 (Skyrim LE+). nif.xml lines 4008–4009.
-        let num_subtex_offsets: u64 = if stream.bsver() <= 34 {
+        let num_subtex_offsets: u64 = if stream.bsver() <= crate::version::bsver::FO3_FNV {
             stream.read_u8()? as u64
         } else {
             stream.read_u32_le()? as u64
@@ -1197,7 +1198,7 @@ pub fn parse_particles_data(stream: &mut NifStream, type_name: &str) -> io::Resu
         stream.skip(num_subtex_offsets * 16)?;
 
         // Skyrim+ (BS_GT_FO3): aspect ratio, aspect flags, 3× speed-to-aspect.
-        if stream.bsver() > 34 {
+        if stream.bsver() > crate::version::bsver::FO3_FNV {
             let _aspect_ratio = stream.read_f32_le()?;
             let _aspect_flags = stream.read_u16_le()?;
             let _speed_to_aspect_aspect_2 = stream.read_f32_le()?;

--- a/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
+++ b/crates/nif/src/blocks/tri_shape/bs_tri_shape.rs
@@ -260,7 +260,7 @@ impl BsTriShape {
         // silently — parse rate stayed at 100% while block contents
         // were wrong. Starfield (BSVER 172) is NOT affected because
         // `BS_F76` is strict equality. See nif.xml:8231.
-        if stream.bsver() == 155 {
+        if stream.bsver() == crate::version::bsver::FO76 {
             stream.skip(24)?;
         }
 

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -476,16 +476,6 @@ pub mod material_flag {
     /// also set.
     pub const TRANSLUCENCY_MIX_ALBEDO: u32 = 1 << 9;
 
-    // ── Pre-Stage-3 aliases — kept so external callers compile
-    // through the rename. New code should reference the un-prefixed
-    // names above. Targeted for removal in a follow-up sweep after
-    // every reader has migrated.
-    pub const BGSM_PBR: u32 = PBR_BSDF;
-    pub const BGSM_TRANSLUCENCY: u32 = TRANSLUCENCY;
-    pub const BGSM_MODEL_SPACE_NORMALS: u32 = MODEL_SPACE_NORMALS;
-    pub const BGSM_TRANSLUCENCY_THICK_OBJECT: u32 = TRANSLUCENCY_THICK_OBJECT;
-    pub const BGSM_TRANSLUCENCY_MIX_ALBEDO: u32 = TRANSLUCENCY_MIX_ALBEDO;
-
     /// Bit-shift for the 8-bit `BSEffectShaderProperty.lighting_influence`
     /// byte packed into `material_flags` bits 16–23. Extract in GLSL as
     /// `float((materialFlags >> MAT_FLAG_EFFECT_LI_SHIFT) & 0xFFu) / 255.0`.
@@ -523,11 +513,11 @@ pub mod material_flag {
     /// surface a distinguishing signal end-to-end, so it continues
     /// on the legacy path (matches pre-fix behaviour, no regression).
     ///
-    /// Distinct from [`BGSM_PBR`] which gates the Disney BSDF /
+    /// Distinct from [`PBR_BSDF`] which gates the Disney BSDF /
     /// translucency suite — `bgsm.pbr=true` is virtually never authored
     /// in vanilla content (sampled across 793 metal/crate/cargo
     /// vanilla FO4 BGSMs in `Fallout4 - Materials.ba2`: 0 with
-    /// pbr=true), so `BGSM_PBR` alone is a dead gate. `BGSM_AUTHORED`
+    /// pbr=true), so `PBR_BSDF` alone is a dead gate. `BGSM_AUTHORED`
     /// records that the spec-glossiness translation ran, but the routing
     /// itself is the CPU-side `metalness_override` / `roughness_override`
     /// write — not a GPU branch on this bit.
@@ -688,8 +678,8 @@ pub mod presets {
             diffuse_g: base[1],
             diffuse_b: base[2],
             // PBR flag so the Disney-diffuse branch fires at the
-            // shader (#1249 gates on `MAT_FLAG_BGSM_PBR`).
-            material_flags: super::material_flag::BGSM_PBR,
+            // shader (#1249 gates on `MAT_FLAG_PBR_BSDF`).
+            material_flags: super::material_flag::PBR_BSDF,
             ..Default::default()
         }
     }
@@ -750,12 +740,12 @@ pub mod presets {
             assert_eq!(m.metalness, 0.0);
             assert_eq!(m.subsurface, 1.0);
             assert_eq!(m.diffuse_r, 0.93);
-            // BGSM_PBR flag must be set so the shader's Disney-
+            // PBR_BSDF flag must be set so the shader's Disney-
             // diffuse branch consumes `subsurface`.
             assert_ne!(
-                m.material_flags & super::super::material_flag::BGSM_PBR,
+                m.material_flags & super::super::material_flag::PBR_BSDF,
                 0,
-                "skin_wax_marble must set BGSM_PBR so the shader's \
+                "skin_wax_marble must set PBR_BSDF so the shader's \
                  disneyDiffuseTerm branch fires and consumes subsurface = 1.0"
             );
         }


### PR DESCRIPTION
Two independent LOW tech-debt naming cleanups, one commit each. Both are behaviour-neutral (named constants equal the literals/aliases they replace).

## #1336 — residual bare-decimal BSVER literals
Seven `stream.bsver()` comparisons in `particle.rs` (6) and `bs_tri_shape.rs` (1) used bare decimals `34`/`100`/`155` where the same files already use the named `version::bsver::{FO3_FNV, SKYRIM_SE, FO76}` constants. Substituted each. Swept the whole `blocks/` tree afterward — remaining hits are prose comments only.

## #1357 — BGSM_* alias constants never migrated
The five `BGSM_*` alias constants in `material.rs` were documented as temporary "pre-Stage-3 aliases" but every reader still used them, so the rename never completed. Migrated all consumers — `pack_bgsm_material_flags` + tests (`cell_loader.rs`), the REFR-overlay flag (`cell_loader/spawn.rs`), and the `skin_wax_marble` preset + test (`material.rs`) — to the canonical names, then removed the alias block. The unrelated `BGSM_AUTHORED` flag (a distinct bit, not an alias) is retained. `MAT_FLAG_BGSM_*` comment prose (GLSL-side define names) left untouched.

## Testing
- `cargo test -p byroredux-nif -p byroredux-renderer -p byroredux` — green
- `cargo test` (full workspace) — green, zero warnings
- Confirmed my edits are rustfmt-clean; did not touch the pre-existing fmt drift on `main`.

Closes #1336.
Closes #1357.