### PR TITLE
Fix #1502: mark absolute-world-UV precision bound in water procedural noise

### DIFF
--- a/.claude/issues/1502/ISSUE.md
+++ b/.claude/issues/1502/ISSUE.md
@@ -1,3 +1,5 @@
+# REN2-17: Procedural water-noise hash degrades at large |world| (absolute-UV lattice) — currently unreachable fallback path
+
 ## Finding REN2-17 — Renderer Audit 2026-06-11
 
 - **Severity**: LOW
@@ -19,3 +21,4 @@ When the procedural path becomes reachable: feed the hash render-origin-relative
 
 ---
 Source: `docs/audits/AUDIT_RENDERER_2026-06-11.md` · Filed by `/audit-publish`
+

--- a/crates/renderer/shaders/water.frag
+++ b/crates/renderer/shaders/water.frag
@@ -169,6 +169,17 @@ vec3 sampleScrollingNormal(uint normalMapIndex, vec2 uvBase, vec2 scroll, float 
         // Cheap, doesn't pretend to be real waves but reads as moving
         // water.
         //
+        // PRECISION BOUND (#1502): `uvBase` here is absolute world XZ
+        // (`vWorldPos.xz`, the flat-water branch at the call site).
+        // `hash21`'s sin/fract lattice loses precision and visibly bands
+        // past ~176k-unit coordinates. Currently harmless because this
+        // branch runs ONLY when no water normal map is bound — the
+        // textured path (`texture(...)`, which wraps) covers all shipping
+        // content at ~30× sub-texel margin and never reaches the hash. If
+        // procedural foam/noise ever becomes a default path, feed the hash
+        // render-origin-relative coordinates (or a fract-reduced lattice)
+        // instead of absolute world XZ.
+        //
         // The gradient → tangent-space normal scaling is tuned so the
         // resulting normal stays within ~15° of straight up: anything
         // larger triggers the crest-foam pass downstream on every


### PR DESCRIPTION
LOW renderer doc/comment fix (REN2-17 from AUDIT_RENDERER_2026-06-11).

## What
The procedural normal fallback in `water.frag` feeds `hash21` the absolute world XZ position (`vWorldPos.xz`). The sin/fract lattice bands past ~176k-unit coordinates. The path runs **only** when no water normal map is bound — the textured path covers all shipping content at ~30× sub-texel margin and never reaches the hash — so this is a latent bound, not an active artifact (exactly as the issue notes).

Per the issue's own guidance ("no action needed today beyond a code comment marking the bound"), this adds a `PRECISION BOUND (#1502)` comment at the fallback documenting the limit and the fix direction (render-origin-relative / fract-reduced coords) for when procedural foam/noise becomes a default path.

## Notes
- **Comment-only** — SPIR-V is unchanged, no shader recompile.
- **SIBLING swept**: the only other `fract(sin(dot(...)))` lattice (`triangle.frag` SparkleSnow) seeds from UV, not absolute world, so it's unaffected. No caustic/foam procedural-noise sibling.
- Full `cargo test` green, zero warnings.

Closes #1502.

---
Companion issue #1501 (REN2-16) was assessed in the same pass and **closed as stale** — its doc-rot was already fixed by #1482 (commit `8eaade44`), which landed after the audit HEAD.