### PR TITLE
M41.x: Havok ragdolls on our Rapier solver (FNV slice)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,8 +124,17 @@ refuted by the 2026-04-17 + 2026-04-25 sweeps; v103 extracts
 147 629 / 147 629 vanilla files end-to-end, see #699). **NPC behavior
 beyond spawn** (AI packages, animation playback wiring) — M41 spawns
 visible T-pose actors with equipment but M42 behavior is Tier 7.
-**FO4 humanoid actor meshes** still wait on a Havok `.hkx` skeleton
-loader (M41.x). **The Papyrus runtime** that executes the 1 257 parsed
+**Actor motion** — NPCs spawn in bind pose; Havok `.hkx` *animation* is
+not yet decoded (M41.x animation slice). The FO4 *skeleton* loads fine —
+the old "FO4 humanoid meshes wait on a `.hkx` skeleton loader" framing
+was a stale premise: `characterassets\skeleton.nif` is a NIF that ships
+in `Fallout4 - Meshes.ba2` and resolves through the corrected path table.
+**M41.x ragdoll (Havok-baseline physics)** — the FNV slice shipped: the
+`bhkRigidBody` + ragdoll/malleable constraint chain parses, threads into
+a Rapier **multibody**, and the `ragdoll <id>` console command runs a
+Bethesda ragdoll on our solver (18-body Doc Mitchell verified). FO4/FO76/
+Starfield ragdolls stay blocked on the `BhkSystemBinary` blob decoder.
+**The Papyrus runtime** that executes the 1 257 parsed
 FO3 SCPT records is M47.2 — the event-hook (M47.0) + condition (M47.1)
 foundations ship, the transpiler does not yet. **Save/load** (M45) is
 unstarted. Weather transitions (fade between WTHR states) and cloud

--- a/byroredux/src/commands.rs
+++ b/byroredux/src/commands.rs
@@ -2363,6 +2363,36 @@ impl ConsoleCommand for MatSetCommand {
     }
 }
 
+/// `ragdoll <entity_id>` — flip an actor from bind-pose to a live Havok
+/// ragdoll simulated on our Rapier solver (M41.x). The entity is the
+/// actor placement root carrying a `RagdollTemplate` (attached at NPC
+/// spawn from the skeleton's parsed Havok articulation). Seeds each body
+/// from the bone's current pose, builds the multibody, and tags the actor
+/// `RagdollActive`; the writeback system then crumples the skinned mesh.
+struct RagdollCommand;
+impl ConsoleCommand for RagdollCommand {
+    fn name(&self) -> &str {
+        "ragdoll"
+    }
+    fn description(&self) -> &str {
+        "Ragdoll an actor (usage: ragdoll <entity_id>)"
+    }
+    fn execute(&self, world: &World, args: &str) -> CommandOutput {
+        let trimmed = args.trim();
+        let Ok(actor) = trimmed.parse::<EntityId>() else {
+            return CommandOutput::line(format!(
+                "ragdoll: failed to parse entity id from `{trimmed}` — usage: ragdoll <entity_id>"
+            ));
+        };
+        match crate::ragdoll::activate_ragdoll(world, actor) {
+            Ok(n) => CommandOutput::line(format!(
+                "ragdoll: entity {actor} now simulating {n} bodies on Rapier"
+            )),
+            Err(e) => CommandOutput::line(format!("ragdoll: {e}")),
+        }
+    }
+}
+
 pub(crate) fn build_command_registry() -> CommandRegistry {
     let mut registry = CommandRegistry::new();
     registry.register(HelpCommand);
@@ -2391,6 +2421,7 @@ pub(crate) fn build_command_registry() -> CommandRegistry {
     registry.register(ScriptActivateCommand);
     registry.register(MatListCommand);
     registry.register(MatSetCommand);
+    registry.register(RagdollCommand);
     registry
 }
 

--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -23,6 +23,7 @@ mod helpers;
 mod material_translate;
 mod npc_spawn;
 mod parsed_nif_cache;
+mod ragdoll;
 mod render;
 mod scene;
 mod scene_import_cache;
@@ -570,6 +571,12 @@ impl App {
         // Pre-register component storages that the physics sync system
         // queries on the first frame (before anything has been inserted).
         world.register::<byroredux_physics::RapierHandles>();
+        // M41.x ragdoll — pre-register so the `ragdoll` command's
+        // `query_mut::insert` and the writeback system's queries return
+        // `Some` even before any actor has been ragdolled.
+        world.register::<byroredux_physics::Ragdoll>();
+        world.register::<crate::ragdoll::RagdollTemplate>();
+        world.register::<crate::ragdoll::RagdollActive>();
         // M44 Phase 3.5: pre-register footstep emitter storage so
         // `footstep_system`'s `query_mut::<FootstepEmitter>` returns
         // `Some` even before the first emitter is inserted (e.g. on
@@ -848,6 +855,19 @@ impl App {
                 .writes::<byroredux_core::ecs::GlobalTransform>()
                 .reads::<Transform>()
                 .writes::<Transform>(),
+        );
+        // M41.x — ragdoll writeback. Stage::Late guarantees it runs after
+        // `physics_sync_system` (Stage::Physics) has stepped the multibody
+        // *and* after PostUpdate transform propagation, so overwriting each
+        // ragdoll bone's GlobalTransform with the simulated pose is the last
+        // word before render (no propagation/animation skip needed).
+        scheduler.add_to_with_access(
+            Stage::Late,
+            crate::ragdoll::ragdoll_writeback_system,
+            Access::new()
+                .reads_resource::<byroredux_physics::PhysicsWorld>()
+                .reads::<byroredux_physics::Ragdoll>()
+                .writes::<byroredux_core::ecs::GlobalTransform>(),
         );
         // M44 Phase 6 — cell-acoustics → reverb send (#846). Runs
         // before `audio_system` so any new spatial track constructed

--- a/byroredux/src/ragdoll.rs
+++ b/byroredux/src/ragdoll.rs
@@ -1,0 +1,385 @@
+//! Ragdoll activation + writeback (M41.x Phase 4).
+//!
+//! The NIF importer hands us an [`ImportedRagdoll`] (bone *names* +
+//! joint geometry). At spawn we resolve those names against the freshly
+//! loaded skeleton into a [`RagdollTemplate`] ECS component on the actor.
+//! The `ragdoll <id>` console command then [`activate_ragdoll`]s it:
+//! seed a [`byroredux_physics::RagdollSpec`] from each bone's *current*
+//! world pose, build the Rapier multibody, and tag the actor
+//! [`RagdollActive`]. Each frame [`ragdoll_writeback_system`] copies the
+//! simulated body poses back onto the bone entities' `GlobalTransform`,
+//! which the skinned mesh already reads — so the mesh crumples.
+//!
+//! Writeback runs in `Stage::Late`, after `physics_sync_system` (Physics)
+//! has stepped the bodies *and* after transform propagation (PostUpdate).
+//! Because it overwrites `GlobalTransform` last, no propagation/animation
+//! skip is needed for slice 1: propagation's bind-pose recompute is
+//! simply overwritten by the simulated pose every frame.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use byroredux_core::ecs::components::CollisionShape;
+use byroredux_core::ecs::sparse_set::SparseSetStorage;
+use byroredux_core::ecs::storage::Component;
+use byroredux_core::ecs::{EntityId, GlobalTransform, World};
+use byroredux_core::math::{Quat, Vec3};
+use byroredux_nif::import::{ImportedJointKind, ImportedRagdoll};
+use byroredux_physics::ragdoll::body_pose;
+use byroredux_physics::{
+    build_ragdoll, ContactConfig, PhysicsWorld, Ragdoll, RagdollBodySpec, RagdollConstraintSpec,
+    RagdollJointSpec, RagdollSpec,
+};
+
+/// Per-actor ragdoll blueprint, resolved at spawn against the loaded
+/// skeleton. Bone-local offsets + shapes + the joint graph; the world
+/// seed is computed at activation from the bones' live poses.
+#[derive(Debug, Clone)]
+pub struct RagdollTemplate {
+    pub bodies: Vec<RagdollTemplateBody>,
+    pub constraints: Vec<RagdollTemplateConstraint>,
+}
+
+impl Component for RagdollTemplate {
+    type Storage = SparseSetStorage<Self>;
+}
+
+#[derive(Debug, Clone)]
+pub struct RagdollTemplateBody {
+    /// Skeleton bone entity this body drives.
+    pub bone: EntityId,
+    /// Body origin offset relative to the bone (Y-up, scaled).
+    pub local_translation: Vec3,
+    pub local_rotation: Quat,
+    pub shape: CollisionShape,
+    pub mass: f32,
+    pub linear_damping: f32,
+    pub angular_damping: f32,
+    pub friction: f32,
+    pub restitution: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RagdollTemplateConstraint {
+    pub body_a: usize,
+    pub body_b: usize,
+    pub joint: RagdollJointSpec,
+}
+
+/// Marker: this actor is currently simulating as a ragdoll.
+#[derive(Debug, Clone, Copy)]
+pub struct RagdollActive;
+
+impl Component for RagdollActive {
+    type Storage = SparseSetStorage<Self>;
+}
+
+/// Resolve an [`ImportedRagdoll`] (bone names) against a skeleton's
+/// name→entity map into a [`RagdollTemplate`]. Bodies whose bone name
+/// doesn't resolve are dropped and the constraint indices remapped;
+/// returns `None` if fewer than 2 bodies or no joints survive.
+pub fn template_from_imported(
+    imported: &ImportedRagdoll,
+    skel_map: &HashMap<Arc<str>, EntityId>,
+) -> Option<RagdollTemplate> {
+    let mut bodies = Vec::with_capacity(imported.bodies.len());
+    let mut old_to_new: Vec<Option<usize>> = vec![None; imported.bodies.len()];
+    for (i, b) in imported.bodies.iter().enumerate() {
+        let Some(&bone) = skel_map.get(&b.bone_name) else {
+            continue;
+        };
+        old_to_new[i] = Some(bodies.len());
+        bodies.push(RagdollTemplateBody {
+            bone,
+            local_translation: b.translation,
+            local_rotation: b.rotation,
+            shape: b.shape.clone(),
+            mass: b.mass,
+            linear_damping: b.linear_damping,
+            angular_damping: b.angular_damping,
+            friction: b.friction,
+            restitution: b.restitution,
+        });
+    }
+    if bodies.len() < 2 {
+        return None;
+    }
+    let mut constraints = Vec::new();
+    for c in &imported.constraints {
+        let (Some(a), Some(b)) = (old_to_new[c.body_a], old_to_new[c.body_b]) else {
+            continue;
+        };
+        constraints.push(RagdollTemplateConstraint {
+            body_a: a,
+            body_b: b,
+            joint: joint_from_imported(&c.kind),
+        });
+    }
+    if constraints.is_empty() {
+        return None;
+    }
+    Some(RagdollTemplate { bodies, constraints })
+}
+
+fn joint_from_imported(k: &ImportedJointKind) -> RagdollJointSpec {
+    match k {
+        ImportedJointKind::Ragdoll {
+            twist_a,
+            plane_a,
+            pivot_a,
+            twist_b,
+            plane_b,
+            pivot_b,
+            cone_max,
+            twist_min,
+            twist_max,
+            ..
+        } => RagdollJointSpec::Ragdoll {
+            twist_a: *twist_a,
+            plane_a: *plane_a,
+            pivot_a: *pivot_a,
+            twist_b: *twist_b,
+            plane_b: *plane_b,
+            pivot_b: *pivot_b,
+            cone_max: *cone_max,
+            twist_min: *twist_min,
+            twist_max: *twist_max,
+        },
+        ImportedJointKind::LimitedHinge {
+            axis_a,
+            pivot_a,
+            axis_b,
+            pivot_b,
+            min_angle,
+            max_angle,
+        } => RagdollJointSpec::LimitedHinge {
+            axis_a: *axis_a,
+            pivot_a: *pivot_a,
+            axis_b: *axis_b,
+            pivot_b: *pivot_b,
+            min_angle: *min_angle,
+            max_angle: *max_angle,
+        },
+    }
+}
+
+/// Flip `actor` from animated/bind-pose to a live Rapier ragdoll. Reads
+/// the actor's [`RagdollTemplate`], seeds each body from its bone's
+/// current `GlobalTransform`, builds the multibody, and attaches
+/// [`Ragdoll`] + [`RagdollActive`]. Returns the body count on success.
+pub fn activate_ragdoll(world: &World, actor: EntityId) -> Result<usize, String> {
+    // 1. Build the world-seeded spec while holding the read guards, then
+    //    drop them before taking the PhysicsWorld write lock.
+    let spec = {
+        let tq = world
+            .query::<RagdollTemplate>()
+            .ok_or("RagdollTemplate storage not registered")?;
+        let template = tq
+            .get(actor)
+            .ok_or_else(|| format!("entity {actor} has no RagdollTemplate"))?;
+        let gtq = world
+            .query::<GlobalTransform>()
+            .ok_or("GlobalTransform storage not registered")?;
+
+        let mut bodies = Vec::with_capacity(template.bodies.len());
+        for b in &template.bodies {
+            let gt = gtq
+                .get(b.bone)
+                .ok_or_else(|| format!("ragdoll bone {} has no GlobalTransform", b.bone))?;
+            // World seed = bone global ∘ body-local offset.
+            let translation = gt.translation + gt.rotation * (b.local_translation * gt.scale);
+            let rotation = gt.rotation * b.local_rotation;
+            bodies.push(RagdollBodySpec {
+                entity: b.bone,
+                translation,
+                rotation,
+                shape: b.shape.clone(),
+                mass: b.mass,
+                linear_damping: b.linear_damping,
+                angular_damping: b.angular_damping,
+                friction: b.friction,
+                restitution: b.restitution,
+            });
+        }
+        let constraints = template
+            .constraints
+            .iter()
+            .map(|c| RagdollConstraintSpec {
+                body_a: c.body_a,
+                body_b: c.body_b,
+                joint: c.joint.clone(),
+            })
+            .collect();
+        RagdollSpec { bodies, constraints }
+    };
+
+    // 2. Build the Rapier multibody.
+    let ragdoll = {
+        let mut pw = world.resource_mut::<PhysicsWorld>();
+        build_ragdoll(&mut pw, &spec, &ContactConfig::DEFAULT)
+    };
+    let n = ragdoll.bodies.len();
+
+    // 3. Tag the actor.
+    world
+        .query_mut::<Ragdoll>()
+        .ok_or("Ragdoll storage not registered")?
+        .insert(actor, ragdoll);
+    world
+        .query_mut::<RagdollActive>()
+        .ok_or("RagdollActive storage not registered")?
+        .insert(actor, RagdollActive);
+
+    Ok(n)
+}
+
+/// Per-frame: copy each active ragdoll's simulated body poses onto the
+/// bone entities' `GlobalTransform`. Register in `Stage::Late` (after
+/// `physics_sync_system` steps the sim). Only the rotation + translation
+/// are written; the bone's `GlobalTransform.scale` is preserved.
+pub fn ragdoll_writeback_system(world: &World, _dt: f32) {
+    let Some(pw) = world.try_resource::<PhysicsWorld>() else {
+        return;
+    };
+    let Some(rq) = world.query::<Ragdoll>() else {
+        return;
+    };
+    let Some(mut gtq) = world.query_mut::<GlobalTransform>() else {
+        return;
+    };
+    for (_actor, ragdoll) in rq.iter() {
+        for (bone, handle) in &ragdoll.bodies {
+            let Some((t, r)) = body_pose(&pw, *handle) else {
+                continue;
+            };
+            if let Some(gt) = gtq.get_mut(*bone) {
+                gt.translation = t;
+                gt.rotation = r;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use byroredux_core::ecs::Transform;
+    use byroredux_physics::world::PHYSICS_DT;
+
+    /// Full headless flow: a synthetic skeleton (root + 3 hanging bones) +
+    /// a RagdollTemplate → `activate_ragdoll` → step → `ragdoll_writeback`
+    /// moves the bone `GlobalTransform`s under gravity while keeping them
+    /// jointed. Exercises every Phase-4 logic path without a GPU.
+    #[test]
+    fn activate_then_writeback_moves_bones() {
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<RagdollTemplate>();
+        world.register::<RagdollActive>();
+        world.register::<Ragdoll>();
+        world.insert_resource(PhysicsWorld::new());
+
+        let actor = world.spawn();
+        // Three bones in a horizontal row at y=1000, all upright.
+        let mut bones = Vec::new();
+        for i in 0..3 {
+            let e = world.spawn();
+            world.insert(
+                e,
+                GlobalTransform {
+                    translation: Vec3::new(i as f32 * 50.0, 1000.0, 0.0),
+                    rotation: Quat::IDENTITY,
+                    scale: 1.0,
+                },
+            );
+            bones.push(e);
+        }
+
+        let joint = |_a: usize, _b: usize| RagdollJointSpec::Ragdoll {
+            twist_a: Vec3::X,
+            plane_a: Vec3::Y,
+            pivot_a: Vec3::new(25.0, 0.0, 0.0),
+            twist_b: Vec3::X,
+            plane_b: Vec3::Y,
+            pivot_b: Vec3::new(-25.0, 0.0, 0.0),
+            cone_max: std::f32::consts::PI,
+            twist_min: -std::f32::consts::PI,
+            twist_max: std::f32::consts::PI,
+        };
+        let template = RagdollTemplate {
+            bodies: bones
+                .iter()
+                .map(|&bone| RagdollTemplateBody {
+                    bone,
+                    local_translation: Vec3::ZERO,
+                    local_rotation: Quat::IDENTITY,
+                    shape: CollisionShape::Ball { radius: 5.0 },
+                    mass: 4.0,
+                    linear_damping: 0.05,
+                    angular_damping: 0.05,
+                    friction: 0.5,
+                    restitution: 0.0,
+                })
+                .collect(),
+            constraints: vec![
+                RagdollTemplateConstraint {
+                    body_a: 0,
+                    body_b: 1,
+                    joint: joint(0, 1),
+                },
+                RagdollTemplateConstraint {
+                    body_a: 1,
+                    body_b: 2,
+                    joint: joint(1, 2),
+                },
+            ],
+        };
+        world.insert(actor, template);
+
+        let n = activate_ragdoll(&world, actor).expect("activation should succeed");
+        assert_eq!(n, 3);
+        assert!(
+            world.query::<RagdollActive>().unwrap().get(actor).is_some(),
+            "actor must be tagged RagdollActive"
+        );
+
+        let far_bone = bones[2];
+        let init_y = bone_y(&world, far_bone);
+
+        // Step the sim + run writeback each frame. With no floor the chain
+        // falls under gravity; the writeback must propagate that onto the
+        // bone GlobalTransforms (joints-hold is covered by the physics-crate
+        // chain test). 120 frames ≈ 2 s.
+        for _ in 0..120 {
+            {
+                let mut pw = world.resource_mut::<PhysicsWorld>();
+                pw.step(PHYSICS_DT);
+            }
+            ragdoll_writeback_system(&world, PHYSICS_DT);
+        }
+
+        let end = world
+            .query::<GlobalTransform>()
+            .unwrap()
+            .get(far_bone)
+            .unwrap()
+            .translation;
+        assert!(end.is_finite(), "writeback produced non-finite pose");
+        assert!(
+            end.y < init_y - 1.0,
+            "writeback should move the bone down under gravity: {init_y} → {}",
+            end.y
+        );
+    }
+
+    fn bone_y(world: &World, bone: EntityId) -> f32 {
+        world
+            .query::<GlobalTransform>()
+            .unwrap()
+            .get(bone)
+            .unwrap()
+            .translation
+            .y
+    }
+}

--- a/byroredux/src/ragdoll.rs
+++ b/byroredux/src/ragdoll.rs
@@ -213,10 +213,15 @@ pub fn activate_ragdoll(world: &World, actor: EntityId) -> Result<usize, String>
         RagdollSpec { bodies, constraints }
     };
 
-    // 2. Build the Rapier multibody.
+    // 2. Build the Rapier multibody (read the live tuning config; copy out
+    //    so no guard is held across the PhysicsWorld write lock).
+    let cfg = world
+        .try_resource::<ContactConfig>()
+        .map(|c| *c)
+        .unwrap_or(ContactConfig::DEFAULT);
     let ragdoll = {
         let mut pw = world.resource_mut::<PhysicsWorld>();
-        build_ragdoll(&mut pw, &spec, &ContactConfig::DEFAULT)
+        build_ragdoll(&mut pw, &spec, &cfg)
     };
     let n = ragdoll.bodies.len();
 

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -1035,6 +1035,26 @@ pub(crate) fn load_nif_bytes_with_skeleton(
                 },
             );
         }
+        // M41.x — when this NIF carries a Havok ragdoll articulation (only
+        // skeletons do; `extract_ragdoll` returns None for meshes), resolve
+        // its bone names against the just-built `node_by_name` map and attach
+        // a `RagdollTemplate` to the root. The `ragdoll <id>` console command
+        // builds the live Rapier multibody from it. Self-gating: facegen /
+        // armor / clutter loads have `ragdoll: None`, so nothing attaches.
+        if let Some(ragdoll) = imported.ragdoll.as_ref() {
+            if let Some(template) =
+                crate::ragdoll::template_from_imported(ragdoll, &node_by_name)
+            {
+                let bodies = template.bodies.len();
+                world.insert(root_entity, template);
+                log::info!(
+                    "Attached RagdollTemplate ({} bodies) to root entity {} from '{}'",
+                    bodies,
+                    root_entity,
+                    label,
+                );
+            }
+        }
     }
 
     // #261 — mesh-embedded controller chains (water UV scroll, torch

--- a/byroredux/src/scene_import_cache.rs
+++ b/byroredux/src/scene_import_cache.rs
@@ -152,6 +152,7 @@ mod tests {
             attach_points: None,
             child_attach_connections: None,
             embedded_clip: None,
+            ragdoll: None,
         })
     }
 

--- a/crates/nif/src/blocks/collision/bhk_constraint_tests.rs
+++ b/crates/nif/src/blocks/collision/bhk_constraint_tests.rs
@@ -1,0 +1,216 @@
+//! Coverage for the M41.x typed `bhkRagdollConstraint` /
+//! `bhkLimitedHingeConstraint` CInfo decode. Pre-M41.x these FO3+
+//! constraints were name-only stubs (16 bytes read, the rest skipped via
+//! `block_size`); now the per-variant body is decoded so the ragdoll
+//! articulation can be threaded out at import.
+//!
+//! Field order + sizes are from nif.xml (`bhkRagdollConstraintCInfo` /
+//! `bhkLimitedHingeConstraintCInfo`, `!#NI_BS_LTE_16#` branch) and
+//! cross-checked against the FNV prefix sizes the sibling
+//! `BhkBreakableConstraint` already encodes (Ragdoll 152, LimitedHinge 140).
+//! The typed decode reads exactly the fixed prefix and leaves the trailing
+//! motor to `block_size` recovery — so these tests assert the stream
+//! advanced by `16 + prefix`, with no motor bytes in the buffer.
+use super::*;
+use crate::header::NifHeader;
+use crate::version::NifVersion;
+
+fn fnv_header() -> NifHeader {
+    NifHeader {
+        version: NifVersion::V20_2_0_7,
+        little_endian: true,
+        user_version: 11,
+        user_version_2: 34,
+        num_blocks: 0,
+        block_types: Vec::new(),
+        block_type_indices: Vec::new(),
+        block_sizes: Vec::new(),
+        strings: Vec::new(),
+        max_string_length: 0,
+        num_groups: 0,
+    }
+}
+
+fn oblivion_header() -> NifHeader {
+    NifHeader {
+        version: NifVersion::V20_0_0_5,
+        little_endian: true,
+        user_version: 11,
+        user_version_2: 0,
+        num_blocks: 0,
+        block_types: Vec::new(),
+        block_type_indices: Vec::new(),
+        block_sizes: Vec::new(),
+        strings: Vec::new(),
+        max_string_length: 0,
+        num_groups: 0,
+    }
+}
+
+/// Shared `bhkConstraintCInfo` base — 16 bytes:
+/// num_entities + entity_a + entity_b + priority.
+fn base() -> Vec<u8> {
+    let mut d = Vec::with_capacity(16);
+    d.extend_from_slice(&2u32.to_le_bytes());
+    d.extend_from_slice(&1u32.to_le_bytes()); // entity_a
+    d.extend_from_slice(&2u32.to_le_bytes()); // entity_b
+    d.extend_from_slice(&3u32.to_le_bytes()); // priority
+    d
+}
+
+fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec<u8> {
+    let mut d = Vec::with_capacity(16);
+    for c in [x, y, z, w] {
+        d.extend_from_slice(&c.to_le_bytes());
+    }
+    d
+}
+
+#[test]
+fn fnv_ragdoll_decodes_typed_cinfo() {
+    let mut bytes = base();
+    // 8 × Vec4 in FO3+ order: TwistA, PlaneA, MotorA, PivotA, TwistB,
+    // PlaneB, MotorB, PivotB. Encode the first component as the index so
+    // each field is individually identifiable.
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // twist_a
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // plane_a
+    bytes.extend(vec4(2.0, 0.0, 0.0, 0.0)); // motor_a
+    bytes.extend(vec4(3.0, 10.0, 20.0, 1.0)); // pivot_a
+    bytes.extend(vec4(4.0, 0.0, 1.0, 0.0)); // twist_b
+    bytes.extend(vec4(5.0, 0.0, 0.0, 0.0)); // plane_b
+    bytes.extend(vec4(6.0, 0.0, 0.0, 0.0)); // motor_b
+    bytes.extend(vec4(7.0, -10.0, 5.0, 1.0)); // pivot_b
+    // 6 × f32 limits.
+    for v in [0.5f32, -0.25, 0.75, -1.5, 1.5, 100.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    assert_eq!(bytes.len(), 16 + 152, "base + 8×Vec4 + 6×f32");
+
+    let header = fnv_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkRagdollConstraint").unwrap();
+
+    assert_eq!(c.priority, 3);
+    let BhkConstraintData::Ragdoll(r) = c.data else {
+        panic!("expected Ragdoll data, got {:?}", c.data);
+    };
+    assert_eq!(r.twist_a, [0.0, 0.0, 1.0, 0.0]);
+    assert_eq!(r.plane_a, [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.motor_a, [2.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.pivot_a, [3.0, 10.0, 20.0, 1.0]);
+    assert_eq!(r.twist_b, [4.0, 0.0, 1.0, 0.0]);
+    assert_eq!(r.plane_b, [5.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.motor_b, [6.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.pivot_b, [7.0, -10.0, 5.0, 1.0]);
+    assert_eq!(r.cone_max_angle, 0.5);
+    assert_eq!(r.plane_min_angle, -0.25);
+    assert_eq!(r.plane_max_angle, 0.75);
+    assert_eq!(r.twist_min_angle, -1.5);
+    assert_eq!(r.twist_max_angle, 1.5);
+    assert_eq!(r.max_friction, 100.0);
+    // Fixed prefix consumed exactly; the trailing motor is left for
+    // block_size recovery.
+    assert_eq!(stream.position() as usize, 16 + 152);
+}
+
+#[test]
+fn fnv_limited_hinge_decodes_typed_cinfo() {
+    let mut bytes = base();
+    // 8 × Vec4 in FO3+ order: AxisA, PerpA1, PerpA2, PivotA, AxisB,
+    // PerpB1, PerpB2, PivotB.
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // axis_a
+    bytes.extend(vec4(0.0, 1.0, 0.0, 0.0)); // perp_axis_in_a1
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // perp_axis_in_a2
+    bytes.extend(vec4(11.0, 22.0, 33.0, 1.0)); // pivot_a
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // axis_b
+    bytes.extend(vec4(0.0, 1.0, 0.0, 0.0)); // perp_axis_in_b1
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // perp_axis_in_b2
+    bytes.extend(vec4(44.0, 55.0, 66.0, 1.0)); // pivot_b
+    // 3 × f32: min, max, friction.
+    for v in [-1.0f32, 1.0, 10.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    assert_eq!(bytes.len(), 16 + 140, "base + 8×Vec4 + 3×f32");
+
+    let header = fnv_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkLimitedHingeConstraint").unwrap();
+
+    let BhkConstraintData::LimitedHinge(h) = c.data else {
+        panic!("expected LimitedHinge data, got {:?}", c.data);
+    };
+    assert_eq!(h.axis_a, [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(h.perp_axis_in_a1, [0.0, 1.0, 0.0, 0.0]);
+    assert_eq!(h.perp_axis_in_a2, [0.0, 0.0, 1.0, 0.0]);
+    assert_eq!(h.pivot_a, [11.0, 22.0, 33.0, 1.0]);
+    assert_eq!(h.pivot_b, [44.0, 55.0, 66.0, 1.0]);
+    assert_eq!(h.min_angle, -1.0);
+    assert_eq!(h.max_angle, 1.0);
+    assert_eq!(h.max_friction, 10.0);
+    assert_eq!(stream.position() as usize, 16 + 140);
+}
+
+/// FNV `bhkMalleableConstraint` wrapping a Ragdoll (Type 7) — the
+/// dominant joint form in the vanilla humanoid skeleton (14 of 17
+/// joints). The inner CInfo's entities are −1/−1; the real bodies are
+/// the outer base. Layout: base(16) + Type(4) + inner CInfo(16) + Ragdoll
+/// prefix(152). The trailing Strength + inner motor recover via block_size.
+#[test]
+fn fnv_malleable_wrapping_ragdoll_surfaces_as_ragdoll() {
+    let mut bytes = base(); // outer base: real bodies (entity_a=1, entity_b=2)
+    bytes.extend_from_slice(&7u32.to_le_bytes()); // wrapped Type = 7 (Ragdoll)
+    // inner bhkConstraintCInfo: num=2, entity_a=-1, entity_b=-1, priority=1
+    bytes.extend_from_slice(&2u32.to_le_bytes());
+    bytes.extend_from_slice(&(-1i32).to_le_bytes());
+    bytes.extend_from_slice(&(-1i32).to_le_bytes());
+    bytes.extend_from_slice(&1u32.to_le_bytes());
+    // inner Ragdoll CInfo: 8 × Vec4 + 6 × f32.
+    for i in 0..8 {
+        bytes.extend(vec4(i as f32, 0.0, 0.0, 0.0));
+    }
+    for v in [0.5f32, -0.25, 0.75, -1.5, 1.5, 100.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+
+    let header = fnv_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkMalleableConstraint").unwrap();
+
+    // Outer entities are the constrained bodies.
+    assert_eq!(c.entity_a.index(), Some(1));
+    assert_eq!(c.entity_b.index(), Some(2));
+    let BhkConstraintData::Ragdoll(r) = c.data else {
+        panic!("malleable-wrapped Ragdoll must surface as Ragdoll, got {:?}", c.data);
+    };
+    assert_eq!(r.twist_a, [0.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.pivot_b, [7.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.max_friction, 100.0);
+    // base(16) + Type(4) + inner CInfo(16) + Ragdoll prefix(152) = 188.
+    assert_eq!(stream.position() as usize, 16 + 4 + 16 + 152);
+}
+
+/// Non-decoded FO3+ types stay name-only stubs (16-byte base read; the
+/// rest recovered via block_size) — unchanged from pre-M41.x behaviour.
+#[test]
+fn fnv_other_constraint_type_stays_stub() {
+    let bytes = base();
+    let header = fnv_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkHingeConstraint").unwrap();
+    assert!(matches!(c.data, BhkConstraintData::Other));
+    assert_eq!(stream.position() as usize, 16, "only the base is read");
+}
+
+/// Oblivion ragdoll keeps the existing fixed-skip path (different field
+/// order, no motor); M41.x does not decode it yet → `Other`, with the
+/// 120-byte Oblivion payload still skipped exactly.
+#[test]
+fn oblivion_ragdoll_skips_and_stays_stub() {
+    let mut bytes = base();
+    bytes.extend(vec![0u8; 120]); // Oblivion Ragdoll: 6×Vec4 + 6×f32
+    let header = oblivion_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkRagdollConstraint").unwrap();
+    assert!(matches!(c.data, BhkConstraintData::Other));
+    assert_eq!(stream.position() as usize, 16 + 120);
+}

--- a/crates/nif/src/blocks/collision/constraints.rs
+++ b/crates/nif/src/blocks/collision/constraints.rs
@@ -171,12 +171,12 @@ impl BhkConstraint {
 
     /// Decode the inner constraint of an FO3+ `bhkMalleableConstraint`.
     /// Layout (nif.xml `bhkMalleableConstraintCInfo`, `since 20.2.0.7`):
-    /// `Type u32` + inner `bhkConstraintCInfo` (16 B, whose entities are
-    /// −1/−1 — the real bodies are the OUTER base the caller already read)
-    /// + the typed inner CInfo. The trailing `Strength` f32 (and the inner
-    /// CInfo's motor) are left for `block_size` recovery. FNV humanoid
-    /// ragdolls wrap 14 of their 17 joints this way, so a malleable-wrapped
-    /// Ragdoll surfaces identically to a bare one.
+    /// a `Type u32`, then an inner `bhkConstraintCInfo` (16 B, whose
+    /// entities are −1/−1 — the real bodies are the OUTER base the caller
+    /// already read), then the typed inner CInfo. The trailing `Strength`
+    /// f32 (and the inner CInfo's motor) are left for `block_size`
+    /// recovery. FNV humanoid ragdolls wrap 14 of their 17 joints this way,
+    /// so a malleable-wrapped Ragdoll surfaces identically to a bare one.
     fn parse_fo3_malleable_inner(stream: &mut NifStream) -> io::Result<BhkConstraintData> {
         let wrapped_type = stream.read_u32_le()?;
         // Inner bhkConstraintCInfo — discard (entities are −1/−1).

--- a/crates/nif/src/blocks/collision/constraints.rs
+++ b/crates/nif/src/blocks/collision/constraints.rs
@@ -11,12 +11,15 @@ use crate::version::NifVersion;
 use std::any::Any;
 use std::io;
 
-/// Opaque stub for a Havok constraint block.
+/// A Havok constraint block.
 ///
-/// Holds just the shared `bhkConstraintCInfo` base (two entity refs
-/// plus priority); everything else is skipped. The concrete constraint
-/// type is preserved in `type_name` so downstream consumers and
-/// telemetry can identify it. See #117.
+/// Always holds the shared `bhkConstraintCInfo` base (two entity refs
+/// plus priority). On FO3+ the joint geometry a humanoid ragdoll uses is
+/// decoded into [`BhkConstraintData`] (M41.x): bare `bhkRagdollConstraint`
+/// / `bhkLimitedHingeConstraint`, and — the dominant FNV form —
+/// `bhkMalleableConstraint` wrapping one of those (surfaced as the inner
+/// joint, with the malleable block's outer entity refs as the bodies).
+/// Every other type stays a `type_name`-only stub. See #117 / M41.x.
 #[derive(Debug)]
 pub struct BhkConstraint {
     /// RTTI class name — one of the seven constraint types.
@@ -24,6 +27,10 @@ pub struct BhkConstraint {
     pub entity_a: BlockRef,
     pub entity_b: BlockRef,
     pub priority: u32,
+    /// Decoded per-variant serialization data, when we parse it
+    /// (FO3+ Ragdoll / LimitedHinge). [`BhkConstraintData::Other`]
+    /// otherwise.
+    pub data: BhkConstraintData,
 }
 
 impl NiObject for BhkConstraint {
@@ -32,6 +39,121 @@ impl NiObject for BhkConstraint {
     }
     fn as_any(&self) -> &dyn Any {
         self
+    }
+}
+
+/// Decoded per-variant `bhkConstraintCInfo` payload. Only the variants
+/// a humanoid ragdoll articulation uses are decoded today (M41.x); the
+/// rest stay [`Other`](BhkConstraintData::Other) (the bytes are still
+/// consumed/skipped, just not surfaced).
+#[derive(Debug, Clone)]
+pub enum BhkConstraintData {
+    /// `bhkRagdollConstraintCInfo` — a 3-DOF cone/twist ball joint.
+    Ragdoll(RagdollCInfo),
+    /// `bhkLimitedHingeConstraintCInfo` — a 1-DOF angle-limited hinge.
+    LimitedHinge(LimitedHingeCInfo),
+    /// Any constraint type we don't decode the body of yet.
+    Other,
+}
+
+/// `bhkRagdollConstraintCInfo`, FO3/FNV (`!#NI_BS_LTE_16#`) layout from
+/// nif.xml. All vectors are **raw Havok Z-up** — coordinate conversion
+/// happens at the import boundary (Phase 2), not here. The trailing
+/// `bhkConstraintMotorCInfo` is left for `block_size` recovery (it's the
+/// last field and carries nothing slice 1 needs).
+#[derive(Debug, Clone)]
+pub struct RagdollCInfo {
+    pub twist_a: [f32; 4],
+    pub plane_a: [f32; 4],
+    pub motor_a: [f32; 4],
+    pub pivot_a: [f32; 4],
+    pub twist_b: [f32; 4],
+    pub plane_b: [f32; 4],
+    pub motor_b: [f32; 4],
+    pub pivot_b: [f32; 4],
+    /// Max angle around the axis orthogonal to Plane A and Twist A.
+    /// Cone min is `-cone_max_angle` (not stored).
+    pub cone_max_angle: f32,
+    pub plane_min_angle: f32,
+    pub plane_max_angle: f32,
+    pub twist_min_angle: f32,
+    pub twist_max_angle: f32,
+    pub max_friction: f32,
+}
+
+impl RagdollCInfo {
+    /// 8 × Vec4 + 6 × f32 = 152 bytes (matches the FNV Ragdoll prefix in
+    /// [`BhkBreakableConstraint::fnv_motor_prefix_size`]).
+    fn parse_fo3(stream: &mut NifStream) -> io::Result<Self> {
+        let twist_a = super::read_vec4(stream)?;
+        let plane_a = super::read_vec4(stream)?;
+        let motor_a = super::read_vec4(stream)?;
+        let pivot_a = super::read_vec4(stream)?;
+        let twist_b = super::read_vec4(stream)?;
+        let plane_b = super::read_vec4(stream)?;
+        let motor_b = super::read_vec4(stream)?;
+        let pivot_b = super::read_vec4(stream)?;
+        Ok(Self {
+            twist_a,
+            plane_a,
+            motor_a,
+            pivot_a,
+            twist_b,
+            plane_b,
+            motor_b,
+            pivot_b,
+            cone_max_angle: stream.read_f32_le()?,
+            plane_min_angle: stream.read_f32_le()?,
+            plane_max_angle: stream.read_f32_le()?,
+            twist_min_angle: stream.read_f32_le()?,
+            twist_max_angle: stream.read_f32_le()?,
+            max_friction: stream.read_f32_le()?,
+        })
+    }
+}
+
+/// `bhkLimitedHingeConstraintCInfo`, FO3/FNV (`!#NI_BS_LTE_16#`) layout
+/// from nif.xml. Raw Havok Z-up (see [`RagdollCInfo`]).
+#[derive(Debug, Clone)]
+pub struct LimitedHingeCInfo {
+    pub axis_a: [f32; 4],
+    pub perp_axis_in_a1: [f32; 4],
+    pub perp_axis_in_a2: [f32; 4],
+    pub pivot_a: [f32; 4],
+    pub axis_b: [f32; 4],
+    pub perp_axis_in_b1: [f32; 4],
+    pub perp_axis_in_b2: [f32; 4],
+    pub pivot_b: [f32; 4],
+    pub min_angle: f32,
+    pub max_angle: f32,
+    pub max_friction: f32,
+}
+
+impl LimitedHingeCInfo {
+    /// 8 × Vec4 + 3 × f32 = 140 bytes (matches the FNV LimitedHinge
+    /// prefix in [`BhkBreakableConstraint::fnv_motor_prefix_size`]).
+    fn parse_fo3(stream: &mut NifStream) -> io::Result<Self> {
+        let axis_a = super::read_vec4(stream)?;
+        let perp_axis_in_a1 = super::read_vec4(stream)?;
+        let perp_axis_in_a2 = super::read_vec4(stream)?;
+        let pivot_a = super::read_vec4(stream)?;
+        let axis_b = super::read_vec4(stream)?;
+        let perp_axis_in_b1 = super::read_vec4(stream)?;
+        let perp_axis_in_b2 = super::read_vec4(stream)?;
+        let pivot_b = super::read_vec4(stream)?;
+        Ok(Self {
+            axis_a,
+            perp_axis_in_a1,
+            perp_axis_in_a2,
+            pivot_a,
+            axis_b,
+            perp_axis_in_b1,
+            perp_axis_in_b2,
+            pivot_b,
+            min_angle: stream.read_f32_le()?,
+            max_angle: stream.read_f32_le()?,
+            max_friction: stream.read_f32_le()?,
+        })
     }
 }
 
@@ -45,6 +167,25 @@ impl BhkConstraint {
         let entity_b = stream.read_block_ref()?;
         let priority = stream.read_u32_le()?;
         Ok((entity_a, entity_b, priority))
+    }
+
+    /// Decode the inner constraint of an FO3+ `bhkMalleableConstraint`.
+    /// Layout (nif.xml `bhkMalleableConstraintCInfo`, `since 20.2.0.7`):
+    /// `Type u32` + inner `bhkConstraintCInfo` (16 B, whose entities are
+    /// −1/−1 — the real bodies are the OUTER base the caller already read)
+    /// + the typed inner CInfo. The trailing `Strength` f32 (and the inner
+    /// CInfo's motor) are left for `block_size` recovery. FNV humanoid
+    /// ragdolls wrap 14 of their 17 joints this way, so a malleable-wrapped
+    /// Ragdoll surfaces identically to a bare one.
+    fn parse_fo3_malleable_inner(stream: &mut NifStream) -> io::Result<BhkConstraintData> {
+        let wrapped_type = stream.read_u32_le()?;
+        // Inner bhkConstraintCInfo — discard (entities are −1/−1).
+        let _inner = Self::parse_base(stream)?;
+        Ok(match wrapped_type {
+            7 => BhkConstraintData::Ragdoll(RagdollCInfo::parse_fo3(stream)?),
+            2 => BhkConstraintData::LimitedHinge(LimitedHingeCInfo::parse_fo3(stream)?),
+            _ => BhkConstraintData::Other,
+        })
     }
 
     /// Parse a constraint block by type name. On Oblivion, reads the
@@ -85,6 +226,7 @@ impl BhkConstraint {
                     entity_a,
                     entity_b,
                     priority,
+                    data: BhkConstraintData::Other,
                 });
             }
 
@@ -121,20 +263,36 @@ impl BhkConstraint {
                     entity_a,
                     entity_b,
                     priority,
+                    data: BhkConstraintData::Other,
                 });
             }
         }
 
-        // FO3+ (or unknown pre-Oblivion content): return after the
-        // 16-byte base. The outer parse_nif loop seeks past the rest
-        // using the header's block_sizes table, which is always present
-        // on v >= 20.2.0.7. The stub still preserves the RTTI name
-        // for telemetry.
+        // FO3+ (FNV/FO3, `!#NI_BS_LTE_16#`). For the two variants a
+        // humanoid ragdoll uses, decode the typed CInfo prefix
+        // (field order + sizes from nif.xml, cross-checked against the
+        // breakable-constraint byte tables below). The trailing
+        // `bhkConstraintMotorCInfo` is deliberately NOT consumed here:
+        // it's the last field of the struct, carries nothing slice 1
+        // needs, and the outer parse_nif loop absolute-seeks to the next
+        // block via the header's block_sizes table (always present on
+        // v >= 20.2.0.7) — so skipping the motor-type dispatch keeps a
+        // recoverable block from ever becoming a hard parse error on
+        // unexpected motor data. Every other type stays a name-only stub.
+        let data = match type_name {
+            "bhkRagdollConstraint" => BhkConstraintData::Ragdoll(RagdollCInfo::parse_fo3(stream)?),
+            "bhkLimitedHingeConstraint" => {
+                BhkConstraintData::LimitedHinge(LimitedHingeCInfo::parse_fo3(stream)?)
+            }
+            "bhkMalleableConstraint" => Self::parse_fo3_malleable_inner(stream)?,
+            _ => BhkConstraintData::Other,
+        };
         Ok(Self {
             type_name,
             entity_a,
             entity_b,
             priority,
+            data,
         })
     }
 }

--- a/crates/nif/src/blocks/collision/mod.rs
+++ b/crates/nif/src/blocks/collision/mod.rs
@@ -40,7 +40,9 @@ pub use collision_object::{
 pub use compressed_mesh::{
     BhkCompressedMeshShape, BhkCompressedMeshShapeData, CmsBigTri, CmsChunk, CmsTransform,
 };
-pub use constraints::{BhkBreakableConstraint, BhkConstraint};
+pub use constraints::{
+    BhkBreakableConstraint, BhkConstraint, BhkConstraintData, LimitedHingeCInfo, RagdollCInfo,
+};
 pub use phantom_action::{
     BhkAabbPhantom, BhkLiquidAction, BhkOrientHingedBodyAction, BhkSimpleShapePhantom,
 };
@@ -98,6 +100,8 @@ fn read_matrix3(stream: &mut NifStream) -> io::Result<[f32; 12]> {
 mod bhk_blend_collision_object_tests;
 #[cfg(test)]
 mod bhk_breakable_constraint_tests;
+#[cfg(test)]
+mod bhk_constraint_tests;
 #[cfg(test)]
 mod bhk_ragdoll_tests;
 #[cfg(test)]

--- a/crates/nif/src/import/collision.rs
+++ b/crates/nif/src/import/collision.rs
@@ -22,10 +22,14 @@
 //! [`NifScene`] (`havok_scale` field, populated by `havok_scale_for` at parse
 //! time) so consumers don't have to re-detect the game variant per call.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::blocks::collision::*;
 use crate::blocks::tri_shape::NiTriStripsData;
+use crate::import::types::{
+    ImportedJointKind, ImportedRagdoll, ImportedRagdollBody, ImportedRagdollConstraint,
+};
 use crate::scene::NifScene;
 use crate::types::BlockRef;
 
@@ -247,6 +251,154 @@ fn extract_from_phantom(
         ),
     }
     None
+}
+
+/// Scene-level extractor: assemble the Havok ragdoll articulation (the
+/// rigid bodies + the constraints linking them) into an engine-native
+/// [`ImportedRagdoll`]. Returns `None` unless the scene carries a real
+/// articulation — ≥2 bodies and ≥1 decoded Ragdoll/LimitedHinge joint;
+/// a lone static collider isn't a ragdoll.
+///
+/// Bodies are reached via the classic `BhkCollisionObject → BhkRigidBody`
+/// chain (the only decodable path; FO4+ NP-blob ragdolls are out of
+/// scope — see the module table). Each body's bone name is its host
+/// NiNode's name. Constraint entity refs are rigid-body *block* indices,
+/// remapped here to body-array indices. All geometry is Y-up + havok-
+/// scaled, reusing the same helpers as [`extract_from_classic`].
+pub fn extract_ragdoll(scene: &NifScene) -> Option<ImportedRagdoll> {
+    let scale = scene.havok_scale;
+    let body_to_bone = build_body_to_bone(scene);
+
+    // Collect skeletal rigid bodies in block order; map block idx → array idx
+    // so the constraints below can translate their entity refs.
+    let mut bodies = Vec::new();
+    let mut block_to_body: HashMap<usize, usize> = HashMap::new();
+    for (idx, block) in scene.blocks.iter().enumerate() {
+        let Some(body) = block.as_any().downcast_ref::<BhkRigidBody>() else {
+            continue;
+        };
+        // Only bodies hosted on a named bone take part in the ragdoll — a
+        // stray rigid body with no host bone can't be driven from / written
+        // back to a bone transform.
+        let Some(bone_name) = body_to_bone.get(&idx).cloned() else {
+            continue;
+        };
+        let mut visited = HashSet::new();
+        let Some(shape) = resolve_shape(scene, body.shape_ref, &mut visited) else {
+            continue;
+        };
+        block_to_body.insert(idx, bodies.len());
+        bodies.push(ImportedRagdollBody {
+            bone_name,
+            mass: body.mass,
+            linear_damping: body.linear_damping,
+            angular_damping: body.angular_damping,
+            friction: body.friction,
+            restitution: body.restitution,
+            shape,
+            translation: havok_to_engine(
+                body.translation[0],
+                body.translation[1],
+                body.translation[2],
+            ) * scale,
+            rotation: havok_quat_to_engine(body.rotation),
+        });
+    }
+    if bodies.len() < 2 {
+        return None;
+    }
+
+    let mut constraints = Vec::new();
+    for block in scene.blocks.iter() {
+        let Some(c) = block.as_any().downcast_ref::<BhkConstraint>() else {
+            continue;
+        };
+        let kind = match &c.data {
+            BhkConstraintData::Ragdoll(r) => ragdoll_joint(r, scale),
+            BhkConstraintData::LimitedHinge(h) => limited_hinge_joint(h, scale),
+            BhkConstraintData::Other => continue,
+        };
+        // Constraint entity refs point at the rigid-body blocks; remap to
+        // body-array indices. A ref to a body we skipped (no bone / shape
+        // failed) drops the joint gracefully.
+        let (Some(body_a), Some(body_b)) = (
+            c.entity_a.index().and_then(|i| block_to_body.get(&i).copied()),
+            c.entity_b.index().and_then(|i| block_to_body.get(&i).copied()),
+        ) else {
+            continue;
+        };
+        if body_a == body_b {
+            continue; // a joint must link two distinct bodies
+        }
+        constraints.push(ImportedRagdollConstraint {
+            body_a,
+            body_b,
+            kind,
+        });
+    }
+    if constraints.is_empty() {
+        return None;
+    }
+
+    Some(ImportedRagdoll { bodies, constraints })
+}
+
+/// Map each `BhkRigidBody` block index → the name of the bone NiNode that
+/// hosts it (via `NiNode.collision_ref → BhkCollisionObject.body_ref`).
+/// The reverse link doesn't exist in the NIF, so we scan AVObjects.
+fn build_body_to_bone(scene: &NifScene) -> HashMap<usize, Arc<str>> {
+    let mut map = HashMap::new();
+    for block in scene.blocks.iter() {
+        let Some(av) = block.as_av_object() else {
+            continue;
+        };
+        let Some(coll_idx) = av.collision_ref().index() else {
+            continue;
+        };
+        let Some(coll) = scene.get_as::<BhkCollisionObject>(coll_idx) else {
+            continue;
+        };
+        let Some(body_idx) = coll.body_ref.index() else {
+            continue;
+        };
+        if let Some(name) = av.name_arc() {
+            map.insert(body_idx, name.clone());
+        }
+    }
+    map
+}
+
+/// Direction-only Z-up→Y-up swap: axis swap with no translation and no
+/// havok scale (a unit direction's length must be preserved).
+fn havok_dir_to_engine(v: [f32; 4]) -> Vec3 {
+    havok_to_engine(v[0], v[1], v[2])
+}
+
+fn ragdoll_joint(r: &RagdollCInfo, scale: f32) -> ImportedJointKind {
+    ImportedJointKind::Ragdoll {
+        twist_a: havok_dir_to_engine(r.twist_a),
+        plane_a: havok_dir_to_engine(r.plane_a),
+        pivot_a: havok_to_engine(r.pivot_a[0], r.pivot_a[1], r.pivot_a[2]) * scale,
+        twist_b: havok_dir_to_engine(r.twist_b),
+        plane_b: havok_dir_to_engine(r.plane_b),
+        pivot_b: havok_to_engine(r.pivot_b[0], r.pivot_b[1], r.pivot_b[2]) * scale,
+        cone_max: r.cone_max_angle,
+        plane_min: r.plane_min_angle,
+        plane_max: r.plane_max_angle,
+        twist_min: r.twist_min_angle,
+        twist_max: r.twist_max_angle,
+    }
+}
+
+fn limited_hinge_joint(h: &LimitedHingeCInfo, scale: f32) -> ImportedJointKind {
+    ImportedJointKind::LimitedHinge {
+        axis_a: havok_dir_to_engine(h.axis_a),
+        pivot_a: havok_to_engine(h.pivot_a[0], h.pivot_a[1], h.pivot_a[2]) * scale,
+        axis_b: havok_dir_to_engine(h.axis_b),
+        pivot_b: havok_to_engine(h.pivot_b[0], h.pivot_b[1], h.pivot_b[2]) * scale,
+        min_angle: h.min_angle,
+        max_angle: h.max_angle,
+    }
 }
 
 /// Recursively resolve a bhk shape block into a CollisionShape enum.
@@ -1464,5 +1616,173 @@ mod dispatch_coverage_tests {
             "these bhk*Shape blocks are parse-dispatched but have NO resolve arm in \
              resolve_shape_inner — authored collision silently drops: {missing:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod ragdoll_extract_tests {
+    //! CI-runnable coverage for [`extract_ragdoll`] (M41.x Phase 2). The
+    //! real-data path (18-body FNV skeleton) is `crates/nif/tests/
+    //! ragdoll_import.rs`, `#[ignore]`; these synthetic scenes lock the
+    //! body-collection, host-bone mapping, constraint-remap, and
+    //! not-a-ragdoll gates without game data.
+    use super::*;
+    use crate::blocks::base::{NiAVObjectData, NiObjectNETData};
+    use crate::blocks::collision::{
+        BhkCollisionObject, BhkConstraint, BhkConstraintData, BhkRigidBody, BhkSphereShape,
+        RagdollCInfo,
+    };
+    use crate::blocks::node::NiNode;
+    use crate::blocks::NiObject;
+    use crate::types::NiTransform;
+
+    fn bone(name: &str, collision_ref: usize) -> Box<dyn NiObject> {
+        Box::new(NiNode {
+            av: NiAVObjectData {
+                net: NiObjectNETData {
+                    name: Some(Arc::from(name)),
+                    extra_data_refs: Vec::new(),
+                    controller_ref: BlockRef::NULL,
+                },
+                flags: 0,
+                transform: NiTransform::default(),
+                properties: Vec::new(),
+                collision_ref: BlockRef(collision_ref as u32),
+            },
+            children: Vec::new(),
+            effects: Vec::new(),
+        })
+    }
+
+    fn coll_obj(body_ref: usize) -> Box<dyn NiObject> {
+        Box::new(BhkCollisionObject {
+            target_ref: BlockRef::NULL,
+            flags: 0,
+            body_ref: BlockRef(body_ref as u32),
+        })
+    }
+
+    fn rigid_body(shape_ref: usize) -> Box<dyn NiObject> {
+        Box::new(BhkRigidBody {
+            shape_ref: BlockRef(shape_ref as u32),
+            havok_filter: 0,
+            translation: [0.0; 4],
+            rotation: [0.0, 0.0, 0.0, 1.0],
+            linear_velocity: [0.0; 4],
+            angular_velocity: [0.0; 4],
+            inertia_tensor: [0.0; 12],
+            center_of_mass: [0.0; 4],
+            mass: 5.0,
+            linear_damping: 0.1,
+            angular_damping: 0.05,
+            friction: 0.3,
+            restitution: 0.4,
+            max_linear_velocity: 0.0,
+            max_angular_velocity: 0.0,
+            penetration_depth: 0.0,
+            motion_type: 1,
+            deactivator_type: 0,
+            solver_deactivation: 0,
+            quality_type: 0,
+            constraint_refs: Vec::new(),
+            body_flags: 0,
+        })
+    }
+
+    fn sphere(radius: f32) -> Box<dyn NiObject> {
+        Box::new(BhkSphereShape {
+            material: 0,
+            radius,
+        })
+    }
+
+    fn ragdoll_constraint(entity_a: usize, entity_b: usize, pivot_a_x: f32) -> Box<dyn NiObject> {
+        Box::new(BhkConstraint {
+            type_name: "bhkRagdollConstraint",
+            entity_a: BlockRef(entity_a as u32),
+            entity_b: BlockRef(entity_b as u32),
+            priority: 1,
+            data: BhkConstraintData::Ragdoll(RagdollCInfo {
+                twist_a: [0.0, 0.0, 1.0, 0.0],
+                plane_a: [1.0, 0.0, 0.0, 0.0],
+                motor_a: [0.0; 4],
+                pivot_a: [pivot_a_x, 0.0, 0.0, 1.0],
+                twist_b: [0.0, 0.0, 1.0, 0.0],
+                plane_b: [1.0, 0.0, 0.0, 0.0],
+                motor_b: [0.0; 4],
+                pivot_b: [-pivot_a_x, 0.0, 0.0, 1.0],
+                cone_max_angle: 0.5,
+                plane_min_angle: -0.5,
+                plane_max_angle: 0.5,
+                twist_min_angle: -0.3,
+                twist_max_angle: 0.3,
+                max_friction: 0.0,
+            }),
+        })
+    }
+
+    /// Two bones, each with a capsule rigid body, joined by one Ragdoll
+    /// constraint → a 2-body / 1-joint graph with the right bone names,
+    /// remapped indices, and Y-up pivot.
+    #[test]
+    fn two_bone_ragdoll_extracts_graph() {
+        let mut scene = NifScene::default();
+        scene.havok_scale = 1.0;
+        scene.blocks.push(bone("Bip01 Pelvis", 1)); // [0]
+        scene.blocks.push(coll_obj(2)); // [1]
+        scene.blocks.push(rigid_body(3)); // [2]
+        scene.blocks.push(sphere(1.0)); // [3]
+        scene.blocks.push(bone("Bip01 Spine", 5)); // [4]
+        scene.blocks.push(coll_obj(6)); // [5]
+        scene.blocks.push(rigid_body(7)); // [6]
+        scene.blocks.push(sphere(1.0)); // [7]
+        scene.blocks.push(ragdoll_constraint(2, 6, 10.0)); // [8] refs rigid-body blocks
+
+        let r = extract_ragdoll(&scene).expect("two bodies + one joint must yield a ragdoll");
+        assert_eq!(r.bodies.len(), 2);
+        assert_eq!(r.bodies[0].bone_name.as_ref(), "Bip01 Pelvis");
+        assert_eq!(r.bodies[1].bone_name.as_ref(), "Bip01 Spine");
+        assert_eq!(r.bodies[0].mass, 5.0);
+
+        assert_eq!(r.constraints.len(), 1);
+        let c = &r.constraints[0];
+        // Block 2 → body 0, block 6 → body 1.
+        assert_eq!(c.body_a, 0);
+        assert_eq!(c.body_b, 1);
+        match &c.kind {
+            ImportedJointKind::Ragdoll { pivot_a, .. } => {
+                // Havok pivot (10,0,0) → engine (x,z,-y) = (10,0,0) at scale 1.
+                assert_eq!(*pivot_a, Vec3::new(10.0, 0.0, 0.0));
+            }
+            other => panic!("expected Ragdoll joint, got {other:?}"),
+        }
+    }
+
+    /// A single body (no second body, no joint) is not a ragdoll.
+    #[test]
+    fn single_body_is_not_a_ragdoll() {
+        let mut scene = NifScene::default();
+        scene.havok_scale = 1.0;
+        scene.blocks.push(bone("Bip01 Pelvis", 1)); // [0]
+        scene.blocks.push(coll_obj(2)); // [1]
+        scene.blocks.push(rigid_body(3)); // [2]
+        scene.blocks.push(sphere(1.0)); // [3]
+        assert!(extract_ragdoll(&scene).is_none());
+    }
+
+    /// Two bodies but no constraint linking them → not a ragdoll.
+    #[test]
+    fn bodies_without_joints_is_not_a_ragdoll() {
+        let mut scene = NifScene::default();
+        scene.havok_scale = 1.0;
+        scene.blocks.push(bone("Bip01 Pelvis", 1)); // [0]
+        scene.blocks.push(coll_obj(2)); // [1]
+        scene.blocks.push(rigid_body(3)); // [2]
+        scene.blocks.push(sphere(1.0)); // [3]
+        scene.blocks.push(bone("Bip01 Spine", 5)); // [4]
+        scene.blocks.push(coll_obj(6)); // [5]
+        scene.blocks.push(rigid_body(7)); // [6]
+        scene.blocks.push(sphere(1.0)); // [7]
+        assert!(extract_ragdoll(&scene).is_none());
     }
 }

--- a/crates/nif/src/import/mod.rs
+++ b/crates/nif/src/import/mod.rs
@@ -138,6 +138,7 @@ fn import_nif_scene_impl(
         attach_points: None,
         child_attach_connections: None,
         embedded_clip: crate::anim::import_embedded_animations(scene),
+        ragdoll: collision::extract_ragdoll(scene),
     };
 
     // A truncated scene means at least one block was lost to a mid-parse

--- a/crates/nif/src/import/types.rs
+++ b/crates/nif/src/import/types.rs
@@ -12,6 +12,7 @@
 
 use super::material::{BsEffectShaderData, NoLightingFalloff, ShaderTypeFields};
 use byroredux_core::ecs::components::collision::{CollisionShape, RigidBodyData};
+use byroredux_core::math::{Quat, Vec3};
 use byroredux_core::string::FixedString;
 use std::sync::Arc;
 
@@ -1034,6 +1035,84 @@ pub struct ImportedScene {
     /// `None` when the NIF authored no such controllers — most
     /// non-FX/non-water meshes. See #261.
     pub embedded_clip: Option<crate::anim::AnimationClip>,
+    /// Havok ragdoll articulation (rigid bodies + the constraints linking
+    /// them) extracted from the classic `BhkRigidBody` chain, when the
+    /// scene carries a real one (≥2 bodies + ≥1 decoded joint). `None`
+    /// for non-skeletal NIFs and for FO4+ NP-blob ragdolls (not yet
+    /// decodable). Consumed by the engine to build a Rapier multibody and
+    /// drive Bethesda ragdolls on our own solver (M41.x).
+    pub ragdoll: Option<ImportedRagdoll>,
+}
+
+/// A Havok ragdoll articulation, engine-native (Y-up, havok-scaled).
+///
+/// `bodies` and `constraints` form a kinematic tree: each constraint
+/// links two `bodies` by array index. Built by
+/// [`crate::import::collision::extract_ragdoll`] from the NIF's
+/// `BhkRigidBody` + `BhkConstraint` blocks. See M41.x.
+#[derive(Debug, Clone)]
+pub struct ImportedRagdoll {
+    pub bodies: Vec<ImportedRagdollBody>,
+    pub constraints: Vec<ImportedRagdollConstraint>,
+}
+
+/// One rigid body of a ragdoll, hosted on a skeleton bone.
+#[derive(Debug, Clone)]
+pub struct ImportedRagdollBody {
+    /// Host bone name (the NiNode that carries this body's collision
+    /// object). The engine resolves it to the bone `EntityId` to seed and
+    /// write back the simulated pose.
+    pub bone_name: Arc<str>,
+    pub mass: f32,
+    pub linear_damping: f32,
+    pub angular_damping: f32,
+    pub friction: f32,
+    pub restitution: f32,
+    /// Collider shape in body-local space (Y-up, havok-scaled).
+    pub shape: CollisionShape,
+    /// Rigid-body origin offset relative to the host bone (Y-up, scaled).
+    pub translation: Vec3,
+    /// Rigid-body orientation relative to the host bone (Y-up).
+    pub rotation: Quat,
+}
+
+/// One joint linking two ragdoll bodies (indices into
+/// [`ImportedRagdoll::bodies`]).
+#[derive(Debug, Clone)]
+pub struct ImportedRagdollConstraint {
+    pub body_a: usize,
+    pub body_b: usize,
+    pub kind: ImportedJointKind,
+}
+
+/// Joint geometry, converted to engine space. Pivots are positions
+/// (Y-up, scaled); axes are unit directions (Y-up, unscaled). Angles are
+/// radians, passed through from Havok.
+#[derive(Debug, Clone)]
+pub enum ImportedJointKind {
+    /// 3-DOF cone/twist ball joint (`bhkRagdollConstraint`).
+    Ragdoll {
+        twist_a: Vec3,
+        plane_a: Vec3,
+        pivot_a: Vec3,
+        twist_b: Vec3,
+        plane_b: Vec3,
+        pivot_b: Vec3,
+        cone_max: f32,
+        plane_min: f32,
+        plane_max: f32,
+        twist_min: f32,
+        twist_max: f32,
+    },
+    /// 1-DOF angle-limited hinge (`bhkLimitedHingeConstraint`).
+    LimitedHinge {
+        axis_a: Vec3,
+        pivot_a: Vec3,
+        axis_b: Vec3,
+        pivot_b: Vec3,
+        min_angle: f32,
+        max_angle: f32,
+    },
 }
 
 /// One particle emitter discovered while walking the NIF scene graph.

--- a/crates/nif/src/import/walk/tests.rs
+++ b/crates/nif/src/import/walk/tests.rs
@@ -583,6 +583,7 @@ mod recursion_depth_tests {
             attach_points: None,
             child_attach_connections: None,
             embedded_clip: None,
+            ragdoll: None,
         }
     }
 

--- a/crates/nif/tests/ragdoll_import.rs
+++ b/crates/nif/tests/ragdoll_import.rs
@@ -1,0 +1,93 @@
+//! Real-data validation for M41.x Phase 2 — the FNV humanoid skeleton's
+//! Havok ragdoll must thread end-to-end into `ImportedScene.ragdoll`:
+//! 18 capsule bodies + 17 joints (3 bare `bhkRagdollConstraint` + 14
+//! `bhkMalleableConstraint` wrapping a Ragdoll), all decoded as Ragdoll
+//! joints, every body resolving a bone name + shape.
+//!
+//! `#[ignore]` because it needs vanilla FNV game data; run with
+//! `cargo test -p byroredux-nif --test ragdoll_import -- --ignored --nocapture`.
+
+mod common;
+
+use common::{open_mesh_archive, Game};
+
+use byroredux_core::string::StringPool;
+use byroredux_nif::import::{import_nif_scene, ImportedJointKind};
+use byroredux_nif::parse_nif;
+
+const SKELETON_PATH: &str = r"meshes\characters\_male\skeleton.nif";
+
+#[test]
+#[ignore]
+fn fnv_humanoid_skeleton_threads_ragdoll() {
+    let Some(archive) = open_mesh_archive(Game::FalloutNV) else {
+        return;
+    };
+    let bytes = archive
+        .extract(SKELETON_PATH)
+        .expect("FNV mesh archive must contain _male/skeleton.nif");
+    let scene = parse_nif(&bytes).expect("skeleton.nif must parse");
+    let mut pool = StringPool::new();
+    let imported = import_nif_scene(&scene, &mut pool);
+
+    let ragdoll = imported
+        .ragdoll
+        .expect("FNV humanoid skeleton must thread a ragdoll articulation");
+
+    eprintln!(
+        "FNV _male skeleton ragdoll: {} bodies, {} joints",
+        ragdoll.bodies.len(),
+        ragdoll.constraints.len(),
+    );
+    let names: Vec<&str> = ragdoll.bodies.iter().map(|b| b.bone_name.as_ref()).collect();
+    eprintln!("ragdoll bones: {names:?}");
+
+    // Vanilla FNV _male skeleton: 18 capsule bodies, 17 joints.
+    assert_eq!(ragdoll.bodies.len(), 18, "expected 18 ragdoll bodies");
+    assert_eq!(ragdoll.constraints.len(), 17, "expected 17 joints");
+
+    for b in &ragdoll.bodies {
+        assert!(!b.bone_name.is_empty(), "ragdoll body missing a bone name");
+        assert!(b.mass >= 0.0, "negative mass on {}", b.bone_name);
+    }
+    for c in &ragdoll.constraints {
+        assert!(
+            c.body_a < ragdoll.bodies.len() && c.body_b < ragdoll.bodies.len(),
+            "joint references an out-of-range body",
+        );
+        assert_ne!(c.body_a, c.body_b, "joint links a body to itself");
+    }
+
+    // Every joint decodes to a real kind — the `constraints` vec only holds
+    // successfully-decoded Ragdoll/LimitedHinge (Other is dropped), so a
+    // count of 17 already means none silently dropped. The FNV humanoid is
+    // a mix: ball-joints for spine/neck/shoulders/hips (Ragdoll) and
+    // angle-limited hinges for elbows/knees (LimitedHinge) — both reached
+    // through the malleable wrapper.
+    let ragdoll_joints = ragdoll
+        .constraints
+        .iter()
+        .filter(|c| matches!(c.kind, ImportedJointKind::Ragdoll { .. }))
+        .count();
+    let hinge_joints = ragdoll
+        .constraints
+        .iter()
+        .filter(|c| matches!(c.kind, ImportedJointKind::LimitedHinge { .. }))
+        .count();
+    eprintln!("joints: {ragdoll_joints} Ragdoll + {hinge_joints} LimitedHinge");
+    assert_eq!(
+        ragdoll_joints + hinge_joints,
+        17,
+        "every joint must decode to Ragdoll or LimitedHinge, none dropped",
+    );
+    assert!(
+        hinge_joints > 0,
+        "FNV humanoid elbows/knees should decode as LimitedHinge",
+    );
+
+    // Bone names round-trip (sanity that the host-NiNode mapping works).
+    assert!(
+        names.iter().any(|n| n.contains("Bip01") || n.contains("Spine")),
+        "expected a Bip01/Spine bone among {names:?}",
+    );
+}

--- a/crates/physics/src/components.rs
+++ b/crates/physics/src/components.rs
@@ -1,8 +1,8 @@
 //! ECS components carrying Rapier handles.
 
 use byroredux_core::ecs::sparse_set::SparseSetStorage;
-use byroredux_core::ecs::storage::Component;
-use rapier3d::prelude::{ColliderHandle, RigidBodyHandle};
+use byroredux_core::ecs::storage::{Component, EntityId};
+use rapier3d::prelude::{ColliderHandle, MultibodyJointHandle, RigidBodyHandle};
 
 /// Handles into the `PhysicsWorld` Rapier sets for one simulated entity.
 ///
@@ -140,6 +140,27 @@ impl CharacterController {
 }
 
 impl Component for CharacterController {
+    type Storage = SparseSetStorage<Self>;
+}
+
+/// An active Havok ragdoll running on our Rapier solver (M41.x).
+///
+/// Attached to the actor (placement) entity by the `ragdoll` console
+/// command via [`crate::ragdoll::build_ragdoll`]. Holds the mapping from
+/// each skeleton bone `EntityId` to its Rapier rigid body so the
+/// per-frame writeback can copy simulated poses back onto the bone
+/// entities (which the skinned mesh already reads). `joints` is retained
+/// only for teardown bookkeeping; removal cascades through
+/// [`crate::world::PhysicsWorld::remove_ragdoll`].
+#[derive(Debug, Clone)]
+pub struct Ragdoll {
+    /// `(bone entity, rapier body)` for every ragdoll body, in build order.
+    pub bodies: Vec<(EntityId, RigidBodyHandle)>,
+    /// Multibody joint handles created for this ragdoll.
+    pub joints: Vec<MultibodyJointHandle>,
+}
+
+impl Component for Ragdoll {
     type Storage = SparseSetStorage<Self>;
 }
 

--- a/crates/physics/src/config.rs
+++ b/crates/physics/src/config.rs
@@ -71,6 +71,13 @@ pub struct ContactConfig {
     /// `KinematicCharacterController.offset` distance in BU. Was 4.0
     /// before unification.
     pub kcc_offset_bu: f32,
+
+    /// Extra angular damping added to every ragdoll body on top of the
+    /// authored Havok value (M41.x). The single biggest "less floppy /
+    /// less clunky than the original Havok ragdoll" lever — raise it to
+    /// settle limbs faster. `0.0` = pure Havok-authored damping (inert
+    /// default); ~1–3 gives a noticeably calmer death/hit ragdoll.
+    pub ragdoll_extra_angular_damping: f32,
 }
 
 impl ContactConfig {
@@ -78,6 +85,7 @@ impl ContactConfig {
         trimesh_flags: TriMeshFlagBits::DEFAULT,
         default_contact_skin_bu: 1.0,
         kcc_offset_bu: 4.0,
+        ragdoll_extra_angular_damping: 0.0,
     };
 }
 

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -19,10 +19,14 @@
 pub mod components;
 pub mod config;
 pub mod convert;
+pub mod ragdoll;
 pub mod sync;
 pub mod world;
 
-pub use components::{CharacterController, RapierHandles};
+pub use components::{CharacterController, Ragdoll, RapierHandles};
 pub use config::{ContactConfig, TriMeshFlagBits};
+pub use ragdoll::{
+    build_ragdoll, RagdollBodySpec, RagdollConstraintSpec, RagdollJointSpec, RagdollSpec,
+};
 pub use sync::{physics_sync_system, set_kinematic_translation, set_linear_velocity};
 pub use world::{CharacterMoveParams, CharacterMoveResult, PhysicsWorld, PHYSICS_DT};

--- a/crates/physics/src/ragdoll.rs
+++ b/crates/physics/src/ragdoll.rs
@@ -1,0 +1,458 @@
+//! Build a Rapier **multibody** ragdoll from an engine-native
+//! [`RagdollSpec`] (M41.x Phase 3).
+//!
+//! The spec is the glam-native form of the NIF importer's
+//! `ImportedRagdoll`, resolved against the live bone world transforms at
+//! activation time (the byroredux binary does that translation — this
+//! crate never sees `byroredux-nif`). Here we turn it into Rapier rigid
+//! bodies + colliders, orient the constraint graph into a kinematic tree,
+//! and connect it with reduced-coordinate **multibody joints**.
+//!
+//! Why multibody, not impulse joints: a ragdoll is a pelvis-rooted tree
+//! (no loops), exactly Rapier's reduced-coordinate sweet spot. Multibody
+//! joints are constraint-by-construction, so the links can't visibly
+//! stretch/separate under stress at the mass ratios and chain depth of a
+//! humanoid — the artifact that makes the original Havok ragdolls feel
+//! clunky. The trade-off (no closed loops) doesn't bite: humanoid
+//! ragdolls are pure trees.
+//!
+//! Joint-limit fidelity is approximate for slice 1: Havok's cone + two
+//! plane-angle model doesn't map 1:1 onto Rapier's per-axis angular
+//! limits, so we apply twist→twist-axis and cone→both swing axes. Good
+//! enough to switch an actor from bind-pose to a plausible ragdoll;
+//! refinement is a follow-up.
+
+use crate::components::Ragdoll;
+use crate::config::ContactConfig;
+use crate::convert::{collision_shape_to_parts, iso_from_trs, quat_from_na, vec3_from_na};
+use crate::world::PhysicsWorld;
+use byroredux_core::ecs::components::collision::CollisionShape;
+use byroredux_core::ecs::storage::EntityId;
+use byroredux_core::math::{Mat3, Quat, Vec3};
+use rapier3d::prelude::*;
+use std::collections::VecDeque;
+
+/// One rigid body of a ragdoll, already resolved to engine world space.
+#[derive(Debug, Clone)]
+pub struct RagdollBodySpec {
+    /// The skeleton bone entity this body drives (for writeback).
+    pub entity: EntityId,
+    /// World-space seed pose (bone world × body-local offset).
+    pub translation: Vec3,
+    pub rotation: Quat,
+    /// Collider shape in body-local space (Y-up, havok-scaled).
+    pub shape: CollisionShape,
+    pub mass: f32,
+    pub linear_damping: f32,
+    pub angular_damping: f32,
+    pub friction: f32,
+    pub restitution: f32,
+}
+
+/// Joint geometry in engine space. Pivots are body-local positions; axes
+/// are body-local unit directions; angles are radians.
+#[derive(Debug, Clone)]
+pub enum RagdollJointSpec {
+    Ragdoll {
+        twist_a: Vec3,
+        plane_a: Vec3,
+        pivot_a: Vec3,
+        twist_b: Vec3,
+        plane_b: Vec3,
+        pivot_b: Vec3,
+        cone_max: f32,
+        twist_min: f32,
+        twist_max: f32,
+    },
+    LimitedHinge {
+        axis_a: Vec3,
+        pivot_a: Vec3,
+        axis_b: Vec3,
+        pivot_b: Vec3,
+        min_angle: f32,
+        max_angle: f32,
+    },
+}
+
+/// One joint linking two bodies by index into [`RagdollSpec::bodies`].
+#[derive(Debug, Clone)]
+pub struct RagdollConstraintSpec {
+    pub body_a: usize,
+    pub body_b: usize,
+    pub joint: RagdollJointSpec,
+}
+
+/// The full articulation, ready to build.
+#[derive(Debug, Clone)]
+pub struct RagdollSpec {
+    pub bodies: Vec<RagdollBodySpec>,
+    pub constraints: Vec<RagdollConstraintSpec>,
+}
+
+/// Build the ragdoll into `pw` and return the [`Ragdoll`] component for
+/// the actor. Creates one dynamic body + collider per spec body, orients
+/// the constraint graph into a tree, and inserts a multibody joint per
+/// edge. Calls [`PhysicsWorld::wake`] so the first step simulates it.
+pub fn build_ragdoll(pw: &mut PhysicsWorld, spec: &RagdollSpec, cfg: &ContactConfig) -> Ragdoll {
+    // 1. Rigid bodies + colliders.
+    let mut handles: Vec<RigidBodyHandle> = Vec::with_capacity(spec.bodies.len());
+    for b in &spec.bodies {
+        let body = RigidBodyBuilder::dynamic()
+            .position(iso_from_trs(b.translation, b.rotation))
+            .linear_damping(b.linear_damping.max(0.0))
+            .angular_damping(b.angular_damping.max(0.0))
+            .build();
+        let h = pw.bodies.insert(body);
+
+        let parts = collision_shape_to_parts(&b.shape, cfg);
+        let part_mass = b.mass.max(1e-3) / parts.len() as f32;
+        let PhysicsWorld {
+            ref mut bodies,
+            ref mut colliders,
+            ..
+        } = *pw;
+        for (iso, shape) in parts {
+            let col = ColliderBuilder::new(shape)
+                .position(iso)
+                .friction(b.friction.max(0.0))
+                .restitution(b.restitution.clamp(0.0, 1.0))
+                .mass(part_mass)
+                .build();
+            colliders.insert_with_parent(col, h, bodies);
+        }
+        handles.push(h);
+    }
+
+    // 2. Orient the (undirected) constraint graph into a parent→child tree
+    //    via BFS, handling a forest if the graph is disconnected. Back-edges
+    //    (which would form a loop multibody can't represent) are dropped.
+    let oriented = orient_tree(spec);
+
+    // 3. Insert one multibody joint per tree edge (parent already in the
+    //    multibody from BFS order; the root is the multibody base).
+    let mut joints = Vec::with_capacity(oriented.len());
+    for edge in &oriented {
+        let joint = build_joint(&spec.constraints[edge.constraint].joint, edge.flip);
+        if let Some(jh) =
+            pw.multibody_joints
+                .insert(handles[edge.parent], handles[edge.child], joint, true)
+        {
+            joints.push(jh);
+        } else {
+            log::warn!(
+                "ragdoll: multibody joint {}→{} rejected (would form a loop?) — skipped",
+                edge.parent,
+                edge.child,
+            );
+        }
+    }
+
+    pw.wake();
+
+    Ragdoll {
+        bodies: spec
+            .bodies
+            .iter()
+            .map(|b| b.entity)
+            .zip(handles)
+            .collect(),
+        joints,
+    }
+}
+
+/// A tree edge after orientation: `flip` is true when the constraint's
+/// `body_a` is the *child* (so frame A/B and pivots must swap).
+struct TreeEdge {
+    parent: usize,
+    child: usize,
+    constraint: usize,
+    flip: bool,
+}
+
+/// BFS-orient the constraint graph into a rooted tree (forest-safe).
+fn orient_tree(spec: &RagdollSpec) -> Vec<TreeEdge> {
+    let n = spec.bodies.len();
+    let mut adj: Vec<Vec<(usize, usize)>> = vec![Vec::new(); n];
+    for (ci, c) in spec.constraints.iter().enumerate() {
+        if c.body_a < n && c.body_b < n {
+            adj[c.body_a].push((c.body_b, ci));
+            adj[c.body_b].push((c.body_a, ci));
+        }
+    }
+    let mut visited = vec![false; n];
+    let mut used = vec![false; spec.constraints.len()];
+    let mut out = Vec::new();
+    let mut queue = VecDeque::new();
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        visited[start] = true;
+        queue.push_back(start);
+        while let Some(p) = queue.pop_front() {
+            for &(child, ci) in &adj[p] {
+                if used[ci] || visited[child] {
+                    continue;
+                }
+                used[ci] = true;
+                visited[child] = true;
+                out.push(TreeEdge {
+                    parent: p,
+                    child,
+                    constraint: ci,
+                    // parent p is body_b ⇒ a is the child ⇒ flip.
+                    flip: spec.constraints[ci].body_a == child,
+                });
+                queue.push_back(child);
+            }
+        }
+    }
+    out
+}
+
+/// All three linear DOF — locked for both ragdoll and hinge joints.
+fn lin_locked() -> JointAxesMask {
+    JointAxesMask::LIN_X | JointAxesMask::LIN_Y | JointAxesMask::LIN_Z
+}
+
+fn build_joint(j: &RagdollJointSpec, flip: bool) -> GenericJoint {
+    match j {
+        RagdollJointSpec::Ragdoll {
+            twist_a,
+            plane_a,
+            pivot_a,
+            twist_b,
+            plane_b,
+            pivot_b,
+            cone_max,
+            twist_min,
+            twist_max,
+        } => {
+            // Orient so frame1 is the parent's. Under flip the twist axis
+            // direction reverses, so the twist limit range negates+swaps.
+            let (t1, p1, pv1, t2, p2, pv2, tmin, tmax) = if !flip {
+                (
+                    *twist_a, *plane_a, *pivot_a, *twist_b, *plane_b, *pivot_b, *twist_min, *twist_max,
+                )
+            } else {
+                (
+                    *twist_b, *plane_b, *pivot_b, *twist_a, *plane_a, *pivot_a, -*twist_max,
+                    -*twist_min,
+                )
+            };
+            let cone = cone_max.abs();
+            GenericJointBuilder::new(lin_locked())
+                .local_frame1(iso_from_trs(pv1, frame_rot(t1, p1)))
+                .local_frame2(iso_from_trs(pv2, frame_rot(t2, p2)))
+                .limits(JointAxis::AngX, [tmin, tmax]) // twist
+                .limits(JointAxis::AngY, [-cone, cone]) // swing
+                .limits(JointAxis::AngZ, [-cone, cone]) // swing
+                .build()
+        }
+        RagdollJointSpec::LimitedHinge {
+            axis_a,
+            pivot_a,
+            axis_b,
+            pivot_b,
+            min_angle,
+            max_angle,
+        } => {
+            let (a1, pv1, a2, pv2, amin, amax) = if !flip {
+                (*axis_a, *pivot_a, *axis_b, *pivot_b, *min_angle, *max_angle)
+            } else {
+                (*axis_b, *pivot_b, *axis_a, *pivot_a, -*max_angle, -*min_angle)
+            };
+            // No authored perp on the hinge spec (slice 1) — synthesize one
+            // orthogonal to the axis. The hinge still rotates about the
+            // correct axis; only the limit's zero-reference is offset.
+            GenericJointBuilder::new(
+                lin_locked() | JointAxesMask::ANG_Y | JointAxesMask::ANG_Z,
+            )
+            .local_frame1(iso_from_trs(pv1, frame_rot(a1, any_perp(a1))))
+            .local_frame2(iso_from_trs(pv2, frame_rot(a2, any_perp(a2))))
+            .limits(JointAxis::AngX, [amin, amax])
+            .build()
+        }
+    }
+}
+
+/// Build a rotation whose local X = `primary`, local Y = `secondary`
+/// orthogonalised against X, local Z = X×Y. Falls back to identity-ish
+/// bases for degenerate (zero / parallel) inputs so a corrupt joint can't
+/// produce a NaN frame.
+fn frame_rot(primary: Vec3, secondary: Vec3) -> Quat {
+    let x = norm_or(primary, Vec3::X);
+    let mut y = secondary - x * x.dot(secondary);
+    y = norm_or(y, any_perp(x));
+    let z = x.cross(y).normalize_or_zero();
+    if z.length_squared() < 1e-8 {
+        return Quat::IDENTITY;
+    }
+    Quat::from_mat3(&Mat3::from_cols(x, y, z)).normalize()
+}
+
+#[inline]
+fn norm_or(v: Vec3, fallback: Vec3) -> Vec3 {
+    let n = v.normalize_or_zero();
+    if n.length_squared() < 1e-8 {
+        fallback
+    } else {
+        n
+    }
+}
+
+/// Any unit vector orthogonal to `axis`.
+fn any_perp(axis: Vec3) -> Vec3 {
+    let a = axis.normalize_or_zero();
+    let seed = if a.x.abs() < 0.9 { Vec3::X } else { Vec3::Y };
+    (seed - a * a.dot(seed)).normalize_or_zero()
+}
+
+impl PhysicsWorld {
+    /// Tear down a ragdoll: remove every member body (which cascades its
+    /// colliders + multibody joints out of the sets). Mirrors the #1520
+    /// no-leak discipline so a cell unload mid-ragdoll doesn't strand
+    /// bodies in the broad-phase. Safe to call with stale handles.
+    pub fn remove_ragdoll(&mut self, ragdoll: &Ragdoll) {
+        for (_, h) in &ragdoll.bodies {
+            self.remove_body(*h);
+        }
+    }
+}
+
+/// Helper for callers/tests: a body's current world translation, if live.
+pub fn body_translation(pw: &PhysicsWorld, h: RigidBodyHandle) -> Option<Vec3> {
+    pw.bodies.get(h).map(|b| vec3_from_na(*b.translation()))
+}
+
+/// Helper for the per-frame writeback: a body's current world
+/// (translation, rotation), if live.
+pub fn body_pose(pw: &PhysicsWorld, h: RigidBodyHandle) -> Option<(Vec3, Quat)> {
+    pw.bodies.get(h).map(|b| {
+        let iso = b.position();
+        (vec3_from_na(iso.translation.vector), quat_from_na(iso.rotation))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::PHYSICS_DT;
+
+    fn ball_body(entity_idx: EntityId, x: f32, y: f32) -> RagdollBodySpec {
+        RagdollBodySpec {
+            entity: entity_idx,
+            translation: Vec3::new(x, y, 0.0),
+            rotation: Quat::IDENTITY,
+            shape: CollisionShape::Ball { radius: 5.0 },
+            mass: 4.0,
+            linear_damping: 0.05,
+            angular_damping: 0.05,
+            friction: 0.5,
+            restitution: 0.0,
+        }
+    }
+
+    fn loose_ragdoll(a: usize, b: usize) -> RagdollConstraintSpec {
+        RagdollConstraintSpec {
+            body_a: a,
+            body_b: b,
+            joint: RagdollJointSpec::Ragdoll {
+                twist_a: Vec3::X,
+                plane_a: Vec3::Y,
+                pivot_a: Vec3::new(25.0, 0.0, 0.0),
+                twist_b: Vec3::X,
+                plane_b: Vec3::Y,
+                pivot_b: Vec3::new(-25.0, 0.0, 0.0),
+                cone_max: std::f32::consts::PI,
+                twist_min: -std::f32::consts::PI,
+                twist_max: std::f32::consts::PI,
+            },
+        }
+    }
+
+    /// A 3-body horizontal chain hung from a pinned root: under gravity it
+    /// swings down (the far body falls) but the multibody joints keep it
+    /// connected (its distance from the root stays bounded by the chain
+    /// length — a free body would fall away unboundedly). Proves the
+    /// build + joints + solver are structurally sound, headless.
+    #[test]
+    fn ragdoll_chain_swings_but_stays_jointed() {
+        let mut pw = PhysicsWorld::new();
+        let spec = RagdollSpec {
+            bodies: vec![
+                ball_body(1, 0.0, 1000.0),
+                ball_body(2, 50.0, 1000.0),
+                ball_body(3, 100.0, 1000.0),
+            ],
+            constraints: vec![loose_ragdoll(0, 1), loose_ragdoll(1, 2)],
+        };
+        let rag = build_ragdoll(&mut pw, &spec, &ContactConfig::DEFAULT);
+        assert_eq!(rag.bodies.len(), 3);
+        assert_eq!(rag.joints.len(), 2, "two multibody joints created");
+
+        // Pin the root so the chain hangs/swings instead of free-falling
+        // as a rigid unit (which would preserve distances trivially).
+        let h_root = rag.bodies[0].1;
+        pw.bodies[h_root].set_body_type(RigidBodyType::Fixed, true);
+        pw.wake();
+
+        let root = body_translation(&pw, h_root).unwrap();
+        let h_far = rag.bodies[2].1;
+        let init_far = body_translation(&pw, h_far).unwrap();
+        let init_dist = (init_far - root).length();
+
+        for _ in 0..180 {
+            pw.step(PHYSICS_DT);
+        }
+
+        let end_far = body_translation(&pw, h_far).unwrap();
+        assert!(end_far.is_finite(), "solver exploded: {end_far:?}");
+        // Swung/fell under gravity.
+        assert!(
+            end_far.y < init_far.y - 1.0,
+            "far body should fall under gravity: {} → {}",
+            init_far.y,
+            end_far.y
+        );
+        // Still jointed — can't drift far beyond the rest chain length.
+        let end_dist = (end_far - root).length();
+        assert!(
+            end_dist < init_dist * 1.5 + 20.0,
+            "chain separated (joints not holding): {init_dist} → {end_dist}"
+        );
+    }
+
+    /// Forest orientation: two disjoint 2-body chains both build without a
+    /// shared root, producing 2 joints total and no panic.
+    #[test]
+    fn disconnected_forest_orients_each_component() {
+        let spec = RagdollSpec {
+            bodies: vec![
+                ball_body(1, 0.0, 0.0),
+                ball_body(2, 50.0, 0.0),
+                ball_body(3, 500.0, 0.0),
+                ball_body(4, 550.0, 0.0),
+            ],
+            constraints: vec![loose_ragdoll(0, 1), loose_ragdoll(2, 3)],
+        };
+        let edges = orient_tree(&spec);
+        assert_eq!(edges.len(), 2, "both components contribute one edge");
+    }
+
+    /// A cyclic graph (triangle) drops the back-edge so the multibody tree
+    /// stays acyclic.
+    #[test]
+    fn cycle_drops_back_edge() {
+        let spec = RagdollSpec {
+            bodies: vec![
+                ball_body(1, 0.0, 0.0),
+                ball_body(2, 50.0, 0.0),
+                ball_body(3, 100.0, 0.0),
+            ],
+            constraints: vec![loose_ragdoll(0, 1), loose_ragdoll(1, 2), loose_ragdoll(2, 0)],
+        };
+        let edges = orient_tree(&spec);
+        assert_eq!(edges.len(), 2, "3-body cycle → spanning tree of 2 edges");
+    }
+}

--- a/crates/physics/src/ragdoll.rs
+++ b/crates/physics/src/ragdoll.rs
@@ -100,7 +100,10 @@ pub fn build_ragdoll(pw: &mut PhysicsWorld, spec: &RagdollSpec, cfg: &ContactCon
         let body = RigidBodyBuilder::dynamic()
             .position(iso_from_trs(b.translation, b.rotation))
             .linear_damping(b.linear_damping.max(0.0))
-            .angular_damping(b.angular_damping.max(0.0))
+            // "less floppy than Havok" lever — extra angular damping on top
+            // of the authored value (inert at the 0.0 default). See
+            // ContactConfig::ragdoll_extra_angular_damping.
+            .angular_damping(b.angular_damping.max(0.0) + cfg.ragdoll_extra_angular_damping.max(0.0))
             .build();
         let h = pw.bodies.insert(body);
 

--- a/crates/spt/src/import/mod.rs
+++ b/crates/spt/src/import/mod.rs
@@ -180,6 +180,8 @@ pub fn import_spt_scene(
         attach_points: None,
         child_attach_connections: None,
         embedded_clip: None,
+        // SpeedTree placeholder billboards carry no Havok ragdoll.
+        ragdoll: None,
     }
 }
 

--- a/docs/smoke-tests/m41-ragdoll.sh
+++ b/docs/smoke-tests/m41-ragdoll.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# M41.x ragdoll smoke test — verify a Bethesda/Havok ragdoll parses,
+# threads, builds on our Rapier solver, and activates end-to-end on a
+# real FNV humanoid (Doc Mitchell in GSDocMitchellHouse).
+#
+# What the engine does at cell load (no command needed):
+#   - parses the FNV `_male/skeleton.nif` Havok ragdoll (18 bodies + 17
+#     joints: bhkRagdoll + bhkMalleableConstraint-wrapped),
+#   - threads it into ImportedScene.ragdoll,
+#   - resolves bone names against the spawned skeleton and attaches a
+#     `RagdollTemplate` to the actor root — logging
+#     `Attached RagdollTemplate (N bodies) to root entity <ID>`.
+#
+# This script then drives the activation:
+#   1. Spawn the engine under `--bench-frames N --bench-hold`.
+#   2. Wait for `bench-hold:`.
+#   3. Scrape the attach log for the root entity id + body count.
+#   4. Pipe `ragdoll <id>` into byro-dbg; the command builds the Rapier
+#      multibody and returns `now simulating <N> bodies`.
+#   5. Hard-assert: a template attached, the command reported >= MIN_BODIES,
+#      and the engine stayed up (bench summary present → no solver blow-up).
+#
+# The VISUAL payoff (Doc Mitchell crumpling) is watched live; this script
+# is the automatable gate that keeps the parse→build→activate chain honest.
+#
+# Usage:
+#   docs/smoke-tests/m41-ragdoll.sh
+#
+# Exit: 0 on success, non-zero on any failed hard assertion.
+
+set -euo pipefail
+
+FNV_DATA="${BYROREDUX_FNV_DATA:-/mnt/data/SteamLibrary/steamapps/common/Fallout New Vegas/Data}"
+PORT="${BYRO_DEBUG_PORT:-9876}"
+BENCH_FRAMES="${BYROREDUX_SMOKE_FRAMES:-30}"
+CELL="${BYROREDUX_RAGDOLL_CELL:-GSDocMitchellHouse}"
+# A vanilla FNV humanoid ragdoll has 18 bodies; floor well below that to
+# absorb a body whose bone name fails to resolve without masking a
+# collapse (a 2-body result would mean the graph barely threaded).
+MIN_BODIES="${BYROREDUX_RAGDOLL_MIN_BODIES:-10}"
+
+if [[ ! -f "$FNV_DATA/FalloutNV.esm" ]]; then
+    echo "smoke[ragdoll]: SKIP — FalloutNV.esm not at $FNV_DATA"
+    exit 0
+fi
+
+LOG_DIR="$(mktemp -d)"
+trap 'rm -rf "$LOG_DIR"' EXIT
+ENGINE_LOG="$LOG_DIR/engine"
+DBG_LOG="$LOG_DIR/dbg.log"
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  smoke[ragdoll]: launching FNV $CELL in background"
+echo "═══════════════════════════════════════════════════════════════"
+
+# RUST_LOG=info so the loader's `Attached RagdollTemplate …` line lands.
+RUST_LOG="${RUST_LOG:-byroredux=info}" cargo run --release --quiet -- \
+    --esm "$FNV_DATA/FalloutNV.esm" \
+    --cell "$CELL" \
+    --bsa "$FNV_DATA/Fallout - Meshes.bsa" \
+    --textures-bsa "$FNV_DATA/Fallout - Textures.bsa" \
+    --textures-bsa "$FNV_DATA/Fallout - Textures2.bsa" \
+    --bench-frames "$BENCH_FRAMES" \
+    --bench-hold \
+    > "$ENGINE_LOG.stdout" 2> "$ENGINE_LOG.stderr" &
+engine_pid=$!
+kill_engine='kill -TERM "$engine_pid" 2>/dev/null || true; wait "$engine_pid" 2>/dev/null || true'
+
+# Wait up to 180s for bench-hold (cold build + cell load).
+deadline=$(( $(date +%s) + 180 ))
+while ! grep -q "^bench-hold:" "$ENGINE_LOG.stderr" 2>/dev/null; do
+    if [[ $(date +%s) -gt $deadline ]]; then
+        echo "smoke[ragdoll]: TIMEOUT waiting for bench-hold"
+        tail -20 "$ENGINE_LOG.stderr" || true
+        eval "$kill_engine"; exit 1
+    fi
+    if ! kill -0 "$engine_pid" 2>/dev/null; then
+        echo "smoke[ragdoll]: engine exited before bench-hold"
+        tail -20 "$ENGINE_LOG.stderr" || true
+        exit 1
+    fi
+    sleep 0.5
+done
+
+# Scrape the attach log: `Attached RagdollTemplate (N bodies) to root entity <ID>`.
+attach_line=$(grep -E "Attached RagdollTemplate \([0-9]+ bodies\) to root entity [0-9]+" \
+    "$ENGINE_LOG.stderr" | head -1 || true)
+if [[ -z "$attach_line" ]]; then
+    echo "smoke[ragdoll]: HARD FAIL — no RagdollTemplate attached (no skeleton ragdoll threaded?)"
+    echo "  (recent engine log:)"; tail -20 "$ENGINE_LOG.stderr" || true
+    eval "$kill_engine"; exit 1
+fi
+attached_bodies=$(echo "$attach_line" | grep -oE '\([0-9]+ bodies\)' | grep -oE '[0-9]+')
+root_id=$(echo "$attach_line" | grep -oE 'root entity [0-9]+' | grep -oE '[0-9]+')
+echo "smoke[ragdoll]: $attach_line"
+echo "smoke[ragdoll]: template root entity = $root_id ($attached_bodies bodies)"
+
+echo "smoke[ragdoll]: attaching byro-dbg on port $PORT → ragdoll $root_id"
+BYRO_DEBUG_PORT="$PORT" cargo run --release --quiet -p byro-dbg <<EOF > "$DBG_LOG" 2>&1 || true
+ragdoll $root_id
+quit
+EOF
+
+echo
+echo "── byro-dbg session log ────────────────────────────────────────"
+cat "$DBG_LOG"
+echo "────────────────────────────────────────────────────────────────"
+
+# `ragdoll` reports `now simulating <N> bodies on Rapier` on success.
+sim_bodies=$(grep -oE 'now simulating [0-9]+ bodies' "$DBG_LOG" | grep -oE '[0-9]+' | head -1 || echo 0)
+: "${sim_bodies:=0}"
+
+# Engine must still be alive after the command (no solver explosion crash).
+engine_alive=0
+if kill -0 "$engine_pid" 2>/dev/null; then engine_alive=1; fi
+
+bench_line=$(grep "^bench:" "$ENGINE_LOG.stdout" || true)
+eval "$kill_engine"
+
+hard_fail=0
+if (( attached_bodies < MIN_BODIES )); then
+    echo "smoke[ragdoll]: HARD FAIL — template has $attached_bodies bodies < floor $MIN_BODIES"
+    hard_fail=1
+else
+    echo "smoke[ragdoll]: PASS — template threaded $attached_bodies bodies (>= $MIN_BODIES)"
+fi
+if (( sim_bodies < MIN_BODIES )); then
+    echo "smoke[ragdoll]: HARD FAIL — ragdoll built only $sim_bodies bodies < floor $MIN_BODIES"
+    hard_fail=1
+else
+    echo "smoke[ragdoll]: PASS — Rapier multibody built $sim_bodies bodies"
+fi
+if (( engine_alive == 1 )); then
+    echo "smoke[ragdoll]: PASS — engine survived activation (no solver blow-up)"
+else
+    echo "smoke[ragdoll]: HARD FAIL — engine died during/after activation"
+    hard_fail=1
+fi
+[[ -n "$bench_line" ]] && echo "  bench: $bench_line"
+
+if (( hard_fail != 0 )); then
+    echo "smoke[ragdoll]: FAIL"
+    exit 1
+fi
+echo "smoke[ragdoll]: PASS — parse→thread→build→activate chain green. Watch Doc Mitchell crumple live."


### PR DESCRIPTION
## What & why

First slice of the **Havok-as-baseline** arc: parse a Bethesda/Havok ragdoll out of a NIF, build it as a Rapier **multibody**, and run it on our own solver — *improving* on Havok's clunky simulation rather than replicating it. Targets **Fallout New Vegas** (the classic `bhkRigidBody` + ragdoll-constraint chain). End-to-end verified on the vanilla `_male\skeleton.nif`: an 18-body / 17-joint humanoid (9 ball + 8 hinge) parses → threads → builds → activates via a console command, and the writeback crumples the skinned mesh.

## Phases (one commit each)

1. **`feat(nif)` constraint-data parser** — decode `bhkRagdollConstraint`, `bhkLimitedHingeConstraint`, and `bhkMalleableConstraint`-wrapping-either (the dominant FNV form, 14/17 joints). Field order/sizes from nif.xml, cross-checked against the existing breakable-constraint byte tables.
2. **`feat(nif)` import graph** — scene-level `extract_ragdoll` → `ImportedScene.ragdoll` (bodies + joints), Y-up + ×7 havok-scale converted, bones resolved via host `NiNode`.
3. **`feat(physics)` Rapier multibody** — `RagdollSpec` (glam-native; physics keeps no nif dependency) → `build_ragdoll` with reduced-coordinate multibody joints (spherical for Ragdoll, revolute for LimitedHinge), `Ragdoll` component, `remove_ragdoll` teardown.
4. **`feat(ragdoll)` activation + writeback** — `RagdollTemplate` attached at skeleton spawn; `ragdoll <id>` console command seeds from live bone poses and builds the multibody; `Stage::Late` writeback copies simulated poses onto bone `GlobalTransform` (which the skin reads). No propagation/animation skip needed — writeback runs last.
5. **`feat(ragdoll)` finish** — `ContactConfig.ragdoll_extra_angular_damping` tuning lever; GPU smoke script; ROADMAP doc-hygiene.

## Validation

- nif **878** tests, physics **29**, byroredux ragdoll integration **1** — all green; nif + physics lib clippy-clean.
- Real-data `#[ignore]` test (`crates/nif/tests/ragdoll_import.rs`) asserts the 18-body / 17-joint FNV graph.
- Headless physics + ECS integration tests cover build (chain swings but stays jointed) and activate→step→writeback (bones move under gravity).

**Run the GPU smoke** (needs FNV data + a Vulkan device):
```
docs/smoke-tests/m41-ragdoll.sh
```
Launches FNV Doc Mitchell, fires `ragdoll <id>`, and hard-asserts the parse→thread→build→activate chain. Watch him crumple live; tune feel via `ragdoll_extra_angular_damping`.

## Two real-data corrections worth a reviewer's eye

- The dominant FNV joint is **malleable-wrapped Ragdoll**, not bare — discovered by probing the real skeleton before building the consumer.
- The **FO4 skeleton loads fine** (it's a NIF); the old "FO4 humanoid meshes wait on a `.hkx` skeleton loader" premise was a stale resolver bug. The real FO4 gap is Havok *animation*. ROADMAP corrected.

## Slice-1 scope / out-of-scope follow-ups

- **FO4/FO76/Starfield ragdoll** — blocked on the `BhkSystemBinary` Havok-blob decoder.
- **Havok `.hkx` animation** — the motion half (NPCs leaving T-pose).
- **Death/hit triggers** — currently console-driven, not AI-wired.
- **Joint-limit fidelity** — Havok cone+2-plane → Rapier per-axis is approximate; motors parsed but off (active ragdoll later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)