### PR TITLE
PHYSAL: Physics Abstraction Layer — merge ragdolls across Oblivion/FO3/FNV/Skyrim

### DIFF
--- a/crates/nif/src/blocks/collision/bhk_constraint_tests.rs
+++ b/crates/nif/src/blocks/collision/bhk_constraint_tests.rs
@@ -1,16 +1,20 @@
-//! Coverage for the M41.x typed `bhkRagdollConstraint` /
-//! `bhkLimitedHingeConstraint` CInfo decode. Pre-M41.x these FO3+
-//! constraints were name-only stubs (16 bytes read, the rest skipped via
-//! `block_size`); now the per-variant body is decoded so the ragdoll
-//! articulation can be threaded out at import.
+//! Coverage for the typed `bhkRagdollConstraint` /
+//! `bhkLimitedHingeConstraint` CInfo decode that feeds PHYSAL (the
+//! physics abstraction layer — see `docs/engine/physal.md`). Pre-M41.x
+//! these were name-only stubs (16 bytes read, the rest skipped); now the
+//! per-variant body is decoded in the era-correct field order so the same
+//! `RagdollCInfo` / `LimitedHingeCInfo` — and therefore one ragdoll path —
+//! is reached from every game.
 //!
-//! Field order + sizes are from nif.xml (`bhkRagdollConstraintCInfo` /
-//! `bhkLimitedHingeConstraintCInfo`, `!#NI_BS_LTE_16#` branch) and
-//! cross-checked against the FNV prefix sizes the sibling
-//! `BhkBreakableConstraint` already encodes (Ragdoll 152, LimitedHinge 140).
-//! The typed decode reads exactly the fixed prefix and leaves the trailing
-//! motor to `block_size` recovery — so these tests assert the stream
-//! advanced by `16 + prefix`, with no motor bytes in the buffer.
+//! Both eras are pinned: Oblivion (`#NI_BS_LTE_16#`: 6 Vec4 ragdoll /
+//! 7 Vec4 hinge, no motors, pivots-first order), FO3/FNV
+//! (`!#NI_BS_LTE_16#`: 8 Vec4 + trailing motor), and Skyrim (same FO3+
+//! layout, gated by NIF version not bsver). Field order + sizes are from
+//! nif.xml, cross-checked against the FNV prefix sizes the sibling
+//! `BhkBreakableConstraint` already encodes (Ragdoll 152, LimitedHinge
+//! 140). The FO3+ typed decode reads exactly the fixed prefix and leaves
+//! the trailing motor to `block_size` recovery — so those tests assert the
+//! stream advanced by `16 + prefix`, with no motor bytes in the buffer.
 use super::*;
 use crate::header::NifHeader;
 use crate::version::NifVersion;
@@ -201,16 +205,163 @@ fn fnv_other_constraint_type_stays_stub() {
     assert_eq!(stream.position() as usize, 16, "only the base is read");
 }
 
-/// Oblivion ragdoll keeps the existing fixed-skip path (different field
-/// order, no motor); M41.x does not decode it yet → `Other`, with the
-/// 120-byte Oblivion payload still skipped exactly.
+/// Oblivion ragdoll decodes its own (`#NI_BS_LTE_16#`) field order:
+/// 6 × Vec4 (pivot/plane/twist, A then B — no Motor A/B) + 6 × f32.
+/// The absent motors zero out; the common subset the importer reads
+/// (twist/plane/pivot + angle limits) must match the FNV decode so the
+/// same `RagdollCInfo` funnels every game into one ragdoll path (PHYSAL).
 #[test]
-fn oblivion_ragdoll_skips_and_stays_stub() {
+fn oblivion_ragdoll_decodes_typed_cinfo() {
     let mut bytes = base();
-    bytes.extend(vec![0u8; 120]); // Oblivion Ragdoll: 6×Vec4 + 6×f32
+    // 6 × Vec4 in Oblivion order: PivotA, PlaneA, TwistA, PivotB, PlaneB,
+    // TwistB. First component encodes the field index.
+    bytes.extend(vec4(0.0, 10.0, 20.0, 1.0)); // pivot_a
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // plane_a
+    bytes.extend(vec4(2.0, 0.0, 1.0, 0.0)); // twist_a
+    bytes.extend(vec4(3.0, -10.0, 5.0, 1.0)); // pivot_b
+    bytes.extend(vec4(4.0, 0.0, 0.0, 0.0)); // plane_b
+    bytes.extend(vec4(5.0, 0.0, 1.0, 0.0)); // twist_b
+    // 6 × f32 limits (same shared trailer as FNV).
+    for v in [0.5f32, -0.25, 0.75, -1.5, 1.5, 10.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    assert_eq!(bytes.len(), 16 + 120, "base + 6×Vec4 + 6×f32");
+
     let header = oblivion_header();
     let mut stream = NifStream::new(&bytes, &header);
     let c = BhkConstraint::parse(&mut stream, "bhkRagdollConstraint").unwrap();
-    assert!(matches!(c.data, BhkConstraintData::Other));
+
+    let BhkConstraintData::Ragdoll(r) = c.data else {
+        panic!("Oblivion Ragdoll must decode, got {:?}", c.data);
+    };
+    // Fields the PHYSAL translate boundary actually reads.
+    assert_eq!(r.pivot_a, [0.0, 10.0, 20.0, 1.0]);
+    assert_eq!(r.plane_a, [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.twist_a, [2.0, 0.0, 1.0, 0.0]);
+    assert_eq!(r.pivot_b, [3.0, -10.0, 5.0, 1.0]);
+    assert_eq!(r.plane_b, [4.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.twist_b, [5.0, 0.0, 1.0, 0.0]);
+    assert_eq!(r.cone_max_angle, 0.5);
+    assert_eq!(r.twist_min_angle, -1.5);
+    assert_eq!(r.twist_max_angle, 1.5);
+    assert_eq!(r.max_friction, 10.0);
+    // FO3-only motors don't exist pre-FO3 → zeroed, invisible downstream.
+    assert_eq!(r.motor_a, [0.0; 4]);
+    assert_eq!(r.motor_b, [0.0; 4]);
     assert_eq!(stream.position() as usize, 16 + 120);
+}
+
+/// Oblivion limited hinge: 7 × Vec4 (pivot/axis/perp, no Perp Axis In B1)
+/// + 3 × f32. Absent perp axis zeroes out.
+#[test]
+fn oblivion_limited_hinge_decodes_typed_cinfo() {
+    let mut bytes = base();
+    // 7 × Vec4 in Oblivion order: PivotA, AxisA, PerpA1, PerpA2, PivotB,
+    // AxisB, PerpB2.
+    bytes.extend(vec4(11.0, 22.0, 33.0, 1.0)); // pivot_a
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // axis_a
+    bytes.extend(vec4(0.0, 1.0, 0.0, 0.0)); // perp_axis_in_a1
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // perp_axis_in_a2
+    bytes.extend(vec4(44.0, 55.0, 66.0, 1.0)); // pivot_b
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // axis_b
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // perp_axis_in_b2
+    for v in [-1.0f32, 1.0, 10.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    assert_eq!(bytes.len(), 16 + 124, "base + 7×Vec4 + 3×f32");
+
+    let header = oblivion_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkLimitedHingeConstraint").unwrap();
+
+    let BhkConstraintData::LimitedHinge(h) = c.data else {
+        panic!("Oblivion LimitedHinge must decode, got {:?}", c.data);
+    };
+    assert_eq!(h.axis_a, [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(h.pivot_a, [11.0, 22.0, 33.0, 1.0]);
+    assert_eq!(h.axis_b, [1.0, 0.0, 0.0, 0.0]);
+    assert_eq!(h.pivot_b, [44.0, 55.0, 66.0, 1.0]);
+    assert_eq!(h.min_angle, -1.0);
+    assert_eq!(h.max_angle, 1.0);
+    assert_eq!(h.max_friction, 10.0);
+    assert_eq!(h.perp_axis_in_b1, [0.0; 4]); // FO3+ only
+    assert_eq!(stream.position() as usize, 16 + 124);
+}
+
+/// Oblivion `bhkMalleableConstraint` wrapping a Ragdoll (Type 7) must
+/// surface as Ragdoll just like the FNV form, using the Oblivion inner
+/// layout (120 B) + the Oblivion tau/damping trailer (8 B).
+#[test]
+fn oblivion_malleable_wrapping_ragdoll_surfaces_as_ragdoll() {
+    let mut bytes = base(); // outer base: real bodies (entity_a=1, entity_b=2)
+    bytes.extend_from_slice(&7u32.to_le_bytes()); // wrapped Type = 7 (Ragdoll)
+    // nested bhkConstraintCInfo: num=2, entity_a=-1, entity_b=-1, priority=1
+    bytes.extend_from_slice(&2u32.to_le_bytes());
+    bytes.extend_from_slice(&(-1i32).to_le_bytes());
+    bytes.extend_from_slice(&(-1i32).to_le_bytes());
+    bytes.extend_from_slice(&1u32.to_le_bytes());
+    // inner Oblivion Ragdoll CInfo: 6 × Vec4 + 6 × f32 = 120.
+    for i in 0..6 {
+        bytes.extend(vec4(i as f32, 0.0, 0.0, 0.0));
+    }
+    for v in [0.5f32, -0.25, 0.75, -1.5, 1.5, 10.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+    // Oblivion malleable trailer: Tau + Damping.
+    bytes.extend_from_slice(&0.8f32.to_le_bytes());
+    bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+    let header = oblivion_header();
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkMalleableConstraint").unwrap();
+
+    assert_eq!(c.entity_a.index(), Some(1));
+    assert_eq!(c.entity_b.index(), Some(2));
+    let BhkConstraintData::Ragdoll(r) = c.data else {
+        panic!("Oblivion malleable-wrapped Ragdoll must surface as Ragdoll, got {:?}", c.data);
+    };
+    // Oblivion order: index 0 = pivot_a, index 2 = twist_a.
+    assert_eq!(r.pivot_a, [0.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.twist_a, [2.0, 0.0, 0.0, 0.0]);
+    assert_eq!(r.max_friction, 10.0);
+    // base(16) + Type(4) + nested CInfo(16) + Ragdoll(120) + trailer(8).
+    assert_eq!(stream.position() as usize, 16 + 4 + 16 + 120 + 8);
+}
+
+/// Skyrim LE/SE share the FNV (`!#NI_BS_LTE_16#`) constraint layout —
+/// they're distinguished from Oblivion by NIF version (20.2.0.7), not
+/// bsver, so a Skyrim-header Ragdoll must decode byte-identically to FNV.
+/// This pins the version gate so a future change can't silently route
+/// Skyrim down the Oblivion arm. (havok_scale ×69.99 is applied later, at
+/// the import boundary, from `havok_scale_for(header)`.)
+#[test]
+fn skyrim_ragdoll_uses_fo3_layout() {
+    let mut bytes = base();
+    // FO3+ order, 8 × Vec4 + 6 × f32 (same as FNV).
+    bytes.extend(vec4(0.0, 0.0, 1.0, 0.0)); // twist_a
+    bytes.extend(vec4(1.0, 0.0, 0.0, 0.0)); // plane_a
+    bytes.extend(vec4(2.0, 0.0, 0.0, 0.0)); // motor_a
+    bytes.extend(vec4(3.0, 10.0, 20.0, 1.0)); // pivot_a
+    bytes.extend(vec4(4.0, 0.0, 1.0, 0.0)); // twist_b
+    bytes.extend(vec4(5.0, 0.0, 0.0, 0.0)); // plane_b
+    bytes.extend(vec4(6.0, 0.0, 0.0, 0.0)); // motor_b
+    bytes.extend(vec4(7.0, -10.0, 5.0, 1.0)); // pivot_b
+    for v in [0.5f32, -0.25, 0.75, -1.5, 1.5, 100.0] {
+        bytes.extend_from_slice(&v.to_le_bytes());
+    }
+
+    // Skyrim SE header: NIF 20.2.0.7 (== FNV), bsver 100 (> 16 → FO3+ arm).
+    let mut header = fnv_header();
+    header.user_version = 12;
+    header.user_version_2 = 100;
+    let mut stream = NifStream::new(&bytes, &header);
+    let c = BhkConstraint::parse(&mut stream, "bhkRagdollConstraint").unwrap();
+
+    let BhkConstraintData::Ragdoll(r) = c.data else {
+        panic!("Skyrim Ragdoll must decode via the FO3+ path, got {:?}", c.data);
+    };
+    assert_eq!(r.pivot_a, [3.0, 10.0, 20.0, 1.0]);
+    assert_eq!(r.pivot_b, [7.0, -10.0, 5.0, 1.0]);
+    assert_eq!(r.motor_a, [2.0, 0.0, 0.0, 0.0]); // FO3+ motors present
+    assert_eq!(stream.position() as usize, 16 + 152);
 }

--- a/crates/nif/src/blocks/collision/constraints.rs
+++ b/crates/nif/src/blocks/collision/constraints.rs
@@ -110,6 +110,39 @@ impl RagdollCInfo {
             max_friction: stream.read_f32_le()?,
         })
     }
+
+    /// Oblivion / Morrowind (`#NI_BS_LTE_16#`) layout from nif.xml:
+    /// 6 × Vec4 + 6 × f32 = 120 bytes. Differs from [`Self::parse_fo3`] in
+    /// BOTH count (no Motor A / Motor B — those are FO3+ additions) and
+    /// order (pivot/plane/twist, A then B — vs FO3's twist/plane/motor/
+    /// pivot). The absent motors are zeroed; the PHYSAL translate boundary
+    /// (`import::collision::ragdoll_joint`) reads only the common subset
+    /// (twist/plane/pivot + the angle limits), so a zeroed motor is
+    /// invisible downstream — the same `RagdollCInfo` feeds every game.
+    fn parse_oblivion(stream: &mut NifStream) -> io::Result<Self> {
+        let pivot_a = super::read_vec4(stream)?;
+        let plane_a = super::read_vec4(stream)?;
+        let twist_a = super::read_vec4(stream)?;
+        let pivot_b = super::read_vec4(stream)?;
+        let plane_b = super::read_vec4(stream)?;
+        let twist_b = super::read_vec4(stream)?;
+        Ok(Self {
+            twist_a,
+            plane_a,
+            motor_a: [0.0; 4],
+            pivot_a,
+            twist_b,
+            plane_b,
+            motor_b: [0.0; 4],
+            pivot_b,
+            cone_max_angle: stream.read_f32_le()?,
+            plane_min_angle: stream.read_f32_le()?,
+            plane_max_angle: stream.read_f32_le()?,
+            twist_min_angle: stream.read_f32_le()?,
+            twist_max_angle: stream.read_f32_le()?,
+            max_friction: stream.read_f32_le()?,
+        })
+    }
 }
 
 /// `bhkLimitedHingeConstraintCInfo`, FO3/FNV (`!#NI_BS_LTE_16#`) layout
@@ -155,6 +188,34 @@ impl LimitedHingeCInfo {
             max_friction: stream.read_f32_le()?,
         })
     }
+
+    /// Oblivion / Morrowind (`#NI_BS_LTE_16#`) layout from nif.xml:
+    /// 7 × Vec4 + 3 × f32 = 124 bytes. No Perp Axis In B1 (an FO3+
+    /// addition) and a pivots-first order. The absent perp axis is zeroed;
+    /// the PHYSAL translate boundary reads only axis/pivot + angle limits,
+    /// so it's invisible downstream.
+    fn parse_oblivion(stream: &mut NifStream) -> io::Result<Self> {
+        let pivot_a = super::read_vec4(stream)?;
+        let axis_a = super::read_vec4(stream)?;
+        let perp_axis_in_a1 = super::read_vec4(stream)?;
+        let perp_axis_in_a2 = super::read_vec4(stream)?;
+        let pivot_b = super::read_vec4(stream)?;
+        let axis_b = super::read_vec4(stream)?;
+        let perp_axis_in_b2 = super::read_vec4(stream)?;
+        Ok(Self {
+            axis_a,
+            perp_axis_in_a1,
+            perp_axis_in_a2,
+            pivot_a,
+            axis_b,
+            perp_axis_in_b1: [0.0; 4],
+            perp_axis_in_b2,
+            pivot_b,
+            min_angle: stream.read_f32_le()?,
+            max_angle: stream.read_f32_le()?,
+            max_friction: stream.read_f32_le()?,
+        })
+    }
 }
 
 impl BhkConstraint {
@@ -188,10 +249,14 @@ impl BhkConstraint {
         })
     }
 
-    /// Parse a constraint block by type name. On Oblivion, reads the
-    /// exact byte layout and returns a `BhkConstraint`. On FO3+, reads
-    /// the 16-byte base and returns early; the caller seeks past the
-    /// remainder via `block_size`.
+    /// Parse a constraint block by type name. For the two joints a
+    /// humanoid ragdoll uses (`bhkRagdollConstraint` /
+    /// `bhkLimitedHingeConstraint`, bare or malleable-wrapped) the typed
+    /// CInfo is decoded into [`BhkConstraintData`] in the era-correct field
+    /// order — Oblivion (`#NI_BS_LTE_16#`) or FO3+ (`!#NI_BS_LTE_16#`).
+    /// Every other type reads its base (and, on Oblivion, skips its fixed
+    /// payload) and stays [`BhkConstraintData::Other`]; on FO3+ the outer
+    /// walker seeks past any unread remainder via `block_size`.
     pub fn parse(stream: &mut NifStream, type_name: &'static str) -> io::Result<Self> {
         let (entity_a, entity_b, priority) = Self::parse_base(stream)?;
 
@@ -200,15 +265,42 @@ impl BhkConstraint {
         // "drop through to the FO3+ short-stub path".
         let is_oblivion = stream.version() <= NifVersion::V20_0_0_5;
         if is_oblivion {
+            // PHYSAL per-game seam: decode the two joints a humanoid
+            // ragdoll uses in the Oblivion (`#NI_BS_LTE_16#`) field order.
+            // Everything downstream of the resulting `BhkConstraintData` is
+            // game-agnostic — only the byte layout differs here, so this is
+            // the *only* Oblivion-specific code in the ragdoll path.
+            match type_name {
+                "bhkRagdollConstraint" => {
+                    return Ok(Self {
+                        type_name,
+                        entity_a,
+                        entity_b,
+                        priority,
+                        data: BhkConstraintData::Ragdoll(RagdollCInfo::parse_oblivion(stream)?),
+                    });
+                }
+                "bhkLimitedHingeConstraint" => {
+                    return Ok(Self {
+                        type_name,
+                        entity_a,
+                        entity_b,
+                        priority,
+                        data: BhkConstraintData::LimitedHinge(LimitedHingeCInfo::parse_oblivion(
+                            stream,
+                        )?),
+                    });
+                }
+                _ => {}
+            }
+
+            // The remaining types aren't decoded yet; consume their fixed
+            // Oblivion payload by byte size and stay `Other`.
             let payload_size: Option<u64> = match type_name {
                 // 2 × Vec4
                 "bhkBallAndSocketConstraint" => Some(32),
                 // 5 × Vec4
                 "bhkHingeConstraint" => Some(80),
-                // 6 × Vec4 + 6 × f32
-                "bhkRagdollConstraint" => Some(120),
-                // 7 × Vec4 + 3 × f32
-                "bhkLimitedHingeConstraint" => Some(124),
                 // 8 × Vec4 + 3 × f32
                 "bhkPrismaticConstraint" => Some(140),
                 // 2 × Vec4 + f32
@@ -232,30 +324,35 @@ impl BhkConstraint {
 
             if type_name == "bhkMalleableConstraint" {
                 // Oblivion layout: type u32 + nested bhkConstraintCInfo
-                // (16) + wrapped CInfo + tau f32 + damping f32.
+                // (16, entities −1/−1) + wrapped CInfo + tau f32 + damping
+                // f32. Decode an inner Ragdoll / LimitedHinge so a
+                // malleable-wrapped joint surfaces identically to a bare
+                // one; other inner types skip by size and stay `Other`.
                 let wrapped_type = stream.read_u32_le()?;
-                let _nested_entities = stream.read_u32_le()?;
-                let _nested_a = stream.read_block_ref()?;
-                let _nested_b = stream.read_block_ref()?;
-                let _nested_priority = stream.read_u32_le()?;
-                let inner_size: u64 = match wrapped_type {
-                    0 => 32,  // Ball and Socket
-                    1 => 80,  // Hinge
-                    2 => 124, // Limited Hinge
-                    6 => 140, // Prismatic
-                    7 => 120, // Ragdoll
-                    8 => 36,  // Stiff Spring
+                let _nested = Self::parse_base(stream)?;
+                let data = match wrapped_type {
+                    7 => BhkConstraintData::Ragdoll(RagdollCInfo::parse_oblivion(stream)?),
+                    2 => BhkConstraintData::LimitedHinge(LimitedHingeCInfo::parse_oblivion(stream)?),
                     other => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!(
-                                "bhkMalleableConstraint: unknown inner type {other} — \
-                                 stream position unreliable"
-                            ),
-                        ));
+                        let inner_size: u64 = match other {
+                            0 => 32,  // Ball and Socket
+                            1 => 80,  // Hinge
+                            6 => 140, // Prismatic
+                            8 => 36,  // Stiff Spring
+                            unknown => {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "bhkMalleableConstraint: unknown inner type {unknown} — \
+                                         stream position unreliable"
+                                    ),
+                                ));
+                            }
+                        };
+                        stream.skip(inner_size)?;
+                        BhkConstraintData::Other
                     }
                 };
-                stream.skip(inner_size)?;
                 // Tau + Damping (Oblivion trailer).
                 stream.skip(8)?;
                 return Ok(Self {
@@ -263,7 +360,7 @@ impl BhkConstraint {
                     entity_a,
                     entity_b,
                     priority,
-                    data: BhkConstraintData::Other,
+                    data,
                 });
             }
         }

--- a/crates/nif/tests/ragdoll_import.rs
+++ b/crates/nif/tests/ragdoll_import.rs
@@ -1,10 +1,12 @@
-//! Real-data validation for M41.x Phase 2 — the FNV humanoid skeleton's
-//! Havok ragdoll must thread end-to-end into `ImportedScene.ragdoll`:
-//! 18 capsule bodies + 17 joints (3 bare `bhkRagdollConstraint` + 14
-//! `bhkMalleableConstraint` wrapping a Ragdoll), all decoded as Ragdoll
-//! joints, every body resolving a bone name + shape.
+//! Real-data validation for PHYSAL ingestion (the physics abstraction
+//! layer — see `docs/engine/physal.md`). A humanoid skeleton's Havok
+//! ragdoll must thread end-to-end into `ImportedScene.ragdoll` through the
+//! *same* code path on every classic-chain game (Oblivion / FNV / Skyrim)
+//! — only the on-disk constraint byte order differs, and that is resolved
+//! at parse. This is the "single consistent ragdoll logic" the layer
+//! exists to provide, exercised on real content.
 //!
-//! `#[ignore]` because it needs vanilla FNV game data; run with
+//! `#[ignore]` because it needs vanilla game data; run with e.g.
 //! `cargo test -p byroredux-nif --test ragdoll_import -- --ignored --nocapture`.
 
 mod common;
@@ -12,58 +14,33 @@ mod common;
 use common::{open_mesh_archive, Game};
 
 use byroredux_core::string::StringPool;
-use byroredux_nif::import::{import_nif_scene, ImportedJointKind};
+use byroredux_nif::import::{import_nif_scene, ImportedJointKind, ImportedRagdoll};
 use byroredux_nif::parse_nif;
 
-const SKELETON_PATH: &str = r"meshes\characters\_male\skeleton.nif";
-
-#[test]
-#[ignore]
-fn fnv_humanoid_skeleton_threads_ragdoll() {
-    let Some(archive) = open_mesh_archive(Game::FalloutNV) else {
-        return;
+/// Extract + import a skeleton and return its threaded ragdoll, or `None`
+/// when the game data / skeleton isn't present (so a missing-data or
+/// path-mismatch run *skips* rather than masquerading as a failure — the
+/// per-game skeleton path varies and we don't fabricate counts for data
+/// we can't open).
+fn thread_skeleton_ragdoll(game: Game, skeleton_path: &str) -> Option<ImportedRagdoll> {
+    let archive = open_mesh_archive(game)?;
+    let bytes = match archive.extract(skeleton_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("{game:?}: skeleton not at {skeleton_path:?} ({e}) — skipping");
+            return None;
+        }
     };
-    let bytes = archive
-        .extract(SKELETON_PATH)
-        .expect("FNV mesh archive must contain _male/skeleton.nif");
     let scene = parse_nif(&bytes).expect("skeleton.nif must parse");
     let mut pool = StringPool::new();
-    let imported = import_nif_scene(&scene, &mut pool);
+    import_nif_scene(&scene, &mut pool).ragdoll
+}
 
-    let ragdoll = imported
-        .ragdoll
-        .expect("FNV humanoid skeleton must thread a ragdoll articulation");
-
-    eprintln!(
-        "FNV _male skeleton ragdoll: {} bodies, {} joints",
-        ragdoll.bodies.len(),
-        ragdoll.constraints.len(),
-    );
-    let names: Vec<&str> = ragdoll.bodies.iter().map(|b| b.bone_name.as_ref()).collect();
-    eprintln!("ragdoll bones: {names:?}");
-
-    // Vanilla FNV _male skeleton: 18 capsule bodies, 17 joints.
-    assert_eq!(ragdoll.bodies.len(), 18, "expected 18 ragdoll bodies");
-    assert_eq!(ragdoll.constraints.len(), 17, "expected 17 joints");
-
-    for b in &ragdoll.bodies {
-        assert!(!b.bone_name.is_empty(), "ragdoll body missing a bone name");
-        assert!(b.mass >= 0.0, "negative mass on {}", b.bone_name);
-    }
-    for c in &ragdoll.constraints {
-        assert!(
-            c.body_a < ragdoll.bodies.len() && c.body_b < ragdoll.bodies.len(),
-            "joint references an out-of-range body",
-        );
-        assert_ne!(c.body_a, c.body_b, "joint links a body to itself");
-    }
-
-    // Every joint decodes to a real kind — the `constraints` vec only holds
-    // successfully-decoded Ragdoll/LimitedHinge (Other is dropped), so a
-    // count of 17 already means none silently dropped. The FNV humanoid is
-    // a mix: ball-joints for spine/neck/shoulders/hips (Ragdoll) and
-    // angle-limited hinges for elbows/knees (LimitedHinge) — both reached
-    // through the malleable wrapper.
+/// Shared structural invariants every game's threaded ragdoll must hold —
+/// no per-game body/joint counts hard-coded here (those are measured, not
+/// assumed). Prints the actual decode so real-data runs can harden the
+/// numbers later, mirroring the smoke-test philosophy.
+fn assert_structural(game: Game, ragdoll: &ImportedRagdoll) {
     let ragdoll_joints = ragdoll
         .constraints
         .iter()
@@ -74,20 +51,91 @@ fn fnv_humanoid_skeleton_threads_ragdoll() {
         .iter()
         .filter(|c| matches!(c.kind, ImportedJointKind::LimitedHinge { .. }))
         .count();
-    eprintln!("joints: {ragdoll_joints} Ragdoll + {hinge_joints} LimitedHinge");
-    assert_eq!(
-        ragdoll_joints + hinge_joints,
-        17,
-        "every joint must decode to Ragdoll or LimitedHinge, none dropped",
-    );
-    assert!(
-        hinge_joints > 0,
-        "FNV humanoid elbows/knees should decode as LimitedHinge",
+    eprintln!(
+        "{game:?} ragdoll: {} bodies, {} joints ({ragdoll_joints} Ragdoll + {hinge_joints} LimitedHinge)",
+        ragdoll.bodies.len(),
+        ragdoll.constraints.len(),
     );
 
-    // Bone names round-trip (sanity that the host-NiNode mapping works).
+    // A ragdoll needs ≥2 bodies and ≥1 joint to articulate at all.
+    assert!(ragdoll.bodies.len() >= 2, "{game:?}: need ≥2 ragdoll bodies");
+    assert!(!ragdoll.constraints.is_empty(), "{game:?}: need ≥1 joint");
+    for b in &ragdoll.bodies {
+        assert!(!b.bone_name.is_empty(), "{game:?}: body missing a bone name");
+        assert!(b.mass >= 0.0, "{game:?}: negative mass on {}", b.bone_name);
+    }
+    for c in &ragdoll.constraints {
+        assert!(
+            c.body_a < ragdoll.bodies.len() && c.body_b < ragdoll.bodies.len(),
+            "{game:?}: joint references an out-of-range body",
+        );
+        assert_ne!(c.body_a, c.body_b, "{game:?}: joint links a body to itself");
+    }
+    // `constraints` only holds successfully-decoded Ragdoll/LimitedHinge
+    // (Other is dropped at extract), so a non-zero count already means
+    // every surfaced joint decoded — i.e. the era-correct field order was
+    // read. This is the cross-game assertion: it holds whether the bytes
+    // arrived in Oblivion or FO3+ order.
+    assert_eq!(
+        ragdoll_joints + hinge_joints,
+        ragdoll.constraints.len(),
+        "{game:?}: every surfaced joint must decode to Ragdoll or LimitedHinge",
+    );
+}
+
+#[test]
+#[ignore]
+fn fnv_humanoid_skeleton_threads_ragdoll() {
+    let Some(ragdoll) =
+        thread_skeleton_ragdoll(Game::FalloutNV, r"meshes\characters\_male\skeleton.nif")
+    else {
+        return;
+    };
+    assert_structural(Game::FalloutNV, &ragdoll);
+
+    // FNV is the measured reference: vanilla _male skeleton is 18 capsule
+    // bodies, 17 joints, with elbows/knees as LimitedHinge.
+    assert_eq!(ragdoll.bodies.len(), 18, "FNV: expected 18 ragdoll bodies");
+    assert_eq!(ragdoll.constraints.len(), 17, "FNV: expected 17 joints");
+    let hinges = ragdoll
+        .constraints
+        .iter()
+        .filter(|c| matches!(c.kind, ImportedJointKind::LimitedHinge { .. }))
+        .count();
+    assert!(hinges > 0, "FNV elbows/knees should decode as LimitedHinge");
+
+    let names: Vec<&str> = ragdoll.bodies.iter().map(|b| b.bone_name.as_ref()).collect();
     assert!(
         names.iter().any(|n| n.contains("Bip01") || n.contains("Spine")),
         "expected a Bip01/Spine bone among {names:?}",
     );
+}
+
+#[test]
+#[ignore]
+fn oblivion_humanoid_skeleton_threads_ragdoll() {
+    // Oblivion introduced Havok ragdolls; the human skeleton lives at the
+    // same `_male` path as FNV but ships the `#NI_BS_LTE_16#` (pivots-first,
+    // no-motor) constraint layout — proof the parse-time seam, and nothing
+    // downstream, is all that differs.
+    let Some(ragdoll) =
+        thread_skeleton_ragdoll(Game::Oblivion, r"meshes\characters\_male\skeleton.nif")
+    else {
+        return;
+    };
+    assert_structural(Game::Oblivion, &ragdoll);
+}
+
+#[test]
+#[ignore]
+fn skyrim_humanoid_skeleton_threads_ragdoll() {
+    // Skyrim SE: FO3+ constraint layout (gated by NIF version, not bsver)
+    // + havok_scale ×69.99. Skeleton path moved under actors/character.
+    let Some(ragdoll) = thread_skeleton_ragdoll(
+        Game::SkyrimSE,
+        r"meshes\actors\character\character assets\skeleton.nif",
+    ) else {
+        return;
+    };
+    assert_structural(Game::SkyrimSE, &ragdoll);
 }

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -16,6 +16,7 @@ built, where the code lives, and what guarantees it makes.
 | [NIF Parser](nif-parser.md) | nif | Block-type dispatch (~254 arms, source of truth: `blocks/mod.rs`), version handling, robustness |
 | [NIFAL — NIF Abstraction Layer](nifal.md) | nif, byroredux | `Imported*` → canonical ECS translation boundary; material, particle, collision, LOD slices |
 | [EXAL — Exterior Abstraction Layer](exal.md) | byroredux, renderer | NIFAL mirror for outdoor rendering: terrain, sky, sun, weather, water, LOD |
+| [PHYSAL — Physics Abstraction Layer](physal.md) | nif, physics, byroredux | Per-game Havok → one canonical articulated-physics spec → solver; ragdolls (Oblivion/FO3/FNV/Skyrim), double-ended (source game + backing solver) |
 | [Archives (BSA + BA2 + CSG)](archives.md) | bsa | BSA v103/104/105, BA2 v1/2/3/7/8 GNRL + DX10, FO4 `.csg` precombined geometry |
 | [Plugin Loading](plugin-loading.md) | plugin, core | `PluginManifest`, `DataStore`, `DependencyResolver`, Form ID system, ESM parser, conflict resolution |
 | [ESM Records](esm-records.md) | plugin | Cell loading, items, NPCs, factions, leveled lists |

--- a/docs/engine/physal.md
+++ b/docs/engine/physal.md
@@ -1,0 +1,254 @@
+# PHYSAL — Physics Abstraction Layer
+
+**PHYSAL** (Physics Abstraction Layer; pronounced "FIZZ-al") is the canonical
+translation tier for **simulated physics** — the articulated, dynamic bodies the
+engine steps every frame: ragdolls today, then loose rigid bodies, phantoms /
+trigger volumes, runtime constraints, and active (motorised) ragdolls. It is the
+sibling of [`nifal.md`](nifal.md) and [`exal.md`](exal.md): where NIFAL
+translates per-game **NIF geometry/material** data and EXAL translates per-game
+**ESM environment** data, PHYSAL translates per-game **Havok physics** data into
+one canonical articulated-physics representation that a solver builds and steps
+identically for every game.
+
+"Abstraction" is the brand; the mechanism is **canonical translation** (per-game
+`Imported*` → one resolved, game-agnostic spec). The verbs stay `translate` /
+`canonical` / `resolve` / `build`; **PHYSAL** names the layer as a whole.
+
+**Status**: ACTIVE (opened 2026-06-14). The ragdoll slice is the reference
+realisation — see §3. Generalises the M41.x FNV ragdoll work into a cross-game
+layer; Oblivion decode landed alongside this doc.
+
+**Goal**: every supported engine version (Oblivion / FO3 / FNV / Skyrim LE/SE /
+FO4 / FO76 / Starfield) translates its native, per-game Havok authoring into
+**one canonical, fully-resolved physics spec** through a single explicit
+parse→canonical boundary, which **one** solver boundary then builds. The
+simulation, writeback, and gameplay layers consume the canonical spec
+**identically for every game** — no per-game branches downstream, no `Option`
+"resolve-it-later" fallbacks. We are not emulating Havok; we are using its
+authored data as a *baseline* and simulating it on our own solver to **fix what
+the original engines never did right** (link separation, jitter, clunky limits).
+
+This is the same doctrine NIFAL formalises
+([`feedback_format_translation.md`](../../) — "never per-game branches downstream;
+translate at the parser boundary"; the `format_abstraction.md` GameVariant
+pattern), now applied to the physics pipeline.
+
+---
+
+## 1. PHYSAL is double-ended
+
+NIFAL and EXAL abstract **one** axis: the source game. PHYSAL abstracts **two** —
+because physics has a sink (the solver) as well as a source (the game):
+
+```
+        SOURCE axis (per game)                            SINK axis (per solver)
+  ┌──────────────────────────────────┐          ┌──────────────────────────────┐
+  Havok in any game's NIF ─parse─▶ Imported ─translate─▶ Canonical spec ─build─▶ Rapier
+       (Oblivion order,              (engine-      (glam-native,        (RigidBody +
+        FO3+ order, FO4 blob)         native graph) solver-agnostic)     multibody joints)
+```
+
+- **Source boundary** (parse + extract + translate): folds every per-game Havok
+  quirk — constraint field order, `havok_scale`, collision-object kind — into one
+  canonical spec. This is where Oblivion vs FO3+ vs FO4 differences live, and the
+  *only* place they live.
+- **Sink boundary** (`build`): the single site that lowers the canonical spec onto
+  the backing solver. Swapping Rapier for another solver reimplements this one
+  function and the pose readback — nothing upstream of it changes.
+
+The payoff of the sink boundary is concrete: the canonical `RagdollSpec` /
+`RagdollJointSpec` are plain glam types with no Rapier in their signatures, so the
+"what to simulate" description is independent of "how it's simulated."
+
+---
+
+## 2. The tier model
+
+```
+                parse + extract                 translate()                    build()
+  NIF bytes ────────────────────▶  Imported*  ──────────────▶  Canonical  ──────────────▶  Solver
+            (per-game bhk* wire              (engine-native,    (entity-resolved          (Rapier rigid
+             decode → Y-up, scaled           game-agnostic      ECS spec, no              bodies +
+             articulation graph)             articulation)      Option leaks)             multibody joints)
+```
+
+| Tier | What it is | Where it lives | Rule |
+|---|---|---|---|
+| **Raw / `Imported*`** | A faithful decode of the Havok articulation — the constraint graph, per-body mass/damping/shape, joint geometry — converted to engine units (Y-up, `havok_scale`). May carry era-specific quirks. **Allowed to be messy.** | `crates/nif/src/blocks/collision/` (wire) + `crates/nif/src/import/collision.rs` (`ImportedRagdoll`) | Decode only; never the engine's source of truth. |
+| **`translate()` boundary** | Resolves `ImportedRagdoll` against the live skeleton (bone names → `EntityId`) into the canonical ECS blueprint, then seeds a world-space build spec from the bones' current poses at activation. Exactly **one** site per concern. | `byroredux/src/ragdoll.rs` (`template_from_imported`, `activate_ragdoll`) | One producer; no duplicate construction. |
+| **Canonical** | The game- and solver-agnostic spec the engine reasons about. `RagdollSpec`/`RagdollJointSpec` (build input) + the `Ragdoll` / `RagdollTemplate` ECS components (runtime state + dormant blueprint). | `crates/physics/src/ragdoll.rs` + `byroredux/src/ragdoll.rs` | The single source of truth. |
+| **Solver build** | Lowers the canonical spec onto Rapier: dynamic bodies, colliders (mass split), constraint graph oriented into a kinematic tree, one multibody joint per edge. | `crates/physics/src/ragdoll.rs::build_ragdoll` | One solver boundary; the only place solver types appear. |
+
+### The canonical-type rule (inherited from NIFAL)
+
+> **Where an ECS component already serves the game- and solver-agnostic,
+> engine-facing role, that component IS the canonical type.** Introduce a new
+> canonical type only where none exists.
+
+The runtime `Ragdoll` component (body handles + joint handles) and the dormant
+`RagdollTemplate` (bone-relative blueprint) are the canonical types — there is no
+parallel `Canonical*` struct they copy from. `RagdollSpec` is not a third type but
+the **transient build argument** to the sink boundary: it exists only between
+`activate_ragdoll` and `build_ragdoll`, carrying the world-space seed the dormant
+template can't (the template is pose-independent; the spec is pose-resolved at the
+instant of activation).
+
+### Relationship to NIFAL
+
+PHYSAL **consumes** NIFAL's canonical collision output: ragdoll body geometry is
+NIFAL's `CollisionShape` (the `bhk*Shape` → `CollisionShape` resolution in
+`import/collision.rs::resolve_shape`, NIFAL's "collision" category). PHYSAL does
+not re-decode shapes — it reuses the canonical ones and adds the *articulation*
+(graph + joints + simulation) NIFAL stops short of. Clean dependency, zero
+duplication.
+
+---
+
+## 3. Ragdolls — the reference realisation
+
+### Source boundary — per-game constraint decode
+
+The whole per-game seam is the typed decode of two constraint CInfos
+(`crates/nif/src/blocks/collision/constraints.rs`). The importer
+(`ragdoll_joint` / `limited_hinge_joint`) reads only the **common subset** of
+fields (twist/plane/pivot + angle limits for ragdoll; axis/pivot + limits for
+hinge), so era-only fields (FO3+ motors, FO3+ `Perp Axis In B1`) are decoded-or-
+zeroed and never reach the canonical spec. One `RagdollCInfo` /
+`LimitedHingeCInfo` therefore feeds every game:
+
+| Game | Discriminator | Constraint layout | State |
+|---|---|---|---|
+| **Oblivion / Morrowind** | NIF ≤ 20.0.0.5 (`#NI_BS_LTE_16#`) | Ragdoll 6×Vec4 + 6×f32 (pivots-first, **no motors**); LimitedHinge 7×Vec4 + 3×f32 (**no Perp B1**) | **decoded (2026-06-14)** |
+| **FO3 / FNV** | NIF 20.2.0.7, bsver ≤ 34 (`!#NI_BS_LTE_16#`) | Ragdoll 8×Vec4 + 6×f32 + motor; LimitedHinge 8×Vec4 + 3×f32 + motor; the dominant FNV form is a `bhkMalleableConstraint` wrapping a Ragdoll | **decoded — slice 1 reference** |
+| **Skyrim LE/SE** | NIF 20.2.0.7, bsver 83–127 | identical FO3+ layout; gated by NIF **version**, not bsver. `havok_scale` ×69.99 applied at import via `havok_scale_for(header)` | **decoded; version-gate pinned by test, real-data validation pending** |
+| **FO4 / FO76 / Starfield** | `BhkNPCollisionObject` → `BhkSystemBinary` | Havok-serialised binary blob — the constraint graph is inside the blob, not as discrete `bhkRigidBody.constraints` | **blocked on a blob decoder (multi-day reverse-engineering); documented limitation, not a leak** |
+
+Sources of truth (no-guessing): `/mnt/data/src/reference/nifxml/nif.xml`
+(`bhkRagdollConstraintCInfo` / `bhkLimitedHingeConstraintCInfo`, both version
+branches) cross-checked against the sibling `BhkBreakableConstraint` byte tables in
+the same file. Every decoder asserts exact stream advancement (byte-level tests in
+`blocks/collision/bhk_constraint_tests.rs`).
+
+### Extract — articulation graph (`crates/nif/src/import/collision.rs`)
+
+`extract_ragdoll` is **already game-agnostic**: it walks `BhkRigidBody` blocks,
+maps each to its host bone (`NiNode.collision_ref → BhkCollisionObject.body_ref →
+host NiNode name`), resolves the shape via NIFAL's `resolve_shape`, and remaps
+constraint entity refs (rigid-body block indices) to body-array indices. It
+switches on `BhkConstraintData`, never on game. Output: `ImportedRagdoll { bodies,
+constraints }` in Y-up, `havok_scale`-applied engine units. Requires ≥2 bodies +
+≥1 joint or returns `None` (a lone collider isn't a ragdoll).
+
+### Translate — bone resolution + activation (`byroredux/src/ragdoll.rs`)
+
+At spawn, `template_from_imported` resolves bone names against the loaded
+skeleton's `name→EntityId` map into a `RagdollTemplate` ECS component (bodies whose
+bone fails to resolve are dropped, constraint indices remapped). On the
+`ragdoll <id>` console trigger, `activate_ragdoll` reads each bone's current
+`GlobalTransform`, seeds a world-space `RagdollSpec`, and calls the sink.
+
+### Build + step + writeback — solver (`crates/physics`)
+
+`build_ragdoll` creates one dynamic body + collider per spec body (mass split
+across compound parts), orients the constraint graph into a forest-safe kinematic
+tree (BFS, loop back-edges dropped), and inserts a Rapier **multibody** joint per
+edge — reduced-coordinate, constraint-by-construction, so links cannot visibly
+separate under stress (the headline "clunkiness" of the original Havok ragdolls).
+`ragdoll_writeback_system` (Stage::Late, after physics + propagation) copies the
+stepped body poses onto the bone `GlobalTransform`s the skinned mesh already
+reads — so the mesh crumples with no renderer change.
+
+### Known approximation
+
+Havok's cone + two-plane angular limit model does not map 1:1 onto Rapier's
+per-axis angular limits. Slice 1 applies twist→twist-axis and cone→both swing
+axes — good enough to switch an actor from bind-pose to a plausible ragdoll;
+limit-fidelity refinement (and motors, captured but unused) are follow-ups.
+
+---
+
+## 4. "Better than Havok" levers
+
+Centralised in `crates/physics/src/config.rs::ContactConfig`, so the
+"reimplement it properly" knobs are one resource, not scattered constants:
+
+- **Multibody joints** (not impulse joints) — the structural win: no inter-link
+  separation, which is most of what makes the original ragdolls read as clunky.
+- `ragdoll_extra_angular_damping` — extra per-body angular damping on top of the
+  authored value (inert at the `0.0` default); the biggest "less floppy than
+  Havok" dial.
+- Solver iteration count (ragdolls want more than clutter for limit stability) and
+  joint-limit stiffness/damping (soft limits vs Havok's hard clamp) — staged as
+  the limits get refined.
+- Motors stay **off** for the ragdoll slice (the `Motor A/B` + `bhkConstraintMotor`
+  data is captured at parse for a future active-ragdoll slice).
+
+---
+
+## 5. Per-concern inventory
+
+How close each physics concern is to the canonical contract.
+
+### Ragdoll articulation — **converged for the classic-chain games (2026-06-14)**
+
+Oblivion / FO3 / FNV / Skyrim all funnel through one `ImportedRagdoll` → one
+`RagdollSpec` → one Rapier multibody. The reference realisation (§3).
+
+### Loose rigid bodies / static collision — **owned by NIFAL + the physics runtime**
+
+`CollisionShape` / `RigidBodyData` → `physics_sync_system` → Rapier is the existing
+M28 path ([`physics.md`](physics.md)). PHYSAL does not re-abstract it; it reuses the
+canonical shapes. If a future slice needs a single dynamic-rigid-body spec, it joins
+PHYSAL under the same source/sink boundaries.
+
+### Phantoms / trigger volumes — **parked (needs a `TriggerVolume` ECS path)**
+
+`BhkPCollisionObject` phantoms are parsed but want a trigger-volume consumer, not a
+rigid body — deferred, mirroring the NIFAL collision note.
+
+### FO4+ packed Havok — **blocked (blob decoder)**
+
+`BhkNPCollisionObject → BhkSystemBinary` holds the whole physics system
+(bodies + constraints) as a serialised Havok binary. Decoding it is a separate
+multi-day project; until then FO4/FO76/Starfield ragdolls don't thread (static
+collision already falls back to a synthesised trimesh — see
+[`physics.md`](physics.md)). Documented limitation, **not** a silent leak.
+
+### Active (motorised) ragdoll — **data captured, simulation deferred**
+
+Motor CInfo is parsed and skipped (slice 1). A future slice drives motors for
+get-up / hit-react / partial-ragdoll. Needs the joint-limit fidelity work first.
+
+---
+
+## 6. Rollout order
+
+1. ~~Ragdoll source boundary — FNV~~ — done (M41.x slice 1).
+2. ~~Ragdoll source boundary — Oblivion + Skyrim~~ — done (2026-06-14): Oblivion
+   `#NI_BS_LTE_16#` decode landed; Skyrim version gate pinned by test (rides the
+   FO3+ path, ×69.99 scale). FO3 already rode the FNV path.
+3. Joint-limit fidelity — map Havok cone + 2-plane onto Rapier limits more
+   faithfully; add soft limits (`ContactConfig`).
+4. Death / hit-react AI triggers — replace the console trigger with gameplay
+   (the activation path is already trigger-agnostic).
+5. Active ragdoll — drive the captured motors.
+6. FO4+ `BhkSystemBinary` decoder — unblocks the packed-Havok games (large,
+   independent).
+
+Each step ships independently behind `cargo test`; none touches the Vulkan
+render-pass / pipeline (writeback rides existing skinning).
+
+---
+
+## 7. Tooling
+
+- `crates/nif/tests/ragdoll_import.rs` — real-data (`#[ignore]`) cross-game thread
+  test (Oblivion / FNV / Skyrim); FNV is the measured 18-body / 17-joint
+  reference, the others assert structural invariants and print actuals.
+- `crates/nif/src/blocks/collision/bhk_constraint_tests.rs` — byte-exact per-era
+  constraint decode (Oblivion / FNV / Skyrim, bare + malleable-wrapped).
+- `docs/smoke-tests/m41-ragdoll.sh` — GPU end-to-end (parse → thread → build →
+  activate) on FNV Doc Mitchell; the visual payoff (the actor crumpling) is watched
+  live.
+- `ragdoll <entity_id>` debug-server command (`byro-dbg` attach) — activate a
+  ragdoll on a live actor.

--- a/docs/engine/physics.md
+++ b/docs/engine/physics.md
@@ -407,10 +407,14 @@ further conversion is needed inside Rapier.
 
 These are intentionally deferred:
 
-- **Constraints / joints** — `bhkRagdollConstraint`,
-  `bhkHingeConstraint`, `bhkLimitedHingeConstraint`, etc. are still
-  parse-only (N23.6 skipped them); the importer does not emit joint data.
-  Ragdolls remain future work alongside skeletal animation.
+- **Constraints / joints** — `bhkRagdollConstraint` /
+  `bhkLimitedHingeConstraint` are decoded and threaded into ragdolls for the
+  classic-chain games (Oblivion / FO3 / FNV / Skyrim) by **PHYSAL** (the
+  physics abstraction layer — see [`physal.md`](physal.md)), which builds them
+  as Rapier multibody joints and writes the simulated poses back onto the
+  skeleton. Other constraint types (`bhkHingeConstraint`, prismatic, stiff
+  spring) stay parse-only; active (motorised) ragdolls and joint-limit fidelity
+  are PHYSAL follow-ups.
 - **FO4+ Havok content-system blob** — `bhkNPCollisionObject`'s
   serialised physics system isn't decoded; the render-geometry trimesh
   fallback above stands in for static architecture.


### PR DESCRIPTION
## What

Formalizes the engine's physics translation tier as **PHYSAL — Physics Abstraction Layer** (sibling of NIFAL/EXAL), and uses it to merge the classic-chain games into a *single, consistent ragdoll logic*. Builds directly on the merged M41.x FNV ragdoll slice (#1528).

We are **not emulating Havok** — we take its authored articulation data as a baseline and simulate it on our own Rapier solver to fix what the original engines never did right (link separation, jitter, clunky limits).

## The architecture: PHYSAL ([docs/engine/physal.md](docs/engine/physal.md))

Mirrors the NIFAL/EXAL template (three-tier, one boundary per concern, "promote the ECS component, don't add a third type"), but is **double-ended** — it abstracts two axes, not one:

- **Source boundary** (parse → extract → translate): every per-game Havok quirk (constraint field order, `havok_scale`, collision-object kind) folds into one canonical spec. This is the *only* place games differ.
- **Sink boundary** (`build_ragdoll`): the single site that lowers the canonical spec onto Rapier. `RagdollSpec`/`RagdollJointSpec` carry no solver types in their signatures — swapping solvers reimplements this one fn + pose readback, nothing upstream.

PHYSAL consumes NIFAL's canonical `CollisionShape` for body geometry (no shape re-decode).

## The merge: Oblivion decoded, Skyrim pinned

The key realization: the entire per-game seam is the typed constraint CInfo decode. Everything from `ImportedRagdoll` downstream already switches on `BhkConstraintData`, never on game. Oblivion was silently dropping to `BhkConstraintData::Other` → ragdolls never formed.

- Added `parse_oblivion` for ragdoll (6×Vec4, pivots-first, **no motors**) and limited-hinge (7×Vec4, **no Perp B1**) in the exact `#NI_BS_LTE_16#` order from nif.xml, plus the Oblivion malleable-wrapper path. The importer reads only the common subset of fields, so FO3-only fields zero out invisibly — **one `RagdollCInfo` now feeds Oblivion / FO3 / FNV / Skyrim.**
- Verified `havok_scale_for(header)` already returns ×69.99 for Skyrim+ (the `7.0`s in `scene.rs` are just test-fixture defaults), and Skyrim rides the FO3+ path gated by NIF **version**, not bsver.

| Game | Layout | State |
|---|---|---|
| Oblivion / Morrowind (`#NI_BS_LTE_16#`) | 6×Vec4 ragdoll / 7×Vec4 hinge, no motors, pivots-first | **decoded (this PR)** |
| FO3 / FNV (`!#NI_BS_LTE_16#`) | 8×Vec4 + motor; malleable-wrapped Ragdoll dominant | reference (#1528) |
| Skyrim LE/SE | same FO3+ layout, gated by NIF version; ×69.99 scale | **version-gate pinned; real-data validation pending** |
| FO4 / FO76 / Starfield | `BhkSystemBinary` Havok-serialised blob | **blocked on a blob decoder — documented limitation, not a leak** |

## Tests — all green, no regressions

- 4 new byte-exact decode tests (Oblivion ragdoll / hinge / malleable + a Skyrim version-gate guard); the stale `oblivion_..._skips` test flipped to a decode assertion.
- `ragdoll_import.rs` generalized to a cross-game `#[ignore]` real-data test (Oblivion / FNV / Skyrim) — FNV keeps its measured 18-body / 17-joint hard-assert; the others assert structural invariants and print actuals (no guessed counts).
- nif lib **811** · nif collision **65** · physics **29** · byroredux ragdoll **1** · clippy clean (nif + physics).

## No-guessing

Constraint field orders + sizes taken from `nif.xml` (`bhkRagdollConstraintCInfo` / `bhkLimitedHingeConstraintCInfo`, both version branches), cross-checked against the sibling `BhkBreakableConstraint` byte tables; every decoder asserts exact stream advancement. The FO4+ blob format is **not** guessed — it stays the one scoped, blocked follow-up.

## Out of scope (PHYSAL rollout follow-ups, §6 of the doc)

Joint-limit fidelity (Havok cone + 2-plane → Rapier per-axis limits), AI death/hit-react triggers (the activation path is already trigger-agnostic), active/motorised ragdoll (motor data captured-but-off), and the FO4+ `BhkSystemBinary` decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)