### PR TITLE
chore(audit): deep-rewrite all audit skills to match current code

### DIFF
--- a/.claude/commands/_audit-common.md
+++ b/.claude/commands/_audit-common.md
@@ -12,7 +12,7 @@ Resources:       crates/core/src/ecs/resources.rs
 Strings:         crates/core/src/string/
 NIF Parser:      crates/nif/src/
 NIF Blocks:      crates/nif/src/blocks/               (see blocks/mod.rs dispatch; controller/ subdir, tri_shape/ subdir {mod, ni_tri_shape, bs_tri_shape, agd}, collision/ subdir {mod, collision_object, rigid_body, ragdoll, shape_primitive, shape_compound, shape_mesh, compressed_mesh, constraints, phantom_action}, particle.rs (typed NiPSysEmitter/NiPSysEmitterCtlr/NiPSysEmitterCtlrData/NiPSysGrowFadeModifier), shader.rs, skin.rs, properties.rs, interpolator.rs, extra_data.rs, light.rs, multibound.rs, palette.rs, legacy_particle.rs, texture.rs, bs_geometry.rs, node.rs, base.rs, traits.rs; *_tests.rs siblings)
-NIF Import:      crates/nif/src/import/               (mod.rs thin dispatch + types.rs + tests.rs; walk/{mod, tests} (mod.rs carries extract_emitter_params/extract_emitter_rate), mesh/{mod, material_path, decode, ni_tri_shape, bs_tri_shape, bs_geometry, tangent, sse_recon, skin, *_tests}, material/{mod, walker, shader_data, *_tests}, transform.rs, coord.rs, collision.rs (translates BhkMultiSphereShape + BhkConvexListShape → CollisionShape))
+NIF Import:      crates/nif/src/import/               (mod.rs thin dispatch + types.rs + tests.rs; walk/{mod, tests} (mod.rs carries extract_emitter_params/extract_emitter_rate), mesh/{mod, material_path, decode, ni_tri_shape, bs_tri_shape, bs_geometry, tangent, sse_recon, skin, *_tests}, material/{mod, walker, shader_data, *_tests}, transform.rs, coord.rs, collision.rs (translates BhkMultiSphereShape + BhkConvexListShape → CollisionShape), precombine.rs (M49 FO4 precombined PSG slice → renderer-space mesh, paired with CsgArchive))
 NIF Animation:   crates/nif/src/anim/                 (mod.rs re-exports; coord, controlled_block, transform, sequence, keys, channel, bspline, entry; types.rs + tests.rs)
 BSA Reader:      crates/bsa/src/archive/             (mod.rs, open.rs, extract.rs, hash.rs, tests.rs)
 BA2 Reader:      crates/bsa/src/ba2.rs
@@ -36,14 +36,17 @@ SVGF Denoiser:   crates/renderer/src/vulkan/svgf.rs
 TAA (M37.5):     crates/renderer/src/vulkan/taa.rs
 Composite:       crates/renderer/src/vulkan/composite.rs
 SSAO:            crates/renderer/src/vulkan/ssao.rs
-Caustics (M??):  crates/renderer/src/vulkan/caustic.rs
+Caustics (M22):  crates/renderer/src/vulkan/caustic.rs       (#321 Option A: per-frame compute splat into R32_UINT accumulator)
+Water Caustic:   crates/renderer/src/vulkan/water_caustic.rs (#1210/#1255 Phase C: per-FIF R32_UINT accumulator for water-side caustics)
+GPU Timers:      crates/renderer/src/vulkan/gpu_timers.rs
+egui Pass:       crates/renderer/src/vulkan/egui_pass.rs      (egui overlay render pass; feeds debug-ui)
 Volumetrics(M55):crates/renderer/src/vulkan/volumetrics.rs  (160×90×128 froxel grid, inject + integrate compute, single-ray TLAS shadow, HG phase)
 Bloom (M58):     crates/renderer/src/vulkan/bloom.rs        (5-mip down + 4-mip up pyramid, B10G11R11_UFLOAT, 4-tap bilinear)
 Water (M38):     crates/renderer/src/vulkan/water.rs        (WaterPipeline: vertex displacement + Fresnel, RT reflection/refraction against TLAS)
 GPU Skin (M29):  crates/renderer/src/vulkan/skin_compute.rs
 Material (R1):   crates/renderer/src/vulkan/material.rs   (MaterialBuffer SSBO, GpuMaterial dedup; replaces per-instance fields)
 SPIR-V Reflect:  crates/renderer/src/vulkan/reflect.rs    (descriptor layout reflection from SPIR-V)
-Scene Buffers:   crates/renderer/src/vulkan/scene_buffer/  (mod, constants, gpu_types, buffers, upload, descriptors; gpu_instance_layout_tests + material_hash_tests + scene_descriptor_reflection_tests)
+Scene Buffers:   crates/renderer/src/vulkan/scene_buffer/  (mod, constants, gpu_types, buffers, upload, descriptors; gpu_instance_layout_tests + instance_hash_tests + material_hash_tests + scene_descriptor_reflection_tests)
 Descriptors:     crates/renderer/src/vulkan/descriptors.rs
 Vk Debug Util:   crates/renderer/src/vulkan/debug.rs
 Vk Instance:     crates/renderer/src/vulkan/instance.rs
@@ -59,12 +62,15 @@ CXX Bridge:      crates/cxx-bridge/
 Binary:          byroredux/src/main.rs
 Systems:         byroredux/src/systems.rs (module index) → systems/{animation, audio, billboard, bounds, camera, character, debug, light_anim, metrics, particle, water, weather}.rs (particle.rs carries apply_emitter_params, fed by the typed NIF emitter pipeline)
 Scene Setup:     byroredux/src/scene.rs (thin) → scene/{nif_loader, world_setup}.rs (+ *_tests.rs siblings: climate_tod_hours, cloud_tile_scale, procedural_fallback, radius_parse)
-Render Data:     byroredux/src/render.rs (build_render_data, draw enumeration) + render/*_tests.rs siblings
-Cell Loader:     byroredux/src/cell_loader.rs (thin dispatch) → cell_loader/{load, unload, exterior, references, spawn, partial, euler, refr, terrain, water, load_order, index, precombined, transition, nif_import_registry}.rs (+ *_tests.rs siblings)
+Render Data:     byroredux/src/render/ (mod.rs carries build_render_data + draw enumeration) → render/{camera, lights, skinned, static_meshes, particles, sky, water}.rs (+ *_tests.rs siblings)
+Cell Loader:     byroredux/src/cell_loader.rs (thin dispatch) → cell_loader/{load, unload, exterior, references, spawn, partial, euler, refr, terrain, terrain_lod, object_lod, water, load_order, index, precombined, transition, nif_import_registry}.rs (+ *_tests.rs siblings)
 Commands:        byroredux/src/commands.rs + commands_tests.rs (console: help, stats, entities, tex.missing, light.dump, cam.where/pos/tp, prid, inspect, …)
-NIFAL Translate: byroredux/src/material_translate.rs (translate_material — the SINGLE raw ImportedMesh → ECS Material boundary; per-game material classification happens here, never in the shader) + crates/core/src/ecs/components/material.rs (Material::resolve_pbr; canonical metalness/roughness are plain f32, resolve-once). Spec: docs/engine/nifal.md. See also /audit-nifal.
+NIFAL Translate: byroredux/src/material_translate.rs (translate_material — the SINGLE raw ImportedMesh → ECS Material boundary; per-game material classification happens here, never in the shader) + crates/core/src/ecs/components/material.rs (Material::resolve_pbr; canonical metalness/roughness are plain f32 fields, resolve-once). Spec: docs/engine/nifal.md. See also /audit-nifal.
+EXAL Translate:  byroredux/src/env_translate.rs (EXAL exterior-environment translation boundary: terrain/sky/sun/weather/water/LOD). Spec: docs/engine/exal.md.
+Ragdoll:         byroredux/src/ragdoll.rs (M41.x ragdoll activation + writeback; PHYSAL consumer). Spec: docs/engine/physal.md.
+Cornell Harness: byroredux/src/cornell.rs (--cornell self-contained RT material/lighting reference scene; no on-disk game data)
 Asset Provider:  byroredux/src/asset_provider.rs (BSA/BA2 texture+mesh extraction, resolve_texture, strip_build_prefix for AE pipeline-path paths)
-Components:      byroredux/src/components.rs (markers + app resources: Spinning, AlphaBlend, TwoSided, Decal, WaterPlane, WaterVolume, SubmersionState, SelectedRef, FootstepScratch, …)
+Components:      byroredux/src/components.rs (binary-local markers + app resources: Spinning, AlphaBlend, TwoSided, DoorTeleport, IsFxMesh, IsLodTerrain, IsCollisionOnly, FootstepEmitter/Config/Scratch, CellLightingRes, SkyParamsRes, WeatherDataRes, LightTuning, …). Shared ECS components (WaterPlane/WaterVolume/SubmersionState) live in crates/core/src/ecs/components/water.rs; SelectedRef is a resource in crates/core/src/ecs/resources.rs)
 NPC Spawn:       byroredux/src/npc_spawn.rs           (M41 actor instantiation)
 World Stream:    byroredux/src/streaming.rs           (M40 cell lifecycle) + streaming_tests.rs
 SF Smoke:        byroredux/src/sf_smoke.rs            (Starfield ESM resolve-rate harness, --sf-smoke CLI)
@@ -187,9 +193,18 @@ Deep audit commands add extra fields (e.g., `Trigger Conditions`, `Flow`, `Chang
 
 ## Domain Labels
 
+These are the labels that actually exist in the repo (verify drift with
+`gh label list --repo matiaszanolli/ByroRedux`). `/audit-publish` must only
+apply labels from this set — `gh issue create` rejects unknown labels.
+
 Severity: `critical`, `high`, `medium`, `low`
-Domain: `ecs`, `renderer`, `vulkan`, `pipeline`, `memory`, `sync`, `platform`, `cxx`, `nif`, `bsa`, `esm`, `animation`, `legacy-compat`, `performance`, `safety`, `tech-debt`
-Type: `bug`, `enhancement`, `maintenance`
+Domain: `ecs`, `renderer`, `vulkan`, `pipeline`, `memory`, `sync`, `cxx`, `nif-parser`, `nif`, `import-pipeline`, `animation`, `legacy-compat`, `performance`, `safety`, `tech-debt`
+Type: `bug`, `enhancement`, `documentation`
+
+Subsystems without their own label map to the closest existing domain:
+BSA/BA2/CSG and ESM/cell loading → `import-pipeline`; audio / platform /
+SpeedTree / sfmaterial → `legacy-compat` or `tech-debt`. There is **no**
+`bsa`, `esm`, `platform`, or `maintenance` label — do not apply them.
 
 ## Report Finalization
 

--- a/.claude/commands/_audit-validate.sh
+++ b/.claude/commands/_audit-validate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # .claude/commands/_audit-validate.sh
 #
-# Validates file/dir path references in `.claude/commands/audit-*.md` and
-# `_audit-*.md` skill files against the live repository tree.
+# Validates file/dir path references in `.claude/commands/audit-*/SKILL.md`
+# and `.claude/commands/_audit-*.md` skill files against the live repo tree.
 #
 # Why: TD7-* "stale path" findings keep recurring after module splits.
 # A one-shot sed sweep is reactive; this gate catches drift on the
@@ -70,7 +70,15 @@ expand_braces() {
 stale_count=0
 checked_count=0
 shopt -s nullglob
-skill_files=(.claude/commands/audit-*.md .claude/commands/_audit-*.md)
+# Audit skills now live in per-command subdirectories as
+# `.claude/commands/<name>/SKILL.md`; the two shared `_audit-*.md`
+# protocol files stay flat at the top level. Glob both shapes so the
+# gate actually inspects every skill (the old flat `audit-*.md` glob
+# silently matched zero files after the subdir migration).
+skill_files=(
+    .claude/commands/audit-*/SKILL.md
+    .claude/commands/_audit-*.md
+)
 shopt -u nullglob
 
 # Enumerate every checkable repo path once so partial refs like

--- a/.claude/commands/audit-audio/SKILL.md
+++ b/.claude/commands/audit-audio/SKILL.md
@@ -5,28 +5,61 @@ argument-hint: "--focus <dimensions> --depth shallow|deep"
 
 # Audio Subsystem Audit (M44)
 
-Audit the `byroredux-audio` crate (M44) for correctness across the kira backend integration: graceful-degradation manager, listener pose sync, spatial sub-track lifecycle, one-shot dispatch (entity + queue paths), looping emitter sustain, streaming music, global reverb send, and ECS lifecycle of audio components across cell streaming.
+Audit the `byroredux-audio` crate (M44, Phases 1–6 shipped) for correctness
+across the kira `0.10` integration: spatial sub-track lifecycle + leaks,
+listener pose / attenuation correctness, `SoundCache` growth, streaming-music
+handle lifecycle, global reverb send routing, graceful-degradation manager, and
+the ECS lifecycle of audio components across cell streaming. Plus the only live
+engine-side consumers (`footstep_system`, `reverb_zone_system`).
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, methodology,
+deduplication, context rules, and finding format. See
+`.claude/commands/_audit-severity.md` for the severity scale. Do NOT duplicate
+those here.
 
 ## Scope
 
-**Crate**: `crates/audio/src/lib.rs` (M44 — single-file crate today, with `crates/audio/src/tests.rs` split out post-Session-34; if `lib.rs` splits further into submodules update entry points before launching).
+**Crate**: `crates/audio/src/lib.rs` (single-file production module; tests split
+into `crates/audio/src/tests.rs` post-Session-34). kira version pinned at
+`0.10` in the workspace `Cargo.toml`. If `lib.rs` splits into submodules, update
+the per-dimension entry points before launching.
 
-**Engine-side consumers** (Dimension 7 — outside the crate): `byroredux/src/systems/audio.rs` (`footstep_system` + `reverb_zone_system`) and `byroredux/src/components.rs` (`FootstepEmitter` / `FootstepConfig` / `FootstepScratch`). These are the only live callers of `play_oneshot` / `set_reverb_send_db`, so the crate API audit is incomplete without them.
+**Engine-side consumers** (Dimension 7 — outside the crate):
+`byroredux/src/systems/audio.rs` (`footstep_system` + `reverb_zone_system`),
+`byroredux/src/components.rs` (`FootstepEmitter` / `FootstepConfig` /
+`FootstepScratch`), and `byroredux/src/asset_provider.rs`
+(`try_load_default_footstep` populates `FootstepConfig.default_sound`). These are
+the ONLY live callers of `play_oneshot` / `set_reverb_send_db`, so the crate-API
+audit is incomplete without them.
 
-**M44 phases shipped (ground truth — read crate docstring before audit)**:
-- Phase 1 — `AudioWorld` resource (graceful-degradation `Option<AudioManager>`), `AudioListener` / `AudioEmitter` / `OneShotSound` components, `audio_system` skeleton
-- Phase 2 — `load_sound_from_bytes` (symphonia decode of BSA-extracted blobs), `SoundCache` (path-keyed `Arc<StaticSoundData>` cache)
-- Phase 3 — Real spatial playback through kira's spatial sub-track model + `spawn_oneshot_at` helper
-- Phase 3.5 — `AudioWorld::play_oneshot` queue API (System-friendly, no entity allocation)
-- Phase 4 — `AudioEmitter.looping` honored via kira `loop_region`; tweened stop on emitter-component removal
-- Phase 5 — `load_streaming_sound_from_bytes` / `load_streaming_sound_from_file`, `play_music` / `stop_music` (single-slot, non-spatial main track)
-- Phase 6 — `AudioWorld::set_reverb_send_db` (one global send track with `ReverbBuilder`, per-new-track opt-in via `with_send`; default `f32::NEG_INFINITY` = silent)
+**Ground truth — read these before auditing**:
+- The `crates/audio/src/lib.rs` module docstring enumerates Phases 1–6.
+- `docs/feature-matrix.md` "Audio (M44 — Phases 1–6 complete)" section is the
+  authoritative runtime-status table.
+- The M44 row in `ROADMAP.md` (active milestones) carries the per-phase shipped
+  detail and the pending-phase list.
 
-**Future phases (NOT yet shipped — do not flag as missing unless audit scope includes them)**: Phase 3.5b FOOT records → per-material sound, REGN ambient soundscapes, MUSC + hardcoded music routing, reverb zones keyed off cell acoustics, raycast occlusion attenuation.
+**Confirmed-shipped surface (verify against the live API, do not assume)**:
+- `AudioWorld` resource — graceful-degradation `Option<AudioManager<DefaultBackend>>`;
+  public API: `new` / `default`, `is_active`, `manager_mut`, `active_sound_count`,
+  `pending_oneshot_count`, `play_oneshot`, `play_music`, `stop_music`,
+  `is_music_active`, `set_reverb_send_db`, `reverb_send_db`.
+- Components: `AudioListener`, `AudioEmitter` (`sound` / `attenuation` / `volume`
+  / `looping` / `unload_fade_ms`), `OneShotSound`. All `SparseSetStorage`.
+- `Attenuation { min_distance, max_distance }`; `DEFAULT_UNLOAD_FADE_MS = 10.0`.
+- Free fns: `audio_system`, `spawn_oneshot_at`, `load_sound_from_bytes`,
+  `load_streaming_sound_from_bytes`, `load_streaming_sound_from_file`.
+- `SoundCache` resource — path-keyed `Arc<StaticSoundData>` cache:
+  `get` / `insert` / `get_or_load` / `len` / `is_empty` / `clear` /
+  `bytes_estimate`.
+- Re-exports: `Sound` (= `StaticSoundData`), `SoundSettings`, `Frame`.
+
+**Future phases (NOT shipped — do not flag as missing unless scope says so)**:
+Phase 3.5b FOOT records → per-material sound, REGN ambient soundscapes, MUSC +
+hardcoded music routing, per-cell-acoustics reverb (current detector is binary
+interior/exterior only), raycast occlusion attenuation.
 
 ## Parameters (from $ARGUMENTS)
 
@@ -35,118 +68,356 @@ See `.claude/commands/_audit-common.md` for project layout, methodology, dedupli
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: Manager Lifecycle | Listener Pose Sync | Spatial Sub-Track Dispatch | Looping & Streaming | Reverb Send & Routing | ECS Lifecycle & Cell Streaming | Gameplay Audio Wiring
+- **Dimension**: Spatial Sub-Track Lifecycle | Listener Pose & Attenuation | SoundCache Growth | Streaming Music Lifecycle | Reverb Send & Routing | Manager Lifecycle & ECS/Cell Streaming | Gameplay Audio Wiring
 
 ## Phase 1: Setup
 
 1. Parse `$ARGUMENTS` for `--focus`, `--depth`
 2. `mkdir -p /tmp/audit/audio`
 3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/audio/issues.json`
-4. Scan `docs/audits/` for prior audio reports (none expected — this is M44's first audit pass)
-5. Read the `crates/audio/src/lib.rs` module docstring to confirm which phases are actually shipped vs. inferred from `HISTORY.md`. If the docstring drifts from the user-visible API, that's a finding in itself.
+4. **A prior audio report exists**: `docs/audits/AUDIT_AUDIO_2026-05-05.md`. Read it
+   first — most of its findings (#843–#859) are CLOSED and now live as regression
+   guards in `crates/audio/src/tests.rs` + `byroredux/src/systems/audio.rs`. A
+   re-flag of any of those is a regression claim, not a new finding; verify the
+   guard is gone before reporting.
+5. Read the `crates/audio/src/lib.rs` module docstring to confirm Phases 1–6 are
+   shipped vs. inferred. If the docstring drifts from the user-visible API,
+   that's a finding in itself (note: the docstring at the `SoundCache` block
+   names a stale helper `resolve_footstep_sound`; the live fn is
+   `try_load_default_footstep` — confirm and treat doc-rot as LOW).
 
 ## Phase 2: Launch Dimension Agents
 
-### Dimension 1: Manager Lifecycle & Graceful Degradation
-**Entry points**: `crates/audio/src/lib.rs` — `AudioWorld::new`, `AudioWorld::default`, `is_active`, `Drop` (implicit via field drop order)
-**Checklist**:
-- `AudioManager::new(AudioManagerSettings::default())` failure path: `Option<AudioManager>` left as `None`, no panic. Booting on a headless server / CI / broken sound driver MUST succeed
-- Every public API on `AudioWorld` (`play_oneshot`, `play_music`, `stop_music`, `set_reverb_send_db`, …) checks `manager.is_some()` (or equivalent `is_active()` gate) and no-ops cleanly when inactive — no `unwrap()` on `Option<AudioManager>`
-- Field-drop order: `active_sounds` (owns `SpatialTrackHandle`s) → `pending_oneshots` → `music` → `reverb_send` → `listener` → `manager`. Rust drops struct fields in declaration order; the declaration order in `pub struct AudioWorld` MUST match the dependency order (track handles before listener before manager), or kira will assert-fail in Drop. Verify the declaration order has not been re-ordered "for readability"
-- `AudioWorld` is `Resource` (interior mutability via `&self` resource access); audit any `&mut World` requirement that snuck back in
-- `kira::AudioManagerSettings::default()` choice — verify default capacity bounds (`sound_capacity`, `sub_track_capacity`) are sufficient for cell-load bursts; document the cap
-- Re-init path: `AudioWorld::new()` is documented to be called once at engine boot. Audit any code that calls it on cell transition or window resize — the manager owns the OS audio device, re-acquiring is expensive and may fail
-**Output**: `/tmp/audit/audio/dim_1.md`
+Dimensions are ordered by audio risk: track-handle leaks and spatial correctness
+first, manager/ECS lifecycle and gameplay wiring last.
 
-### Dimension 2: Listener Pose Sync
-**Entry points**: `crates/audio/src/lib.rs` — `sync_listener_pose`, `AudioListener` component
-**Checklist**:
-- Listener is created **lazily** on the first frame an `AudioListener`-tagged entity has a resolved `GlobalTransform`. Before that, the audio system early-returns. Verify the lazy-creation path does NOT panic if the entity exists but `GlobalTransform` hasn't propagated yet (frame-1 cold-start race)
-- Listener-entity selection: query `AudioListener` returns the FIRST entity in iteration order. If multiple `AudioListener` components exist (mod scenario, debug fly-cam swap), behavior is "whichever wins iteration." Audit whether the system warns once when count > 1, or silently picks. Either is defensible; not warning when count > 1 is the audit hazard
-- `set_position` / `set_orientation` use `Tween::default()` every frame — this is correct for camera follow (smooth interpolation). Audit any path that switches to `Tween::IMMEDIATE` (would cause audible spatial jumps on warp / fast-travel)
-- Listener orientation: kira expects a `Quat` for orientation; verify the `GlobalTransform.rotation` semantic matches kira's "forward = -Z, up = +Y" (or whatever the active kira contract is). Mismatch is left/right channel inversion across the whole soundscape — subtle, lethal
-- `add_listener` failure (kira returns `Err`): logged as `warn!` and listener stays `None`. Verify the next frame retries (lazy create is idempotent on `None`) — without retry, a transient init failure permanently breaks audio for the session
-- Listener handle drops BEFORE manager drops (covered in Dim 1 — note here as cross-dim invariant)
-- `EntityId` of the listener is NOT cached across frames — re-resolved per tick. Verify, because caching would silently break debug fly-cam swaps
-**Output**: `/tmp/audit/audio/dim_2.md`
-
-### Dimension 3: Spatial Sub-Track Dispatch (One-Shot + Emitter Paths)
-**Entry points**: `crates/audio/src/lib.rs` — `dispatch_new_oneshots`, `drain_pending_oneshots`, `spawn_oneshot_at`, `AudioWorld::play_oneshot`, `ActiveSound`, `PendingOneShot`
+### Dimension 1: Spatial Sub-Track Lifecycle & Leaks (highest risk)
+**Entry points**: `crates/audio/src/lib.rs` — `ActiveSound`, `dispatch_new_oneshots`,
+`drain_pending_oneshots`, `prune_stopped_sounds`, `PendingOneShot`,
+`AudioWorld::play_oneshot`, `spawn_oneshot_at`
 **Checklist**:
 - Two dispatch paths exist and MUST stay observably equivalent:
-  - **Entity path**: `OneShotSound + AudioEmitter` on an entity → `dispatch_new_oneshots` builds a per-emitter `SpatialTrackHandle`, plays the sound, removes `OneShotSound` (keeps `AudioEmitter` so callers can query active state)
-  - **Queue path**: `AudioWorld::play_oneshot(sound, position, attenuation, volume)` enqueues `PendingOneShot` → drained at frame start by `drain_pending_oneshots` through the same spatial-sub-track shape, but `entity: None` on the resulting `ActiveSound`
-- Both paths MUST route through a `SpatialTrackBuilder` anchored at the listener (not at the world origin) — the `listener_id` is required for kira's spatial scene to attach the sub-track. Verify each dispatch path queries `listener_id` and early-returns if absent (`crates/audio/src/lib.rs::drain_pending_oneshots` and `crates/audio/src/lib.rs::dispatch_new_oneshots` both gate on it)
-- Per-sub-track reverb send: each `SpatialTrackBuilder` MUST opt into the global send via `.with_send(reverb_send_id, reverb_send_db)` at construction, NOT after — kira does not allow retroactive send level changes on a built track. Audit any path that builds a track without `with_send` (will not pick up reverb)
-- `ActiveSound._track: SpatialTrackHandle` — held for Drop side effect. Removing the underscore prefix or accidentally `drop()`ing it tears down playback even while the `handle` still ticks. Verify the field is named `_track` and not just `track`
-- `looping: bool` (Phase 4): when `true`, kira's `StaticSoundData::loop_region(..)` is applied at dispatch time. The prune sweep must distinguish `Stopped` for one-shots (natural termination → drop entry) vs `Stopped` for loops (caller-driven stop, e.g. cell unload → already-tweened-stop has completed → drop entry). A loop that reports `Stopped` without a prior caller-driven `stop()` is a bug — log as warn
-- Drain cap: `crates/audio/src/lib.rs::drain_pending_oneshots` warns at WARN if a single tick drains > 32 items. Verify the threshold is meaningful for footstep tempo; a per-frame retrigger is the regression class to detect
-- `Arc<StaticSoundData>` clone semantics: the same `Arc` can back many emitters without re-decoding (`SoundCache` invariant). Audit any path that clones `StaticSoundData` instead of cloning the `Arc`
-- Source-position resolution: queue path takes `position: Vec3` directly (no entity lookup); entity path reads `GlobalTransform.translation`. Verify the entity path does NOT also accept a fallback `Transform` (interpolation-state mismatch — must use the post-propagation `GlobalTransform`)
+  - **Entity path** (`dispatch_new_oneshots`): `OneShotSound + AudioEmitter` on
+    an entity → per-emitter `SpatialTrackHandle`, plays the sound, removes
+    `OneShotSound` (keeps `AudioEmitter` so callers can query active state),
+    `ActiveSound.entity = Some(..)`.
+  - **Queue path** (`drain_pending_oneshots`): `play_oneshot(sound, position,
+    attenuation, volume)` enqueues `PendingOneShot` → drained at frame start
+    through the same spatial-sub-track shape, `ActiveSound.entity = None`.
+- Both paths gate on `listener_id` (`listener.as_ref().map(|l| l.id())`) and
+  early-return if absent — `add_spatial_sub_track` requires a listener id. Verify
+  both helpers short-circuit when the listener hasn't been created yet (frame-1).
+- **`ActiveSound._track: SpatialTrackHandle` is held for Drop side effect only.**
+  Dropping it tears down playback while `handle` still ticks. Verify the field
+  keeps its `_track` name (an underscore strip / accidental `drop()` is the leak
+  class). The track must land in `active_sounds` before the helper returns, never
+  in a local that drops at end of scope.
+- `looping: bool` (Phase 4) → `loop_region(..)` applied at dispatch in the entity
+  path only (queue one-shots never loop). Verify the queue path never sets it.
+- **Drain cap**: `drain_pending_oneshots` warns at WARN when one tick drains > 32
+  items (footstep-tempo gone wrong — a per-frame retrigger). Confirm the threshold.
+- **Producer-side queue cap (regression guard, #852/#853)**: `play_oneshot` drops
+  oldest at 256 entries via `VecDeque::pop_front` (O(1)), and returns early when
+  `manager.is_none()` so the queue can't fill on headless. Re-verify the
+  `VecDeque` (not `Vec::remove(0)`) and the up-front manager-`None` drop.
+- **Drain ordering (regression guard, #851)**: the manager-active gate sits
+  BEFORE `std::mem::take(&mut pending_oneshots)`. A take-then-bail reorder would
+  silently lose drained items. Confirm the gate precedes the take.
+- `Arc<StaticSoundData>` clone semantics: same `Arc` backs many emitters without
+  re-decoding. Entity path uses `Arc::clone(&emitter.sound)`; volume is applied
+  via `(*sound).clone().volume(db)` which reuses the underlying `Arc<[Frame]>`.
+  Flag any path that deep-clones the PCM.
+- Source-position resolution: queue path takes `position: Vec3` directly; entity
+  path reads `GlobalTransform.translation`. Verify the entity path does NOT fall
+  back to interpolation-state `Transform` (must use post-propagation pose).
+- Volume→dB conversion (`20*log10(volume)`, clamped to -60 dB for ≤0) is
+  duplicated across `drain_pending_oneshots`, `dispatch_new_oneshots`, and
+  `play_music`. Flag drift between the three copies (a divergent clamp is a real
+  bug, not just dup).
+**Output**: `/tmp/audit/audio/dim_1.md`
+
+### Dimension 2: Listener Pose & Spatial Attenuation Correctness
+**Entry points**: `crates/audio/src/lib.rs` — `sync_listener_pose`,
+`AudioListener`, `Attenuation`
+**Checklist**:
+- Listener is created **lazily** on the first frame an `AudioListener`-tagged
+  entity has a resolved `GlobalTransform` (`add_listener(pose.0, pose.1)`). Before
+  that, `sync_listener_pose` early-returns at the first failed `iter.next()` /
+  `query` / `get`. Verify no panic on the frame-1 cold-start race (entity exists,
+  `GlobalTransform` not yet propagated).
+- **Listener handle is sticky across entity churn (regression guard, #849)**: the
+  `listener` field is created once and NEVER cleared, even when the marker entity
+  despawns (third-person swap, fly-cam destroy, save-load). On respawn the
+  existing handle's pose is updated, not a fresh `add_listener`. This is
+  deliberate — kira's listener capacity is the default (8); a clear-on-missing /
+  re-add-on-respawn loop would exhaust it. Flag any code that clears `listener`
+  on missing entity.
+- **Multi-listener diagnostic (regression guard, #843)**: when count > 1,
+  `sync_listener_pose` warns ONCE (`multi_listener_warned` debounce) and uses the
+  first iteration entity. Verify the warn is debounced (no per-frame spam during
+  the brief two-listener window of a camera transition).
+- `set_position` / `set_orientation` use `Tween::default()` every frame (smooth
+  camera follow). Flag any switch to immediate (audible spatial jump on
+  warp/fast-travel).
+- **Orientation contract**: kira expects a `Quat`; `GlobalTransform.rotation` is
+  passed straight through. Verify the Z-up(Gamebryo)→Y-up(renderer) conversion
+  has already happened upstream (NIFAL `coord.rs`) so the quat handed to kira is
+  in renderer space — a residual coordinate-frame mismatch is left/right channel
+  inversion across the whole soundscape, subtle and lethal.
+- **Attenuation curve**: `Attenuation` is `min_distance..=max_distance` linear
+  falloff via `SpatialTrackBuilder::distances`. Default `{2.0, 30.0}`. Verify the
+  range is passed as `RangeInclusive` (the exclusive `..` doesn't impl
+  `Into<SpatialTrackDistances>`) and that `min <= max` is never violated by a
+  caller (footsteps use `{0.5, 12.0}`).
+- `add_listener` failure is logged WARN and leaves `listener = None`; the next
+  frame retries (lazy create is idempotent on `None`). Verify the retry — a
+  transient init failure must not permanently break audio for the session.
+**Output**: `/tmp/audit/audio/dim_2.md`
+
+### Dimension 3: SoundCache Growth & Eviction
+**Entry points**: `crates/audio/src/lib.rs` — `SoundCache` (`get`, `insert`,
+`get_or_load`, `len`, `clear`, `bytes_estimate`), `load_sound_from_bytes`
+**Checklist**:
+- Path keys are interned lowercased at `insert` / `get` / `get_or_load` time
+  (`to_ascii_lowercase`) to match the engine-wide case-insensitive asset
+  convention. Verify every key path lowercases exactly once (no double-lowercase,
+  no missed call site).
+- **Eviction is manual via `clear()` — no automatic LRU.** That's documented as
+  acceptable (#850): the cache is intended to dedupe by path, mirroring
+  `AnimationClipRegistry`. The audit hazard is unbounded growth IF a real
+  consumer lands. Verify `clear()` does NOT invalidate `Arc`s held by live
+  `ActiveSound` entries (kira holds its own clone; the cache is not read through
+  after the play call) — this is the safety property a future cell-unload
+  `clear()` relies on.
+- **Dormant-API reality (#859)**: the engine binary has ZERO `SoundCache` call
+  sites today — `try_load_default_footstep` writes the decoded `Arc` straight
+  into `FootstepConfig.default_sound`, bypassing the cache. Steady-state
+  `len() == 0`. Confirm this (grep `SoundCache` across `byroredux/`); the
+  "unbounded growth" concern is FUTURE-phase, not a present leak. The audit task
+  is to pin that the decoupled API + tests survive so a producer can land without
+  rewriting call sites — and to flag if anyone wires the first consumer WITHOUT
+  also wiring eviction.
+- `bytes_estimate` sums `frames.len() * size_of::<kira::Frame>()` (8 B/frame
+  stereo) for telemetry. Verify it's wired to a `stats`-style console path (or
+  flag as dead if not) so an unbounded-growth regression surfaces in telemetry,
+  not at OOM.
+- `get_or_load` invokes the loader only on a miss and returns `None` on
+  decode-fail (logs WARN). Verify the loader isn't called on a hit (BSA-extract
+  cost paid lazily).
 **Output**: `/tmp/audit/audio/dim_3.md`
 
-### Dimension 4: Looping Emitter Sustain & Streaming Music
-**Entry points**: `crates/audio/src/lib.rs` — `prune_stopped_sounds`, `play_music`, `stop_music`, `load_streaming_sound_from_bytes`, `load_streaming_sound_from_file`
+### Dimension 4: Streaming Music Lifecycle
+**Entry points**: `crates/audio/src/lib.rs` — `play_music`, `stop_music`,
+`is_music_active`, `load_streaming_sound_from_bytes`,
+`load_streaming_sound_from_file`; field `music: Option<StreamingSoundHandle<FromFileError>>`
 **Checklist**:
-- Phase 4 looping: `AudioEmitter.looping = true` causes the prune sweep to issue a tweened `stop()` on the kira handle when the source entity has lost its `AudioEmitter` component (despawn-by-cell-unload, or explicit removal). Verify the tween duration is non-zero (instantaneous stop = audible click) AND that the next prune tick observes `Stopped` and drops the entry. Without the second tick, looping entries leak into the active list forever
-- Single-slot music dispatch (Phase 5): `play_music` overwrites any currently-playing track with a tweened crossfade. Verify there is exactly ONE music slot — multi-slot music is not in scope for M44, but a regression that adds a second slot would not fail any test today
-- **MUSC parse→play gap (re-scope, do NOT audit as a live path)**: cell-music FormIDs ARE parsed — `default_music` (ZNAM, `crates/plugin/src/esm/cell/wrld.rs:125`; field at `crates/plugin/src/esm/cell/mod.rs:744`) and `music_type_form` (XCMO, `wrld.rs:307`; field at `cell/mod.rs:169`) — but NO caller invokes `AudioWorld::play_music` (grep `play_music` across `byroredux/` returns zero hits; it is defined only at `crates/audio/src/lib.rs:416`). Treat cross-cell music continuity below as an explicit future-phase gap (MUSC routing on the FUTURE list), not a reachable path. The audit task is to confirm the parse→play wiring is absent (so the single-slot / main-track invariants are pinned for the eventual caller), NOT to trace a flow that has no producer
-- Music routes through the **main track** (non-spatial), NOT a spatial sub-track. Audit any path that puts music into the spatial scene — it would attenuate with listener distance, which is wrong for non-diegetic music
-- `StreamingSoundData` (kira) does NOT buffer the full decompressed PCM. Verify `load_streaming_sound_from_bytes` uses `StreamingSoundData::from_cursor`, not `StaticSoundData::from_cursor` — the latter buffers everything, OOM risk on multi-minute music tracks
-- File overload (`load_streaming_sound_from_file`): verify it resolves loose `Data/Music/*.mp3` / `*.wav` paths through the same path-resolution discipline as the BSA extractor (case-insensitive on Windows-derived game data, etc.)
-- `stop_music` fade duration: configurable. Audit default value; instant stop is a regression
-- Music handle field-drop: `music: Option<StreamingSoundHandle<...>>` drops before `manager` drops (Dim 1 invariant)
+- **Single-slot music**: `play_music` fades out any existing `music` handle and
+  replaces it (crossfade — both fades use the same `fade_in_secs` tween). Verify
+  exactly ONE music slot. A regression adding a second slot would fail no test
+  today — pin the single-slot invariant.
+- Music routes through the **main track** via `mgr.play(...)`, NOT a spatial
+  sub-track. Flag any path that puts music into the spatial scene (it would
+  attenuate with listener distance — wrong for non-diegetic music).
+- **Streaming, not buffered**: `load_streaming_sound_from_bytes` /
+  `_from_file` use `StreamingSoundData::from_cursor` / `::from_file`, NOT
+  `StaticSoundData` — the latter buffers full decompressed PCM (OOM on
+  multi-minute tracks). Verify the streaming types.
+- `stop_music` issues a fade-out then drops the handle (`music = None`); kira
+  keeps the sound alive internally until the fade completes. Verify the fade
+  duration is `fade_out_secs.max(0.0)` (instant stop = audible click is a
+  regression) and that dropping the handle doesn't cut the fade short.
+- `is_music_active` returns `false` once the handle reports `Stopped`. Verify it
+  doesn't report active during the fade-out tail in a way that blocks a legit
+  re-`play_music`.
+- **MUSC parse→play gap (re-scope — do NOT audit as a live path)**: cell-music
+  FormIDs ARE parsed — `default_music` (ZNAM, `crates/plugin/src/esm/cell/wrld.rs`
+  ~ZNAM arm; field `crates/plugin/src/esm/cell/mod.rs` `default_music: Option<u32>`)
+  and `music_type_form` (XCMO, `wrld.rs` XCMO arm; field `cell/mod.rs`
+  `music_type_form: Option<u32>`) — but NO caller invokes `play_music` (grep
+  `play_music` across `byroredux/` returns zero hits; it's defined only in
+  `crates/audio/src/lib.rs`). Treat MUSC routing as a FUTURE-phase gap. The audit
+  task is to CONFIRM the parse→play wiring is absent so the single-slot / main-track
+  invariants stay pinned for the eventual caller — not to trace a flow with no producer.
+- Music handle field-drop: `music` drops before `manager` (Dim 6 field-drop invariant).
 **Output**: `/tmp/audit/audio/dim_4.md`
 
 ### Dimension 5: Reverb Send & Routing (Phase 6)
-**Entry points**: `crates/audio/src/lib.rs` — `AudioWorld::new` (send track creation), `set_reverb_send_db`, every `SpatialTrackBuilder` site (`with_send` opt-in)
+**Entry points**: `crates/audio/src/lib.rs` — `AudioWorld::new` (send-track
+creation), `set_reverb_send_db`, `reverb_send_db`, both `with_send` sites
+(`drain_pending_oneshots` + `dispatch_new_oneshots`)
 **Checklist**:
-- One global send track is created at manager init with `SendTrackBuilder` + `ReverbBuilder` effect at full-wet output. `reverb_send: Option<SendTrackHandle>` is `None` if creation failed (e.g. manager itself was inactive) — verify this fallback path does NOT cascade into any later `unwrap()`
-- Default `reverb_send_db = f32::NEG_INFINITY` ("silent / reverb off"). Engine boots with NO audible reverb. Audit any path that initialises to a finite default (would mean every cell sounds wet from frame 1)
-- Per-new-track send level: applied at `with_send` construction time. **Already-playing sounds keep their construction-time level** — this is documented in the crate docstring (lib.rs:101-105). For short SFX (footsteps, gunshots) the level naturally refreshes as new sounds replace old ones; for long sustains (looping ambients) a level change won't apply until the loop is restarted. Audit findings claiming "reverb level changes don't take effect immediately" are stale premise — verify they actually need immediate application, then propose per-track level injection (not in M44 scope)
-- Cell-load → reverb level toggle: the interior detector is `byroredux/src/systems/audio.rs::reverb_zone_system` (#846). It watches `CellLightingRes::is_interior` and flips `set_reverb_send_db(INTERIOR_REVERB_SEND_DB = -12.0)` for interiors, back to `EXTERIOR_REVERB_SEND_DB = f32::NEG_INFINITY` for exteriors (both `const` local to the fn). Confirm: (a) the transition is bit-equality gated (`reverb_send_db().to_bits() == target_db.to_bits()` short-circuits the no-op tick — verify the gate stays bit-equal so `NEG_INFINITY → NEG_INFINITY` never re-touches the field); (b) the system no-ops safely when `CellLightingRes` is absent (engine boot pre-cell-load) AND when `AudioWorld` is absent (headless); (c) it is registered to write `AudioWorld` BEFORE `audio_system` constructs any new spatial track this frame (it runs exclusive at `Stage::Late`, ahead of `audio_system` — see `byroredux/src/main.rs:779` vs `:801`). Without ordering, a sound built this tick picks up last tick's send level. See Dimension 7 for the full detector audit
-- `set_reverb_send_db(f32::NEG_INFINITY)` should disable routing for new tracks (kira's send semantic: -∞ dB = silent). Audit whether kira clamps `-inf` to a finite floor (some send-bus implementations do); if so, the silent default is leaky
-- Reverb-send field-drop ordering: drops between `music` and `listener` (per Dim 1). Verify
+- One global send track is created in `AudioWorld::new` via
+  `SendTrackBuilder::new().with_effect(ReverbBuilder::new().feedback(0.85)
+  .damping(0.6).stereo_width(1.0).mix(Mix::WET))`. `reverb_send:
+  Option<SendTrackHandle>` is `None` if the manager was inactive or
+  `add_send_track` failed — verify the `None` path never cascades into a later
+  `unwrap()`.
+- **Per-new-track send opt-in**: each `SpatialTrackBuilder` opts into the send
+  via `.with_send(reverb.id(), reverb_send_db)` at construction time, gated on
+  `reverb_send_db.is_finite() && reverb_send_db > -60.0`. kira 0.10 has no
+  retroactive send-level setter, so this is build-time only. Verify BOTH dispatch
+  paths apply the gate identically (drift = inconsistent wetness between footsteps
+  and entity emitters).
+- **Default `reverb_send_db = f32::NEG_INFINITY`** ("reverb off"). Engine boots
+  dry. Flag any finite default (every cell wet from frame 1).
+- **Construction-time send level is a known limitation (#847), not a bug.**
+  Already-playing sounds keep their build-time level; the change applies to
+  NEW sounds. Audit findings claiming "level changes don't take effect
+  immediately" have a stale premise — verify they actually need immediate
+  application before escalating; the documented contract is "next-dispatch knob,
+  not a live fader."
+- `set_reverb_send_db(f32::NEG_INFINITY)` disables routing for new tracks (the
+  `> -60.0` gate means `-inf` never reaches `with_send`). Verify the gate so the
+  silent default is truly silent and never leaks a finite floor.
+- **Cell-load reverb toggle lives in Dim 7** (`reverb_zone_system`, #846). Note
+  here as a cross-dim pointer; keep the full detector audit in Dim 7.
+- Reverb-send field-drop ordering: `reverb_send` drops between `music` and
+  `listener` (Dim 6 field-drop invariant).
 **Output**: `/tmp/audit/audio/dim_5.md`
 
-### Dimension 6: ECS Lifecycle & Cell Streaming (M40 Interaction)
-**Entry points**: `crates/audio/src/lib.rs` (+ `crates/audio/src/tests.rs` post-Session-34 split) — `audio_system`, `prune_stopped_sounds`, `OneShotSound`, `AudioEmitter`; cross-cut: `byroredux/src/streaming.rs` (cell unload), `byroredux/src/cell_loader/{load,unload}.rs` (cell load/unload — was monolithic cell_loader.rs pre-Session-34)
+### Dimension 6: Manager Lifecycle, ECS Lifecycle & Cell Streaming
+**Entry points**: `crates/audio/src/lib.rs` — `AudioWorld::new` / `default` /
+`is_active` / `manager_mut`, struct field order, `audio_system`,
+`prune_stopped_sounds`; cross-cut: `byroredux/src/streaming.rs`,
+`byroredux/src/cell_loader/load.rs`, `byroredux/src/cell_loader/unload.rs`
 **Checklist**:
-- `audio_system` is documented to run at `Stage::Late` (after transform propagation produces final world poses). Verify the Schedule registration matches (`byroredux/src/main.rs:801`, `scheduler.add_exclusive(Stage::Late, byroredux_audio::audio_system)`); running before transform propagation reads stale `GlobalTransform` for the listener and emitters
-- **Cross-stage producer→consumer ordering (footstep → audio)**: `footstep_system` is registered exclusive at `Stage::PostUpdate` (`byroredux/src/main.rs:718`) and ENQUEUES `PendingOneShot` via `AudioWorld::play_oneshot`; `audio_system` DRAINS the queue at `Stage::Late` (`byroredux/src/main.rs:801`), strictly later the SAME frame. Verify `PostUpdate` precedes `Late` in the stage order so a footstep emitted in PostUpdate is heard the same tick — never lags a frame and never silently drops on a stage reorder. `footstep_system` is also exclusive specifically so it sequences AFTER `make_transform_propagation_system` produces the final pose (pre-#848 it ran in `Stage::Update` ahead of propagation → footstep landed at last-frame's pose). Audit any move of either system out of its stage
-- `OneShotSound` marker lifecycle: removed by `dispatch_new_oneshots` after dispatch (single-frame). Audit any path that retains the marker across frames (would re-trigger the sound every frame)
-- `AudioEmitter` lifecycle: stays on the entity for the duration of playback (Phase 3 contract — callers can query "is this entity still playing?"). When the playback handle reports `Stopped`, the prune pass removes `AudioEmitter`. Verify a downstream cleanup system can despawn the now-empty entity without coupling to audio state
-- Cell unload (M40 streaming): when a cell unloads, the entities carrying `AudioEmitter` are despawned. The prune pass MUST observe loops still attached to despawned entities and issue tweened stops, NOT leave orphan kira handles ticking. The `entity: Option<EntityId>` field on `ActiveSound` is the link — verify the prune pass checks entity-still-alive AND component-still-present (despawn drops both, but a partial-despawn — emitter removed but entity alive — is the corner case)
-- Cross-cell-load music continuity: music does NOT despawn on cell transition (single-slot, lives in `AudioWorld` resource). The "gate `play_music` on is-the-new-cell's-music-different" invariant is a FUTURE-phase contract — no cell-load caller reaches `play_music` today (see Dim 4 MUSC parse→play gap). Audit this as "the eventual MUSC caller MUST gate on FormID equality" — re-loading the same `StreamingSoundHandle` causes a re-decode + re-stream — rather than as a present regression surface
-- Listener entity despawn: if the entity carrying `AudioListener` is despawned (debug fly-cam destroy, world reset), the next `sync_listener_pose` early-returns. Verify the listener handle is cleaned up — it should drop with `AudioWorld` at engine shutdown, but a despawn-then-respawn cycle should not leak listener handles
-- `SoundCache` (Resource): process-lifetime path-keyed cache of decoded `Arc<StaticSoundData>`. Audit growth bound — should NOT grow per cell load (interning by lowercased path is the de-dupe mechanism, mirroring `AnimationClipRegistry` #790). If a cache `clear()` ever lands, verify it does NOT invalidate `Arc`s currently held by `ActiveSound` entries
-- Send-track lifetime: outlives every spatial sub-track that opted into it. Verify `reverb_send` is dropped strictly after `active_sounds` (Dim 1 invariant)
-- Future phase guard: when REGN ambient soundscapes (Phase 4 of the future-phases list) lands, expect a per-region `AudioEmitter` spawn-on-cell-enter / despawn-on-cell-leave pattern — this dimension's lifecycle invariants are the contract that will be tested then
+- **Graceful degradation**: `AudioManager::new` failure leaves `manager = None`,
+  no panic. Booting headless / CI / broken-driver MUST succeed. Every public API
+  gates on `manager.is_some()` (or the `audio_system` `is_active()` early-return)
+  with no `unwrap()` on the `Option<AudioManager>`. Regression guard:
+  `audio_world_constructs_without_panic_on_any_environment` (`tests.rs`).
+- **Capacities (regression guard, #842)**: `AudioWorld::new` sets
+  `sub_track_capacity = SUB_TRACK_CAPACITY (512)` and `send_track_capacity =
+  SEND_TRACK_CAPACITY (32)`, both above kira's defaults — populated interiors
+  (~400 emitters once FOOT/REGN land) blow past the 128 default with silent-drop
+  on `ResourceLimitReached`. Verify the consts and that `new()` actually applies
+  them. Guard: `manager_capacities_exceed_kira_defaults`.
+- **Field-drop order (single source of truth — collapse Dims 1/4/5 here)**: Rust
+  drops struct fields in declaration order. `AudioWorld` MUST declare in
+  dependency order so handles drop before the manager: `active_sounds`
+  (owns `SpatialTrackHandle`s) → `pending_oneshots` → `music` → `reverb_send` →
+  `reverb_send_db` → `listener` → `manager`. A "readability" reorder that moves
+  `manager` up would make kira assert-fail in Drop. Verify the declaration order.
+- `AudioWorld` / `SoundCache` are `Resource` (interior mutability via `&self`
+  resource access). Flag any `&mut World` requirement that snuck back in. `new()`
+  is boot-only — flag any call on cell transition / window resize (re-acquiring
+  the OS audio device is expensive and may fail).
+- **`audio_system` stage**: registered `add_exclusive(Stage::Late,
+  byroredux_audio::audio_system)` in `byroredux/src/main.rs` (after transform
+  propagation produces final poses). Running before propagation reads stale
+  `GlobalTransform`. Verify the stage hasn't moved. `audio_system` body order is:
+  `sync_listener_pose` → `drain_pending_oneshots` → `dispatch_new_oneshots` →
+  `prune_stopped_sounds`.
+- **Cross-stage producer→consumer (footstep → audio)**: `footstep_system` is
+  exclusive at `Stage::PostUpdate` and ENQUEUES `play_oneshot`; `audio_system`
+  DRAINS at `Stage::Late`, the SAME frame. Verify `PostUpdate` precedes `Late` so
+  a footstep is heard the same tick (never lags / drops on a stage reorder). Flag
+  any move of either system out of its stage.
+- **`OneShotSound` lifecycle**: removed by `dispatch_new_oneshots` after dispatch
+  (single-frame). Flag any path retaining the marker across frames (re-triggers
+  every frame).
+- **Despawn truncation (regression guard, #845/#858/SAFE-23)**: when an entity
+  loses its `AudioEmitter` (cell unload / explicit remove), `prune_stopped_sounds`
+  issues a tweened `stop()` using `ActiveSound.unload_fade_ms` (captured at
+  dispatch from `AudioEmitter.unload_fade_ms`, default `DEFAULT_UNLOAD_FADE_MS =
+  10.0` ms). Applies to looping AND non-looping (#858 extended it from
+  looping-only). `stop_issued` debounces the re-walk during the async fade window
+  (#844). Queue-driven sounds (`entity == None`) are exempt — they run to natural
+  termination. Verify: (a) entity-presence check via `AudioEmitter` query, (b)
+  `stop_issued` set after the stop, (c) the `retain` drops only on
+  `PlaybackState::Stopped`, (d) `AudioEmitter` removed on completion. Guards:
+  `looping_emitter_survives_natural_duration_and_stops_on_emitter_remove`,
+  `non_looping_emitter_stops_on_emitter_remove_regression_858`.
+- Listener-entity despawn: `sync_listener_pose` early-returns; the handle stays
+  (see Dim 2 sticky-listener guard) and drops with `AudioWorld` at shutdown — a
+  despawn/respawn cycle must not leak listener handles.
+- Cross-cell music continuity is a FUTURE-phase contract (no `play_music` caller
+  today — see Dim 4). The eventual MUSC caller MUST gate on FormID equality
+  (re-loading the same `StreamingSoundHandle` re-decodes + re-streams). Audit as
+  "pin the invariant for the future caller," not a present regression surface.
 **Output**: `/tmp/audit/audio/dim_6.md`
 
 ### Dimension 7: Gameplay Audio Wiring (Engine-Side Consumers)
-**Entry points**: `byroredux/src/systems/audio.rs` — `footstep_system`, `reverb_zone_system`; `byroredux/src/components.rs` — `FootstepEmitter`, `FootstepConfig`, `FootstepScratch`; `byroredux/src/scene.rs` (camera opt-in), `byroredux/src/asset_provider.rs` (`FootstepConfig.default_sound` population)
-**Why this dimension**: the M44 audio CRATE (Dims 1–6) is the producer of the `play_oneshot` / reverb API; the consumer that actually DRIVES it lives outside the crate, in `byroredux/src/systems/audio.rs`. `footstep_system` is the ONLY live `play_oneshot` caller in the engine, and `reverb_zone_system` is the ONLY caller of `set_reverb_send_db` on cell load. Neither was covered by the crate-scoped dimensions.
+**Entry points**: `byroredux/src/systems/audio.rs` — `footstep_system`,
+`reverb_zone_system`; `byroredux/src/components.rs` — `FootstepEmitter`,
+`FootstepConfig`, `FootstepScratch`; `byroredux/src/scene.rs` (camera opt-in);
+`byroredux/src/asset_provider.rs` — `try_load_default_footstep`
+**Why this dimension**: the M44 CRATE (Dims 1–6) is the producer of the
+`play_oneshot` / reverb API; the consumers that DRIVE it live outside the crate.
+`footstep_system` is the ONLY live `play_oneshot` caller; `reverb_zone_system` is
+the ONLY `set_reverb_send_db` caller. Neither is covered by the crate dimensions.
 **Checklist**:
-- **Footstep stride accumulation**: `footstep_system` walks every `FootstepEmitter`, accumulates XZ-plane (horizontal only — Y motion is not a step) movement against `FootstepEmitter.stride_threshold`, and fires one `play_oneshot` per threshold crossing. Verify only horizontal distance accumulates and `accumulated_stride` resets to `0.0` on fire (not subtracts — a subtract would carry over fractional stride and double-fire on a single large jump)
-- **First-tick seed (#848)**: on the first tick an emitter is seen (`!fs.initialised`), the system seeds `last_position = pos`, sets `initialised = true`, and `continue`s WITHOUT accumulating — otherwise the cold-start delta from origin to spawn would fire a phantom footstep. Verify the seed path exists and the seeded frame produces zero triggers
-- **`FootstepScratch` Vec reuse (#932)**: the per-tick trigger buffer lives in the `FootstepScratch` Resource (`triggers: Vec<Vec3>`, `Vec::with_capacity(32)` default) and is `clear()`-reused + `std::mem::take`-drained, NOT freshly allocated each frame. Verify the buffer's heap allocation is restored to the resource after dispatch (the `try_resource_mut::<FootstepScratch>()` re-acquire at fn end) on BOTH the success path and the `AudioWorld`-absent bail path — dropping the moved-out `Vec` would strand the capacity and re-allocate next frame
-- **Lock-drop ordering (query_mut → play_oneshot)**: Phase 1 holds `GlobalTransform` (read) + `FootstepEmitter` (write) concurrently, then RELEASES both before Phase 2 touches `AudioWorld`. The `FootstepScratch` mut-lock is also dropped (`drop(scratch)`) BEFORE `AudioWorld` is acquired — holding two resource-mut locks at once would force the TypeId-sorted acquisition contract. Verify no path holds a component query lock across a `play_oneshot` call (would serialise audio dispatch against the propagation read set)
-- **Footstep attenuation**: each footstep `play_oneshot` uses a tight `Attenuation { min_distance: 0.5, max_distance: 12.0 }` (tighter than the engine default — footsteps drop off fast). Audit any change to a wider falloff (would make distant NPC footsteps audible across a whole interior)
-- **Silent no-op contracts**: `footstep_system` returns early and silently when `FootstepConfig` is absent, when `FootstepConfig.default_sound` is `None` (no decoded footstep sound resolved — see `byroredux/src/asset_provider.rs`), when `FootstepScratch` is absent, when the emitter/transform queries fail, or when `AudioWorld` is absent. Verify NONE of these paths panic or log per-frame spam — the engine must boot and run with audio off
-- **Camera opt-in**: the player/fly-cam entity is given `FootstepEmitter` in `byroredux/src/scene.rs` (`world.insert(cam, crate::components::FootstepEmitter::new())`). Verify the opt-in is component-driven (no hardcoded camera-entity assumption inside the system), so NPCs can carry `FootstepEmitter` under future REGN/AI work
-- **`reverb_zone_system` (#846)** — the interior-reverb detector (full pins in Dim 5): re-confirm here as a gameplay-wiring consumer that `INTERIOR_REVERB_SEND_DB = -12.0` / `EXTERIOR_REVERB_SEND_DB = f32::NEG_INFINITY`, the bit-equality transition gate, the `CellLightingRes`-absent and `AudioWorld`-absent safe no-ops, and the `Stage::Late` registration ahead of `audio_system`
+- **Stride accumulation**: `footstep_system` accumulates XZ-plane (horizontal
+  only — Y is not a step) movement against `FootstepEmitter.stride_threshold`,
+  fires one `play_oneshot` per crossing, and RESETS `accumulated_stride = 0.0` on
+  fire (a subtract-remainder would multiply footsteps on a large teleport).
+  Guard: `single_large_jump_fires_one_footstep_only`.
+- **First-tick seed (#848)**: on the first tick (`!fs.initialised`), seed
+  `last_position = pos`, set `initialised = true`, and `continue` WITHOUT
+  accumulating — else the cold-start origin→spawn delta fires a phantom step.
+  Guard: `first_tick_seeds_last_position_without_firing`.
+- **`FootstepScratch` Vec reuse (#932)**: the per-tick trigger buffer lives in the
+  `FootstepScratch` resource (`triggers: Vec<Vec3>`, capacity 32) and is
+  `clear()`-reused + `std::mem::take`-drained, NOT freshly allocated. Verify the
+  buffer's heap allocation is restored to the resource (`try_resource_mut::<
+  FootstepScratch>()` re-acquire at fn end) on BOTH the success path AND the
+  `AudioWorld`-absent bail path — dropping the moved-out `Vec` strands the capacity.
+- **Lock-drop ordering**: Phase 1 holds `GlobalTransform` (read) + `FootstepEmitter`
+  (write) concurrently, then RELEASES both before Phase 2 touches `AudioWorld`.
+  The `FootstepScratch` mut-lock is `drop()`-ed BEFORE `AudioWorld` is acquired —
+  holding two resource-mut locks at once would force the TypeId-sorted
+  acquisition contract. Verify no component query lock is held across
+  `play_oneshot`.
+- **Footstep attenuation**: each footstep uses `Attenuation { min_distance: 0.5,
+  max_distance: 12.0 }` (tighter than the `{2.0, 30.0}` default — footsteps drop
+  off fast). Flag any widening (distant NPC footsteps audible across a whole
+  interior).
+- **Silent no-op contracts**: `footstep_system` returns early and silently when
+  `FootstepConfig` is absent, `default_sound` is `None`, `FootstepScratch` is
+  absent, the emitter/transform queries fail, or `AudioWorld` is absent. Verify
+  NONE panic or log per-frame spam. Guards: `no_default_sound_is_silent_noop`,
+  `standing_still_never_fires`.
+- **Camera opt-in**: the fly-cam entity gets `FootstepEmitter` in
+  `byroredux/src/scene.rs`. Verify the opt-in is component-driven (no hardcoded
+  camera-entity assumption inside the system) so NPCs can carry `FootstepEmitter`
+  under future REGN/AI work.
+- **`try_load_default_footstep`** (`byroredux/src/asset_provider.rs`): populates
+  `FootstepConfig.default_sound` from `--sounds-bsa` (canonical FNV dirt-walk
+  WAV), bypassing `SoundCache`. Verify it no-ops cleanly when the BSA / arg is
+  absent (engine boots with footsteps off).
+- **`reverb_zone_system` (#846)** — the interior-reverb detector. Re-confirm:
+  `INTERIOR_REVERB_SEND_DB = -12.0` / `EXTERIOR_REVERB_SEND_DB = f32::NEG_INFINITY`
+  (both `const` local to the fn); the transition is **bit-equality gated**
+  (`reverb_send_db().to_bits() == target_db.to_bits()` short-circuits, so
+  `NEG_INFINITY → NEG_INFINITY` never re-touches the field); it no-ops safely when
+  `CellLightingRes` is absent (boot pre-cell-load) AND when `AudioWorld` is absent
+  (headless); and it is registered `add_exclusive(Stage::Late, ...)` in
+  `byroredux/src/main.rs` BEFORE `audio_system` in the same stage — so a track
+  built this tick picks up this tick's send level, not last tick's. Guards:
+  `interior_cell_sets_subtle_reverb_send`,
+  `interior_to_exterior_transition_resets_send_to_dry`,
+  `no_cell_lighting_resource_is_safe_noop`, `no_audio_world_is_safe_noop`.
 **Output**: `/tmp/audit/audio/dim_7.md`
 
 ## Phase 3: Merge
 
 1. Read all `/tmp/audit/audio/dim_*.md` files
 2. Combine into `docs/audits/AUDIT_AUDIO_<TODAY>.md` with structure:
-   - **Executive Summary** — Crate phases shipped (1–6) + engine-side consumers shipped (Phase 3.5 footstep gameplay loop via `footstep_system`, Phase 6 reverb detector via `reverb_zone_system`) vs phases stubbed (3.5b, REGN, MUSC routing). Note the MUSC parse→play gap explicitly (FormIDs parsed, no `play_music` caller). Findings count by severity. Headless-mode boot status (must be PASS).
-   - **Lifecycle Invariant Matrix** — Field-drop order × verified / drifted, per-handle owner × renderer/audio crate.
+   - **Executive Summary** — Crate Phases 1–6 + engine consumers shipped
+     (footstep gameplay loop via `footstep_system`, per-cell reverb via
+     `reverb_zone_system`) vs pending (3.5b FOOT, REGN, MUSC routing, occlusion).
+     Note the MUSC parse→play gap explicitly (FormIDs parsed, no `play_music`
+     caller). Findings count by severity. Headless-mode boot status (MUST be PASS).
+     Delta vs the prior report `docs/audits/AUDIT_AUDIO_2026-05-05.md` (which of
+     #843–#859 are now regression-guarded).
+   - **Lifecycle Invariant Matrix** — Field-drop order × verified/drifted;
+     per-handle owner; sticky-listener; despawn-truncation guards.
    - **Findings** — Grouped by severity (CRITICAL first), deduplicated.
-   - **Future-Phase Readiness** — What invariants this audit pinned that the next phase (FOOT/3.5b material sounds / REGN / MUSC / occlusion) will rely on.
-3. Remove cross-dimension duplicates (Dim 1's field-drop order shows up in Dims 4 + 5 + 6 — collapse into Dim 1's row; `reverb_zone_system` is pinned in both Dim 5 and Dim 7 — keep the full detector audit in Dim 7, leave Dim 5's pointer to it)
+   - **Future-Phase Readiness** — Which invariants this audit pinned for the next
+     phase (FOOT/3.5b material sounds, REGN, MUSC routing, occlusion).
+3. Remove cross-dimension duplicates: field-drop order is owned by Dim 6 (pointers
+   from Dims 1/4/5); `reverb_zone_system` full audit lives in Dim 7 (pointer from
+   Dim 5).
 
 ## Phase 4: Cleanup
 

--- a/.claude/commands/audit-concurrency/SKILL.md
+++ b/.claude/commands/audit-concurrency/SKILL.md
@@ -1,25 +1,57 @@
 ---
-description: "Audit ECS lock ordering, Vulkan queue sync, RwLock patterns, deadlock potential"
+description: "Audit Vulkan queue/AS sync, ECS lock ordering, scheduler access declarations, RwLock patterns, deadlock potential"
 argument-hint: "--focus <dimensions> --depth shallow|deep"
 ---
 
 # Concurrency and Synchronization Audit
 
-Audit ByroRedux for deadlocks, race conditions, incorrect lock ordering, Vulkan synchronization gaps, and thread safety violations.
+Audit ByroRedux for data races, deadlocks, incorrect lock ordering, missing
+Vulkan synchronization, and thread-safety violations.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, methodology,
+deduplication, context rules, finding format, and the path-reference convention.
+See `.claude/commands/_audit-severity.md` for the severity scale — the rows that
+matter here:
+
+| Condition | Minimum Severity |
+|-----------|-----------------|
+| Data race on Vulkan queue / use-after-free / AS built at wrong address | CRITICAL |
+| Vulkan spec violation (missing barrier, fence misuse) | HIGH |
+| Missing AS barrier (build → shader read) | HIGH |
+| Resource / descriptor / command-buffer leak per frame | HIGH |
+| Missing cleanup on swapchain recreate | HIGH |
+| ECS deadlock potential (RwLock ordering violation) | HIGH |
+| FFI lifetime violation across the cxx bridge | CRITICAL |
+
+Dimensions below are ordered by **concurrency blast radius**: GPU queue / AS
+data races (CRITICAL) first, then ECS deadlock surfaces, then the
+already-closed scheduler/access machinery (now regression guards), then the
+slower-moving lifecycle / worker / chain dimensions.
 
 ## Parameters (from $ARGUMENTS)
 
 - `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 7.
-- `--depth shallow|deep`: `shallow` = check lock presence; `deep` = trace concurrent paths. Default: `deep`.
+- `--depth shallow|deep`: `shallow` = check barrier/lock presence; `deep` = trace concurrent paths and timing windows. Default: `deep`.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: ECS Locking | Vulkan Sync | Resource Lifecycle | Thread Safety | Compute → AS → Fragment Chains | Worker Threads (Streaming, Debug) | Physics Step Lock Ordering
-- **Trigger Conditions**: Exact timing/concurrency scenario needed to reproduce
+- **Dimension**: Vulkan Queue & AS Sync | Compute → AS → Fragment Chains | ECS Lock Ordering | Scheduler Access Declarations | RwLock Patterns (Resource↔Storage, Physics) | Resource Lifecycle | Worker Threads (Streaming, Debug)
+- **Trigger Conditions**: Exact timing/concurrency window needed to reproduce
+- **Verification Path**: For Vulkan-sync findings — whether the failure is observable in `cargo test`, the validation layer, or only RenderDoc (see "Speculative-fix guardrail" below)
+
+## Speculative-fix guardrail (read before reporting any Vulkan-sync finding)
+
+Vulkan render-pass / pipeline-barrier / semaphore / fence bugs are largely
+**invisible to `cargo test`** — there is no headless device assertion that
+catches a missing image barrier or a wrong stage mask. Per the project's
+standing rule, do **not** propose shipping a barrier/stage/layout change on
+reasoning alone. Frame each such finding as **"needs validation-layer or
+RenderDoc confirmation"** and state the concrete signal that would confirm it
+(a specific `VUID-*` validation message, a RenderDoc resource-state mismatch,
+or a visible artifact class). A finding whose only evidence is "this barrier
+looks wrong" is a HYPOTHESIS row, not a fix.
 
 ## Phase 1: Setup
 
@@ -29,39 +61,79 @@ See `.claude/commands/_audit-common.md` for project layout, methodology, dedupli
 
 ## Phase 2: Launch Dimension Agents
 
-### Dimension 1: ECS Lock Ordering
-**Entry points**: `crates/core/src/ecs/world.rs`, `crates/core/src/ecs/query.rs`, all system functions under `byroredux/src/systems/` (post-Session-34: `animation.rs`, `audio.rs`, `billboard.rs`, `bounds.rs`, `camera.rs`, `character.rs`, `debug.rs`, `light_anim.rs`, `metrics.rs`, `particle.rs`, `water.rs`, `weather.rs` — `systems.rs` itself is now a thin (33-line) module index)
-**Checklist**: TypeId-sorted lock acquisition in multi-component queries, RwLock held across system function calls, query_mut dropping before next query, resource_mut scope, nested query patterns (animation_system queries Player then Transform), World::insert during system execution.
+### Dimension 1: Vulkan Queue & Acceleration-Structure Sync (CRITICAL surface)
+**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (`draw_frame`), `crates/renderer/src/vulkan/sync.rs`, `crates/renderer/src/vulkan/acceleration/` (`blas_static.rs`, `blas_skinned.rs`, `tlas.rs`), `crates/renderer/src/vulkan/context/resize.rs`
+**Checklist**:
+- **Queue submission is single-Mutex.** `graphics_queue` and `present_queue` are both `Arc<Mutex<vk::Queue>>` (`context/mod.rs`); `present_queue` is an `Arc::clone` of `graphics_queue`, so one Mutex serialises all submits + presents. `vk::Queue` is `Copy`, so the canonical pattern is "lock → copy the handle out → drop the guard → `queue_submit`": confirm the guard is **not** held across `queue_submit`/`queue_present` (a held guard during a blocking submit would serialise every other queue user; a copied-out handle used after a *second* thread re-submits is a data race). Cross-check the `.lock()` sites in `draw.rs` (main submit ~`queue_submit`, and the secondary one-time-command submit) against this rule.
+- **Frame-in-flight discipline.** The `in_flight[frame]` fence must be waited on before its command buffer / per-frame resources are reused; `image_available[frame]` semaphore must not be reused while a prior acquire is still pending (the draw.rs comment block around the acquire→submit window documents the ordering — verify it still holds).
+- **Acquire → render → present semaphore chain** is correct and uses per-image (not per-frame) signal semaphores where required by the swapchain image index.
+- **AS build → read barrier.** Every BLAS/TLAS build or refit that a later ray query reads must be followed by an `ACCELERATION_STRUCTURE_WRITE_KHR → ACCELERATION_STRUCTURE_READ_KHR` barrier before the fragment-stage ray-query consumer. Static BLAS: `blas_static.rs` (`memory_barrier`, WRITE→READ). Skinned BLAS refit: `blas_skinned.rs` (note its refit-to-refit case is WRITE→WRITE). TLAS: `tlas.rs` (`cmd_pipeline_barrier`). A missing or wrong-stage barrier here is HIGH (CRITICAL if the AS is built at a wrong/stale device address — wrong geometry in shadows/reflections/GI).
+- **Swapchain recreate sync.** `recreate_swapchain` (`context/resize.rs`) must cover all in-flight work with `device_wait_idle` (or equivalent fence drain) before destroying/rebuilding swapchain-dependent resources — no use-after-destroy across the recreate.
+- **One-time command buffers** (BLAS initial build, staging copies) block the main thread on a fence — flag if any such blocking submit runs inside the per-frame hot path rather than at load time.
 **Output**: `/tmp/audit/concurrency/dim_1.md`
 
-### Dimension 2: Vulkan Synchronization
-**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (draw_frame), `crates/renderer/src/vulkan/sync.rs`, `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/src/vulkan/svgf.rs`, `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/src/vulkan/caustic.rs`, `crates/renderer/src/vulkan/volumetrics.rs`, `crates/renderer/src/vulkan/bloom.rs`, `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/src/vulkan/composite.rs`
-**Checklist**: Frame-in-flight fence wait before command buffer reuse, semaphore signaling order (acquire → render → present), TLAS build barrier before fragment shader read (AS_WRITE → AS_READ, build stage → fragment stage), SVGF compute dispatch barrier (G-buffer write → compute read, compute write → composite read), TAA dispatch barrier (HDR + motion + mesh_id sampled-read → compute read; compute write → composite sampled-read), caustic CLEAR → COMPUTE → FRAGMENT chain (host→compute UBO upload barrier + clear→compute image barrier + compute→fragment composite read barrier), volumetrics INJECT → INTEGRATE → composite-read chain (`volumetrics.rs`, M55, #1105): HOST→COMPUTE UBO upload barrier, injection (`lighting_volumes` write) → integration (read lighting, write `integrated_volumes`) → COMPUTE_WRITE→FRAGMENT_READ before `composite.frag` samples the integrated volume, plus the `tlas_written` per-frame-in-flight latch — `dispatch()` debug_asserts `write_tlas` ran for this slot first; verify the `dispatch()`-behind-`integrated`-consumed-const gate, bloom pyramid intra-frame mip barriers (`bloom.rs`, M58): per-level COMPUTE_WRITE(`SHADER_WRITE`)→COMPUTE_READ(`SHADER_READ`) `image_memory_barrier` between every downsample mip and every upsample mip (read-after-write within one command buffer; #931 emits only the post-barrier on the just-written mip), then `up_mips[0]` → composite sampled-read, skin_compute palette-build → skin → AS-BUILD → FRAGMENT chain (M29.5 `SkinPaletteComputePipeline` writes the bone palette → COMPUTE_WRITE→SHADER_READ → M29.3 `SkinComputePipeline` skin write → BLAS refit → ray-query read in fragment shader), descriptor set update timing (only safe after fence wait), swapchain recreate synchronization (device_wait_idle coverage), graphics_queue Mutex lock duration, BLAS build one-time command fence wait (blocks main thread).
+### Dimension 2: Compute → AS → Fragment Chains
+**Entry points**: `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/src/vulkan/acceleration/blas_skinned.rs` (refit path), `crates/renderer/src/vulkan/svgf.rs`, `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/src/vulkan/caustic.rs`, `crates/renderer/src/vulkan/water_caustic.rs`, `crates/renderer/src/vulkan/volumetrics.rs`, `crates/renderer/src/vulkan/bloom.rs`, `crates/renderer/src/vulkan/material.rs`, `crates/renderer/src/vulkan/context/draw.rs` (master ordering)
+**Checklist**:
+- **Skin chain (M29).** Palette build (`skin_compute.rs`) → `COMPUTE_WRITE→SHADER_READ` → per-mesh skin output → BLAS refit (`blas_skinned.rs`) reads it → fragment ray query hits the refit BLAS. The full palette→skin→refit→ray-query chain must be intact; a drift = stale geometry in shadows/reflections/GI. The live raster path uses inline skinning in `triangle.vert` (not the SSBO output), so a `VERTEX_INPUT` barrier is **not** currently required — flag only if a raster-from-skinned-SSBO path is added without one.
+- **Cross-frame ping-pong (no slot N reads slot N's in-flight write).** SVGF history, TAA history, caustic accumulator, water-caustic per-FIF `R32_UINT` accumulator, and volumetrics (`lighting_volumes` → `integrated_volumes`) all read the *previous* frame's slot. Verify the per-frame-in-flight indexing.
+- **Volumetrics gate (#1105).** Injection writes `lighting_volumes` (COMPUTE) → integration reads it, writes `integrated_volumes` (COMPUTE→COMPUTE) → `composite.frag` samples it (COMPUTE_WRITE→FRAGMENT_READ). `write_tlas` must run before `dispatch` each gated frame — `volumetrics.rs` keeps a `tlas_written: [bool; MAX_FRAMES_IN_FLIGHT]` latch that `dispatch` `debug_assert!`s and then resets. Verify the latch set/reset symmetry.
+- **Bloom within-frame RAW chain (#931).** Down-pyramid and up-pyramid each need a per-mip `COMPUTE_WRITE(SHADER_WRITE)→COMPUTE_READ(SHADER_READ)` image barrier so mip[i+1] sees mip[i]'s write; `up_mips[0]` must complete before composite samples it. Confirm the "post-barrier on the just-written mip only" accounting leaves no missing publish on the final up-mip.
+- **Caustic CLEAR → COMPUTE → FRAGMENT.** Accumulator cleared before compute writes; compute completes before composite reads.
+- **MaterialBuffer SSBO (R1).** `material.rs` upload is `HOST_WRITE → VERTEX/FRAGMENT_READ`; today it lands before draw recording so the frame fence already covers it — flag only if the upload moves into a compute path mid-frame.
 **Output**: `/tmp/audit/concurrency/dim_2.md`
 
-### Dimension 3: Resource Lifecycle
-**Entry points**: `crates/renderer/src/vulkan/context/mod.rs` (Drop impl), all `destroy()` methods, `crates/renderer/src/vulkan/buffer.rs`, `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/src/vulkan/context/resize.rs`, `crates/renderer/src/vulkan/egui_pass.rs` (`EguiPass`)
-**Checklist**: Reverse-order destruction (Vulkan requirement), Drop called for all GPU resources, no use-after-destroy during swapchain recreate, allocator freed last, BLAS/TLAS cleanup on shutdown (all BlasEntry buffers + TlasState buffers + scratch), G-buffer/SVGF/TAA/caustic/volumetrics/bloom/composite cleanup on swapchain recreate (per-frame-in-flight history images for TAA, accumulator images for caustic, `lighting_volumes` + `integrated_volumes` froxel slots for volumetrics, `down_mips` + `up_mips` for bloom), per-skinned-entity SkinSlot output buffers retained until owning entity destroyed, scene_buffer cleanup, MaterialBuffer SSBO cleanup (R1), texture registry cleanup, debug-ui `EguiPass` teardown (`destroy()` releases the egui-ash-renderer Vulkan resources + framebuffers; `egui_pass: Option<EguiPass>` taken/dropped in reverse order in `context/mod.rs` Drop; recreated framebuffers on resize via `context/resize.rs`).
+### Dimension 3: ECS Lock Ordering & Deadlock
+**Entry points**: `crates/core/src/ecs/world.rs` (`query_2_mut`, `query_2_mut_mut`, the resource-pair queries), `crates/core/src/ecs/query.rs`, `crates/core/src/ecs/lock_tracker.rs`, all system functions under `byroredux/src/systems/` (`animation.rs`, `audio.rs`, `billboard.rs`, `bounds.rs`, `camera.rs`, `character.rs`, `debug.rs`, `light_anim.rs`, `metrics.rs`, `particle.rs`, `water.rs`, `weather.rs`)
+**Checklist**:
+- **TypeId-sorted acquisition is the deadlock-prevention invariant.** `world.rs` multi-component queries acquire storage locks in `TypeId`-ascending order regardless of the generic-parameter order the caller spells (the `if id_a < id_b { … } else { … }` branches in `query_2_mut`). The `lock_tracker` scope guards are set up in the *same* order so the lock-order graph never sees a spurious ABBA edge when the caller writes `<B, A>` with `TypeId(A) < TypeId(B)` (#313). Verify any new multi-lock accessor follows this and that same-type access still hits the `assert_ne!` panic.
+- **`lock_tracker` coverage.** Same-thread re-entrant conflict detection is **always-on** in debug builds (`track_read`/`track_write` panic on a conflicting held lock). The cross-thread global lock-order graph is **opt-in via `BYRO_LOCK_ORDER_CHECK=1`** (`global_order` module) — so an ABBA risk between two *parallel* systems is only caught when that env var is set. Flag any CI/test path that should run with it but doesn't (see `docs/contributing.md` `lock-order-check` job).
+- **Guard lifetime in system bodies.** No `query_mut`/`resource_mut` guard held across a call that re-enters the same storage/resource; nested query patterns (e.g. animation querying Player then Transform) must drop the first guard or use the paired `query_N_mut` accessor; no `World::insert` (structural mutation, `&mut self`) during system execution (systems hold `&World`).
+- **Poisoning.** Storage `RwLock`s poison on panic; every acquisition resolves `PoisonError` through `storage_lock_poisoned::<T>()` (re-panics with a diagnostic). Confirm no acquisition path silently `unwrap()`s a poisoned guard into torn state.
 **Output**: `/tmp/audit/concurrency/dim_3.md`
 
-### Dimension 4: Thread Safety
-**Entry points**: All types with `Send + Sync` bounds (Component, Resource), `Arc<Mutex<Allocator>>`, `Mutex<vk::Queue>`, Ruffle player (wgpu context), `crates/debug-ui/src/lib.rs` (`EguiPassConfig`)
-**Checklist**: Component storage accessed only through World query guards, Resource access only through World resource guards, no raw pointer sharing across threads, cxx bridge pointer lifetimes, UI manager thread safety (wgpu device is Send but not Sync), debug-ui allocator sharing — `EguiPassConfig.allocator: Arc<Mutex<gpu_allocator::vulkan::Allocator>>` is a NEW consumer of the same allocator Mutex `VulkanContext` holds; the `EguiPass` is built/owned by the renderer (`egui_pass.rs`) and its overlay dispatch runs inside `draw_frame` (single-threaded main loop, after composite), so the only sharing concern is that the egui-ash-renderer holds the `Arc<Mutex<Allocator>>` clone for its whole lifetime — confirm no lock is held across a queue submit. Parse-time `Material` translation (`byroredux/src/material_translate.rs::translate_material`, `Material::resolve_pbr`) is single-threaded with no Mutex/RwLock/resource_mut — OUT of concurrency scope; see also `/audit-nifal` for the canonical translation tier.
+### Dimension 4: Scheduler Access Declarations (regression guard — M27 closed)
+**Entry points**: `crates/core/src/ecs/scheduler.rs`, `crates/core/src/ecs/access.rs`, `byroredux/src/commands.rs` (`sys.accesses`)
+**Status**: M27 (parallel dispatch) and R7 (access declarations) are **closed**
+(ROADMAP.md). The `parallel-scheduler` feature is **on by default**; the
+post-migration `sys.accesses` report is **0 unknown / 0 conflicts**. This
+dimension is therefore a **regression guard**, not migration tracking.
+**Checklist**:
+- **The conflict model is sound and matches the enum.** `AccessConflict` has exactly three variants — `None`, `Unknown { left_undeclared, right_undeclared }`, `Conflict { pairs }` (`access.rs`); there is **no `Parallel` variant**. `analyze_pair` returns `Unknown` whenever either side is undeclared (the *pessimistic* fallback, not "no conflict"), `Conflict` on a write/read or write/write overlap on the same component or resource, `None` otherwise. Verify any new variant or analyzer change preserves the "undeclared ⇒ Unknown ⇒ assume serialise" semantics.
+- **Migration KPIs.** `AccessReport::undeclared_parallel_count()` is the migration KPI (the population the analyzer can reason about); `undeclared_count()` = parallel + exclusive split via `undeclared_parallel_count()` + `undeclared_exclusive_count()` (#1237). `known_conflict_count()` and `unknown_pair_count()` must stay **0** on the engine binary — a regression here means a parallel-stage system was added without an `add_to_with_access` declaration (closures/bare-fns can't override `System::access`, so they need the registration-site channel; #1236).
+- **Exclusive phase.** Exclusive systems run serially after the parallel batch (`StageData.exclusive`) — they're listed in the report but never paired; the four runtime-mutually-exclusive systems re-staged in M27 Phase 3 (audio, spin, character-mode dispatcher, `player_controller_system`) must stay exclusive. Flag any move back to parallel.
+- **Re-entry & panic policy.** `Scheduler` is owned by `App`, never a `Resource` — re-entry from a system body is structurally impossible (#868). Panic-in-system is fail-fast by design (#1412); do not report "missing catch_unwind" as a bug.
 **Output**: `/tmp/audit/concurrency/dim_4.md`
 
-### Dimension 5: Compute → AS → Fragment Chains
-**Entry points**: `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/src/vulkan/acceleration/` (refit path), `crates/renderer/src/vulkan/svgf.rs`, `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/src/vulkan/caustic.rs`, `crates/renderer/src/vulkan/volumetrics.rs`, `crates/renderer/src/vulkan/bloom.rs`, `crates/renderer/src/vulkan/context/draw.rs` (master ordering)
-**Checklist**: Per-frame-in-flight ping-pong correctness across SVGF history, TAA history, caustic accum, and volumetrics (`lighting_volumes` → `integrated_volumes` per FIF) — no slot N reads from slot N's in-flight write. M29.5 palette-build compute writes the per-frame bone palette → COMPUTE_WRITE→SHADER_READ → M29.3 skin compute writes the per-skinned-mesh output buffer THEN BLAS refit reads it THEN fragment shader's ray queries hit the refit BLAS — the full chain (palette → skin → refit → ray-query) must be intact (drift = stale geometry in shadows / reflections / GI). M29.3 raster path: same skinned output buffer also flows COMPUTE → VERTEX (deferred — `triangle.vert` inline-skinning is the live path); when raster-from-SSBO ships, requires a `VK_PIPELINE_STAGE_VERTEX_INPUT_BIT` barrier — verify the additional usage flag is set. SVGF reads the previous frame's history (never the current's in-flight write); TAA same invariant for history slots. Caustic accumulator must be cleared BEFORE compute writes (CLEAR → COMPUTE), and compute writes must complete BEFORE composite reads (COMPUTE → FRAGMENT). Volumetrics injection writes `lighting_volumes` BEFORE integration reads it (COMPUTE → COMPUTE), integration writes `integrated_volumes` BEFORE composite samples it (COMPUTE → FRAGMENT), and `write_tlas` must run BEFORE `dispatch` each frame the integrated-volume gate is on (`tlas_written` per-FIF latch, debug_asserted; #1105). Bloom is a within-frame RAW chain (no cross-frame history): the down-pyramid and up-pyramid each need a per-mip COMPUTE_WRITE→COMPUTE_READ barrier so mip[i+1] sees mip[i]'s write, and `up_mips[0]` must complete before composite samples it — verify the #931 "post-barrier on the just-written mip only" accounting holds (no missing publish on the final up-mip). MaterialBuffer SSBO upload (R1) is HOST_WRITE → VERTEX/FRAGMENT_READ; per-frame upload happens before draw record begins, fence wait already covers it but verify if upload moves into compute path.
+### Dimension 5: RwLock Patterns — Resource↔Storage & Physics Step
+**Entry points**: `crates/physics/src/sync.rs` (`physics_sync_system`, `set_linear_velocity`, `set_kinematic_translation`), `crates/physics/src/world.rs` (`PhysicsWorld`), `crates/physics/src/components.rs` (`RapierHandles`), `crates/physics/src/config.rs` (`ContactConfig`), `byroredux/src/cell_loader/unload.rs` (`release_victim_rapier_bodies`), `byroredux/src/systems/character.rs`
+**Checklist**:
+- **TypeId-sorting does NOT cover the Resource↔Storage pair.** The deadlock-prevention sort in `query_N_mut` orders *storage* locks; a Resource lock (`resource_mut`) and a storage lock (`query`/`query_mut`) are an unordered pair. So no `resource_mut::<PhysicsWorld>()` guard may be held across a `query`/`query_mut` iteration and vice-versa. `physics_sync_system` is a 4-phase system (collect newcomers → register → step → pull dynamic). Verify Phase 1 `collect_newcomers` collects to a `Vec` under read guards and **drops them** before `register_newcomers` takes the `PhysicsWorld` + `RapierHandles` write guards.
+- **Helper lock order.** `set_linear_velocity` / `set_kinematic_translation` read `RapierHandles` via `world.query::<RapierHandles>()...copied()` (the read guard drops at the end of the `match`/`let` expression because the handle is `Copy`), *then* take `resource_mut::<PhysicsWorld>()`. Confirm the read guard is genuinely dropped before the write guard, and that callers (e.g. `character_controller_system`) don't already hold a `PhysicsWorld` guard when they call these.
+- **`ContactConfig`** is read via `try_resource` (optional) and snapshotted once per batch in `register_newcomers` — confirm it is not re-locked inside the per-newcomer loop.
+- **Cell-unload teardown (#1520).** `release_victim_rapier_bodies` (`unload.rs`) collects each victim's `RapierHandles` into a scratch `Vec` under the storage read guard, drops it, then removes bodies/colliders from `PhysicsWorld` — same release-reads-before-write discipline; verify it runs before the despawn loop drops the handles.
+- **Single-threaded placement.** `physics_sync_system` runs in `Stage::Physics` after transform propagation and must not be co-scheduled (parallel) with any other system that touches `PhysicsWorld` / `RapierHandles` / `Transform`.
 **Output**: `/tmp/audit/concurrency/dim_5.md`
 
-### Dimension 6: Worker Threads (Streaming, Debug Server)
-**Entry points**: `byroredux/src/streaming.rs` (M40 async pre-parse worker), `crates/debug-server/src/listener.rs` (per-client TCP threads), `crates/debug-server/src/system.rs` (DebugDrainSystem)
-**Checklist**: Streaming worker thread: shutdown drain joins cleanly (no detached thread leak on app exit) — **#1167 Drop-ordering pin**: `WorldStreamingState::request_tx` is `Option<mpsc::Sender<LoadCellRequest>>` and the `Drop` impl `take()`s + drops the Sender BEFORE the `worker: Option<JoinHandle<()>>` is dropped (declaration-order field-drop would otherwise drop/detach the worker before the channel closes, defeating the join); `shutdown(&mut self)` takes the worker handle so the later `Drop` safety-net observes `worker: None` and short-circuits. No `panic` propagation across the channel, parsed cell payload moves to main thread via channel without races on the World. Worker off-thread NIF/texture extract uses `Arc<TextureProvider>` whose inner `BsaArchive`/`Ba2Archive` serialise `File` access via `Mutex` (concurrent extracts are safe); BGSM resolution (`MaterialProvider::merge_bgsm_into_mesh`, `&mut`) stays main-thread-only — worker does NOT touch BGSM. NIF import cache (`Resource`) accessed from worker — verify locking discipline (read-only fast path, write-back deferred to main). Debug server: per-client threads do NOT touch the World directly — all mutations go through DebugDrainSystem on the main thread (Late-stage exclusive). Command queue between TCP listener and main thread is bounded (no unbounded buffering on slow main loop). Screenshot flow: GPU readback completes on a fence wait — verify no race between drain system and present.
+### Dimension 6: Resource Lifecycle (GPU teardown ordering)
+**Entry points**: `crates/renderer/src/vulkan/context/mod.rs` (Drop impl), all `destroy()` methods, `crates/renderer/src/vulkan/buffer.rs`, `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/src/vulkan/context/resize.rs`, `crates/renderer/src/vulkan/egui_pass.rs`, `crates/renderer/src/vulkan/scene_buffer/`, `crates/renderer/src/vulkan/material.rs`
+**Checklist**:
+- **Reverse-order destruction** (Vulkan requirement); Drop reached for all GPU resources; allocator freed last. Note #1483 hoisted allocator-independent destroys out of the allocator-guard scope in Drop — verify no resource that *needs* the allocator is destroyed after the guard is dropped.
+- **No use-after-destroy across swapchain recreate.** G-buffer / SVGF / TAA / caustic / water-caustic / volumetrics (`lighting_volumes` + `integrated_volumes`) / bloom (`down_mips` + `up_mips`) / composite resources rebuilt on recreate; per-FIF history/accumulator images freed for every in-flight slot; egui framebuffers rebuilt (`resize.rs`).
+- **AS cleanup on shutdown.** All `BlasEntry` buffers + `TlasState` buffers + scratch released; per-skinned-entity skin output buffers retained until the owning entity is destroyed.
+- **Other GPU SSBO/descriptor cleanup.** `scene_buffer` cleanup, `MaterialBuffer` SSBO (R1), texture registry, `EguiPass::destroy()` (releases egui-ash-renderer resources + framebuffers; `egui_pass: Option<EguiPass>` taken/dropped in reverse order in `context/mod.rs` Drop).
+- **Per-frame leaks.** Any descriptor / command-buffer / staging allocation created per frame but not freed/reset is HIGH (compounds).
 **Output**: `/tmp/audit/concurrency/dim_6.md`
 
-### Dimension 7: Physics Step Lock Ordering
-**Entry points**: `crates/physics/src/sync.rs` (`physics_sync_system`, `set_linear_velocity`, `set_kinematic_translation`), `crates/physics/src/world.rs` (`PhysicsWorld`), `crates/physics/src/components.rs` (`RapierHandles`), `crates/physics/src/config.rs` (`ContactConfig`), `byroredux/src/systems/character.rs` (KCC consumer, M28.5)
-**Checklist**: `physics_sync_system` is a 4-phase ECS system (register newcomers → push kinematic → step → pull dynamic) that takes sequential write locks (`resource_mut::<PhysicsWorld>()`) interleaved with `query`/`query_mut::<RapierHandles>()` and `try_resource::<ContactConfig>()`. Verify the documented "release read locks before acquiring write locks" discipline holds: Phase 1 `collect_newcomers` collects to a `Vec` under read guards, drops them, THEN `register_newcomers` takes the `PhysicsWorld` write guard + the `RapierHandles` write guard — no read guard on the same storage may still be live when the write guard is taken (would deadlock under the RwLock). No `resource_mut::<PhysicsWorld>()` guard held across a `query`/`query_mut` iteration over a component storage and vice-versa (TypeId-sorted acquisition does not cover the Resource↔Storage lock pair). `ContactConfig` is read via `try_resource` (optional) and snapshotted once per batch — confirm it is not re-locked inside the loop. Single-threaded main-loop placement: the system runs after `transform_propagation_system` and is not dispatched concurrently with any other system that touches `PhysicsWorld` / `RapierHandles` / `Transform`. The `set_linear_velocity` / `set_kinematic_translation` helpers each take a `RapierHandles` read guard then a `PhysicsWorld` write guard — verify the read guard is dropped (out of the `match`) before the write guard, and that callers (e.g. `character_controller_system`) don't already hold a `PhysicsWorld` guard.
+### Dimension 7: Worker Threads (Streaming, Debug Server) & Thread-Safety Bounds
+**Entry points**: `byroredux/src/streaming.rs` (M40 async pre-parse worker), `crates/debug-server/src/listener.rs` (per-client TCP threads), `crates/debug-server/src/system.rs` (`DebugDrainSystem`), `crates/debug-ui/src/lib.rs`, all types with `Send + Sync` bounds (`Component`, `Resource`), `crates/renderer/src/vulkan/allocator.rs` (`SharedAllocator`)
+**Checklist**:
+- **Streaming Drop ordering (#1167).** `WorldStreamingState::request_tx` is `Option<mpsc::Sender<LoadCellRequest>>` and `worker` is `Option<JoinHandle<()>>`. The `Drop` impl must `take()` + drop the Sender BEFORE the worker handle is dropped (declaration-order field drop would otherwise detach the worker before the channel closes, defeating the join). `shutdown(&mut self, timeout)` takes the worker handle so the later `Drop` safety-net observes `worker: None` and short-circuits. Verify the field-drop / `take()` ordering and the join-with-timeout path.
+- **Worker ↔ main data flow.** Parsed cell payload moves to the main thread via channel — no shared `&mut World` from the worker. Off-thread NIF/texture extract goes through `Arc<TextureProvider>` whose inner `BsaArchive`/`Ba2Archive` serialise `File` access via Mutex (concurrent extracts safe). BGSM resolution (`&mut`, `MaterialProvider::merge_bgsm_into_mesh`) stays main-thread-only — confirm the worker doesn't touch it. NIF import cache (`Resource`) accessed from the worker must use a read-only fast path with write-back deferred to main.
+- **Debug server.** Per-client TCP threads do **not** touch the World directly — all mutations route through `DebugDrainSystem` on the main thread (Late-stage exclusive). The command queue between listener and main thread must be bounded (no unbounded buffering on a slow main loop). Screenshot readback completes on a fence wait — verify no race between the drain system and present.
+- **Allocator sharing.** `SharedAllocator = Arc<Mutex<vulkan::Allocator>>` (`allocator.rs`) is held by `VulkanContext` and cloned into `EguiPass` (`egui_pass.rs`), volumetrics, ssao, scene_buffer, etc. All dispatch runs single-threaded inside `draw_frame`; the only correctness concern is that no holder keeps the Mutex locked across a queue submit. The egui overlay dispatch runs after composite on the main loop.
+- **`Send + Sync` bounds.** Component/Resource storage reached only through World query/resource guards; no raw pointer shared across threads; cxx-bridge pointer lifetimes bounded; Ruffle/wgpu (UI) device is `Send` but not `Sync` — confirm it stays on one thread.
+- **Out of scope:** parse-time `Material` translation (`byroredux/src/material_translate.rs::translate_material`, `Material::resolve_pbr`) is single-threaded with no Mutex/RwLock/resource_mut — see `/audit-nifal` for that boundary.
 **Output**: `/tmp/audit/concurrency/dim_7.md`
 
 ## Phase 3: Merge

--- a/.claude/commands/audit-ecs/SKILL.md
+++ b/.claude/commands/audit-ecs/SKILL.md
@@ -6,83 +6,307 @@ description: "Deep audit of the ECS — storage backends, queries, world, system
 
 Read `_audit-common.md` and `_audit-severity.md` for shared protocol.
 
+The ECS core is `crates/core/src/ecs/`. Since Session 34's split the module
+is one-file-per-concern: `storage.rs` holds only the `Component` /
+`ComponentStorage` / `DynStorage` traits + `EntityId`; the two backends live in
+`packed.rs` (`PackedStorage`) and `sparse_set.rs` (`SparseSetStorage`).
+`world.rs` owns the `RwLock`-per-storage `World`; `query.rs` the guard-owning
+query wrappers; `resource.rs` the resource guards; `scheduler.rs` the stage
+scheduler; `access.rs` the declared-access conflict analyzer; `lock_tracker.rs`
+the deadlock / ABBA detector; `systems.rs` the transform-propagation system.
+
+Dimensions are ordered by ECS blast radius: lock ordering / deadlock first,
+then storage correctness, query borrow safety, scheduler declarations, resource
+lifetimes, then the cross-cutting lifecycle and hot-path guards.
+
 ## Dimensions
 
-### 1. Storage Correctness
-- SparseSetStorage: swap-remove fixes sparse pointer for moved entity
-- SparseSetStorage: insert into existing entity overwrites (no duplicate)
-- PackedStorage: binary_search maintains sort invariant after insert/remove
-- PackedStorage: insert at correct position, remove shifts correctly
+### 1. Lock Ordering & Deadlock (HIGHEST blast radius)
 
-### 2. Query Safety
-- RwLockReadGuard lifetime doesn't outlive the query
-- RwLockWriteGuard is exclusive (no double write-lock)
-- query_2_mut / query_2_mut_mut: locks acquired in TypeId order
-- Same-type double-lock: panics with clear message (not deadlock)
-- QueryRead/QueryWrite Deref impls don't expose unsound references
+A wrong lock order is a HIGH (per `_audit-severity`: "ECS deadlock potential").
 
-### 3. World Integrity
-- TypeMap: downcast_ref/downcast_mut always correct (TypeId matches)
-- Lazy storage init: first insert creates storage, queries before insert return None
-- Entity ID monotonic (no reuse, no overflow handling — document limitation)
-- find_by_name: no string comparison in scan (FixedString integer equality only)
+- **Same-thread reentrancy**: `lock_tracker` (`lock_tracker.rs`) panics with a
+  clear message when a thread takes `write` on a type it already holds (read or
+  write), or `read` while holding `write`. The thread-local check runs in BOTH
+  debug and release; the global lock-order graph (ABBA, #313) is debug-only.
+  Verify every `query` / `query_mut` / `resource` / `resource_mut` site in
+  `world.rs` arms a `TrackedRead` / `TrackedWrite` scope, defuses it only AFTER
+  the real lock is acquired, and that the wrapper's `Drop` untracks.
+- **TypeId-sorted multi-lock acquisition**: `query_2_mut` / `query_2_mut_mut`
+  (`world.rs`) and `resource_2_mut` / `try_resource_2_mut` (`world.rs`) acquire
+  in `id_a < id_b` order — and set up the *tracker scopes in the same order*
+  (the #313 fix: pre-fix the scopes were armed in generic-parameter order, which
+  looked like ABBA to the graph when the caller spelled `<B, A>`). A regression
+  that arms scopes in parameter order instead of TypeId order re-opens #313.
+- **Same-type double-lock panics, never deadlocks**: `query_2_mut` /
+  `query_2_mut_mut` / `resource_2_mut` `assert_ne!` on `A == B` with a clear
+  message. A silent self-deadlock is the regression.
+- **ABBA across rayon workers**: the global graph generalizes the pair guarantee
+  to any N-lock hold pattern across the parallel scheduler. Two single-type
+  queries acquired in opposite orders on two workers must trip the graph, not
+  deadlock. Pin: this is the only protection for ad-hoc N>2 lock holds.
+- **Poison-on-panic resolution**: every lock acquisition resolves
+  `PoisonError` through `storage_lock_poisoned::<T>()` /
+  `storage_lock_poisoned_erased()` / `resource_lock_poisoned::<R>()`
+  (`world.rs`) — a post-panic access re-panics loud with the type name, never
+  silently reads torn state. `despawn` uses the type-erased variant fed by the
+  `type_names` side-table (#466). Removing a poison-resolve site is a finding.
 
-### 4. Resource Safety
-- resource() panics with type name on missing resource
-- try_resource() returns None (no panic)
-- ResourceRead/ResourceWrite Deref impls type-safe
-- Resources usable from systems (interior mutability via &self)
+### 2. Storage Correctness
 
-### 5. System & Scheduler
-- Blanket impl for Fn(&World, f32) correct (no ownership issues)
-- Mutations from system N visible to system N+1 in same run()
-- Empty scheduler runs without panic
-- system_names() returns correct order
+- **SparseSetStorage** (`sparse_set.rs`): swap-remove fixes the sparse pointer
+  for the entity moved into the gap (`self.sparse[moved_entity] = Some(dense_idx)`);
+  removing the last element takes the no-swap path; insert into an existing
+  entity overwrites in place (no duplicate, len unchanged). Pinned by
+  `swap_remove`, `remove_last`, `overwrite` in the file's test module.
+- **PackedStorage** (`packed.rs`): `binary_search` maintains the sorted-by-entity
+  invariant on every insert/remove; `insert_bulk` uses the append + single-sort
+  fast path (#467) instead of O(n) per-insert shift; a bulk insert that
+  re-sorts must keep the set sorted AND deduplicated.
+- **Change tracking (`Component::TRACK_CHANGES`)**: opt-in per-entity dirty set
+  (`PackedStorage`, via `mark_dirty` on insert/get_mut/remove) and a monotonic
+  `structural_gen` counter (`SparseSetStorage::structural_generation`, bumped on
+  insert/remove incl. reparent overwrite). The const is `false` by default so
+  non-tracked components pay nothing (branch folds away). Enabled for
+  `Transform` / `GlobalTransform`. Audit: `drain_dirty_into` clears `out` then
+  drains while *preserving* `self.dirty` capacity (#1371); `take_dirty` hands
+  capacity away (0-cap regrow). The dirty set MAY contain duplicates — consumers
+  must tolerate that. A storage that forgets to `mark_dirty` on a mutation path
+  silently breaks transform propagation's fast path (dim 8).
+- **`insert_bulk` debug guard**: `World::insert_batch` (`world.rs`) wraps the
+  iterator so the `entity < next_entity` `debug_assert` still fires per item —
+  a bulk path that skips it lets unspawned IDs in.
 
-### 5b. M27 — Parallel Scheduler Access Declarations (closed 2026-05-23)
-- **M27 Phase 1+2** (`a9810d40`): every system in `byroredux/src/systems/*.rs` declares its component / resource access surface (read / write per type). The declaration is checked by the scheduler at registration time; any system missing a declaration is a regression (`SystemAccess::default()` would conservatively serialize everything)
-- **M27 Phase 3** (`05fe2bac`): the four remaining access conflicts between parallel-stage systems were resolved, bringing the scheduler to **0 unknown / 0 conflicts**. Audit pattern: any system pair that re-introduces a conflict on the same parallel stage must either be moved to different stages or have one side's access narrowed
-- **Undeclared-access classification (#1394, `a7e1502b`)**: a pair is classified `AccessConflict::Unknown` when one or both sides have `None` declared access (closures and not-yet-migrated systems) — `analyze_pair` returns `Unknown { left_undeclared, right_undeclared }`, and the `AccessConflict` enum has exactly three variants (`None`, `Unknown`, `Conflict`) — there is **no** `Parallel` variant. What #1394 actually added is the `undeclared_parallel_count()` accessor on `AccessReport`: the migration KPI that counts parallel-stage systems still carrying `None`. The audit driving target is `undeclared_parallel_count() == 0`, which in turn drives `unknown_pair_count()` to 0 because every parallel pair then has both sides declared. Pin: `undeclared_closure_pairs_show_as_unknown` (`crates/core/src/ecs/scheduler.rs`) asserts two undeclared closures yield `unknown_pair_count() == 1`.
-- **#1236 + #1237 R7 scheduler access surface extended to exclusives** (`94e78b9f`): exclusive (Late-stage) systems also declare access surface now — the cell-loader drain, debug-server drain, audio prune, and event-cleanup systems all have explicit declarations. Verify no exclusive system regresses to undeclared access
-- **#1238 Scheduler stage-order chain pinned across all 5 stages** (`54ea11c0`): Early → Update → ParallelUpdate → Late → LateExclusive ordering pinned by a test. Re-ordering or merging stages without updating the test is the regression pattern
-- **Regression guard**: `cargo test -p byroredux` must report **0 unknown** and **0 conflicts** at scheduler init (look for the boot-time log line). Any non-zero count is an audit finding
+### 3. Query Borrow Safety
+
+- **Guard-owning wrappers**: `QueryRead` / `QueryWrite` / `ComponentRef`
+  (`query.rs`) hold the `RwLock*Guard` for the wrapper's lifetime and cache a
+  raw pointer downcast ONCE in `new()` (#1367 hot-path fix). The SAFETY argument:
+  the cached `*const`/`*mut T::Storage` points into the box the guard keeps
+  locked + pinned; no writer can move it while the lock is held. Re-verify each
+  `unsafe { &*self.storage }` / `&mut *self.storage` still has the guard field
+  alive (the `#[allow(dead_code)] guard` must not be dropped early).
+- **`ComponentRef` is the sound replacement for the unsound #35 pattern** —
+  it retains the guard rather than returning a raw pointer to dropped storage.
+  A regression that drops the guard and hands back a pointer is CRITICAL (UAF).
+- **Deref soundness**: `QueryWrite`'s `Deref`/`DerefMut` route through
+  `storage()` / `storage_mut()`; `DerefMut` requires `&mut self`, so the borrow
+  checker forbids a live `&` and `&mut` into the same storage simultaneously.
+- **`query` / `query_mut` return `None` for never-created storage** (no lazy
+  empty-storage creation on the read path). `register::<T>()` is the way to
+  guarantee a query succeeds before first insert.
+
+### 4. Resource Lifetimes
+
+- `resource()` / `resource_mut()` panic with the type name when the resource was
+  never inserted; `try_resource()` / `try_resource_mut()` return `None`.
+- `ResourceRead` / `ResourceWrite` (`resource.rs`) downcast through the guard on
+  each `Deref` (NOT cached — these are not the #1367 hot path); verify the
+  downcast `expect` can't fire (TypeId keys the map).
+- Resources are usable from systems via `&self` interior mutability.
+- `insert_resource` returns the prior value (downcast back out of the old lock);
+  `remove_resource` resolves poison via `resource_lock_poisoned`.
+- `try_resource_2_mut` does BOTH existence checks before acquiring EITHER lock
+  (#465) — a regression that checks-then-locks-then-checks reintroduces a
+  partial-acquire deadlock window.
+
+### 5. System & Scheduler Wiring
+
+- Blanket `System` impl for `Fn(&World, f32)` (`system.rs`); closures and bare
+  fns can't override `System::access`, so they declare via the scheduler's
+  registration-site override (dim 5b).
+- Mutations from a system are visible to later systems in the same `run()`
+  (pinned by `mutation_visible_across_stages`).
+- Empty scheduler and empty intermediate stages run without panic
+  (`empty_scheduler_runs_cleanly`, `empty_stages_skipped`).
+- `system_names()` returns stage-order then within-stage (parallel first, then
+  exclusive); duplicate names warn on `add_*` but `try_add_*` rejects with
+  `Err(name)` across the flat name space (#312).
+- Panic policy is **fail-fast by design** (TS-08 / #1412): a panicking system
+  aborts the frame and the process; do NOT report "missing `catch_unwind`" as a
+  bug — see the `Scheduler::run` doc comment. `run` takes `&mut self` and
+  `Scheduler` is intentionally NOT a `Resource` (re-entry is structurally
+  impossible, #868).
+
+### 5b. Scheduler Access Declarations (R7 / M27, closed 2026-05-23)
+
+The stages are **`Early` → `Update` → `PostUpdate` → `Physics` → `Late`**
+(`Stage` enum, `scheduler.rs`, discriminants `0..=4`, iterated via
+`BTreeMap<Stage, _>` `Ord`). There is **no** `ParallelUpdate` or `LateExclusive`
+stage — "exclusive" is a *phase within every stage* (`StageData.exclusive`),
+not a stage. Exclusive systems run serially after the stage's parallel batch.
+
+- **`Access` (not `SystemAccess`) is the declaration type** (`access.rs`):
+  `Access::new().reads::<T>().writes::<U>().reads_resource::<R>()…`. A system's
+  declaration is `Some(Access)` or `None` (undeclared). Three states: declared-
+  empty ("touches no ECS state"), declared-with-claims, or undeclared (`None`).
+  The default for both `System::access()` and the per-entry override is `None`.
+- **M27 Phase 1+2** (`a9810d40`): the 12 parallel-stage systems on the engine
+  binary declare reads/writes via `Scheduler::add_to_with_access` at the
+  registration site in `byroredux/src/main.rs` (closures can't impl
+  `System::access`). Any parallel system registered via plain `add_to` (no
+  declared access) is a regression.
+- **M27 Phase 3** (`05fe2bac`): 4 runtime-mutually-exclusive systems were
+  re-staged as **exclusive** to remove structurally-impossible conflicts — most
+  notably `player_controller_system` (Stage::Early) declares the *union* of
+  `fly_camera` + `character_controller` accesses because it branches on
+  `PlayerMode` per frame. `sys.accesses` reports **0 unknown / 0 conflicts**.
+- **`AccessConflict` lives in `access.rs`** (re-exported via `ecs::mod`) and has
+  EXACTLY three variants: `None`, `Unknown { left_undeclared, right_undeclared }`,
+  `Conflict { pairs }`. There is **no** `Parallel` variant (the #1521 wording
+  fix). `analyze_pair` returns `Unknown` when one/both sides are undeclared.
+  #1394 (`a7e1502b`) added the `undeclared_parallel_count()` accessor on
+  `AccessReport` — the migration KPI counting parallel-stage systems still at
+  `None` — NOT a reclassification. Driving `undeclared_parallel_count() == 0`
+  drives `unknown_pair_count()` to 0 because every parallel pair then has both
+  sides declared. Pin: `undeclared_closure_pairs_show_as_unknown`
+  (`scheduler.rs`) asserts two undeclared closures yield `unknown_pair_count() == 1`.
+- **Exclusive declarations are OPTIONAL and mostly absent** (#1236/#1237,
+  `94e78b9f`): `add_exclusive_with_access` / `try_add_exclusive_with_access`
+  EXIST so closures/fns *can* declare on the exclusive phase, but the live
+  schedule still registers most exclusives via plain `add_exclusive` (e.g.
+  `event_cleanup_system`, `audio_system`, `spin_system`, the DLC dispatchers),
+  so `undeclared_exclusive_count()` is non-zero by design. The analyzer
+  (`access_report`) only pairs parallel-stage systems — exclusives are listed
+  but never paired (`exclusive_systems_are_listed_but_not_paired`). Do NOT
+  report undeclared exclusives as a conflict; flag only a regression where a
+  *parallel* system loses its declaration.
+- **#1238 stage-order chain** (`54ea11c0`): `all_five_stages_run_in_order`
+  (`scheduler.rs`) registers out of order and asserts the `BTreeMap` `Ord` runs
+  `Early..=Late` exactly once. Reordering / merging / inserting a stage without
+  updating this test is the regression pattern. (Correct chain:
+  `Early → Update → PostUpdate → Physics → Late`.)
+- **Regression guard**: `byroredux/src/main.rs` runs
+  `debug_assert_eq!(scheduler.access_report().undeclared_parallel_count(), 0)`
+  after building the schedule (#1394) — this is the boot guard, NOT a log line.
+  Operators inspect contention at runtime via the `sys.accesses` console command
+  (reads the `SchedulerAccessReport` resource). A non-zero
+  `undeclared_parallel_count` / `known_conflict_count` is an audit finding.
 
 ### 6. Unsafe Code Review
-- World::get() uses raw pointer to extend lifetime — is the safety argument valid?
-- Any other unsafe blocks: document safety invariants
 
-### 7. Streaming, Scripting & New Component Lifecycles
-- M40 streaming (`byroredux/src/streaming.rs`): cell-load attaches components, cell-unload removes them — verify no orphaned components after a load/unload cycle
-- M41 NPC spawn (`byroredux/src/npc_spawn.rs`): ACHR REFR → entity dispatch is idempotent (same REFR FormId never spawns twice)
-- Scripting events (`crates/scripting/src/events.rs`): transient marker components (ActivateEvent, HitEvent, TimerExpired) are removed by `event_cleanup_system` (Late stage) — verify single-frame lifetime
-- ScriptTimer (`crates/scripting/src/timer.rs`): `timer_tick_system` decrements per-frame, fires TimerExpired marker on hit — verify no negative-time accumulation
-- Animation controller (`crates/core/src/animation/controller.rs`): controller component lifecycle vs AnimationPlayer — verify no dangling clip references after unload
-- AnimationClipRegistry (`crates/core/src/animation/registry.rs`): #790 dedupes by lowercased path so cell streaming doesn't grow it unboundedly. Without case-folding interning, one full keyframe set leaks per cell load — observable as steady RAM growth across exterior streaming
-- DebugDrainSystem (`crates/debug-server/src/system.rs`): Late-stage exclusive — verify no World mutation outside drain (per-client TCP threads must enqueue commands, not mutate)
-- AudioWorld resource (`crates/audio/src/lib.rs`, M44): `audio_system` runs Late-stage; `OneShotSound` markers are removed by `prune_stopped_sounds` once the kira playback transitions to `PlaybackState::Stopped` — verify no infinite-marker leak path. `AudioListener` / `AudioEmitter` lifecycle: spatial sub-track handle drop must precede listener handle drop (kira invariant)
-- Particle emitter component lifecycle (NIFAL typed-block path): `byroredux/src/systems/particle.rs::apply_emitter_params` populates the `ParticleEmitter` component (`crates/core/src/ecs/components/particle.rs`) from `byroredux_nif::import::ImportedEmitterParams` (struct in `crates/nif/src/import/types.rs`, built by `extract_emitter_params` / `extract_emitter_rate` in `crates/nif/src/import/walk/mod.rs` from the typed `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` blocks in `crates/nif/src/blocks/particle.rs`). Pin the override semantics: authored size is `initial_radius × base_scale.unwrap_or(1.0)` (Oblivion has no `base_scale` → multiplier 1.0) and color is NOT clobbered by the translation — see `apply_emitter_params_size_defaults_base_scale_to_one` and `apply_emitter_params_overrides_kinematics_and_size_not_color`. The regression is a typed-block translation that zero-sizes the emitter or overwrites the preset color. See also `/audit-nifal` (NIF→canonical translation boundary)
-- Character / light-anim component lifecycle: `byroredux/src/systems/character.rs` owns the player/character KCC state via `byroredux_physics::CharacterController` (+ `RapierHandles`); `byroredux/src/systems/light_anim.rs::animate_lights_system` reads `LightFlicker` (`crates/core/src/ecs/components/light.rs`) against `LightSource`. These systems own components added since this dim-7 list was first written — verify no orphaned `CharacterController` / `LightFlicker` after a cell load/unload cycle, matching the `streaming.rs` orphan invariant above
+- The only `unsafe` in the ECS core is the three cached-pointer derefs in
+  `query.rs` (`QueryRead::storage`, `QueryWrite::storage`/`storage_mut`,
+  `ComponentRef::Deref`) — all #1367. Each MUST have a SAFETY comment tying
+  validity to the live guard. Verify no new unsafe block lacks one (MEDIUM min
+  per `_audit-severity`).
+- `World::spawn` uses `checked_add` and panics on `EntityId` overflow (#36);
+  `despawn` does NOT reclaim IDs (no generational tagging — #372) — document,
+  do not "fix" by reusing IDs (silent corruption on dangling `Parent` refs).
 
-### 8. ECS Hot-Path Performance Invariants (2026-05-04 batch — regression guards)
-- `lock_tracker::held_others` Vec collection is `cfg(debug_assertions)`-gated (#823 ECS-PERF-01). Re-enabling for release rebuilds ~100 small allocs/frame for a no-op
-- `NameIndex.map` (struct defined in `byroredux/src/components.rs`) is refilled in place via `HashMap::clear` + `reserve` + reinsert inside `animation_system` (`byroredux/src/systems/animation.rs`, the `idx.map.clear()` block) instead of allocating a fresh map (#824 ECS-PERF-02). The `HashMap::new() + std::mem::swap` pattern costs ~3 ms cell-stream-in spike — a regression test should pin the in-place refill
-- `transform_propagation_system` (now in `byroredux/src/systems/animation.rs` post-Session-34 split) caches the root entity set keyed on `(Transform::len, Parent storage len OR 0 when Parent absent, world.next_entity_id())` (#825 ECS-PERF-03; see `crates/core/src/ecs/systems.rs` cache state + invalidation logic — third field is an `EntityId` value, not a count, and the Parent-len has `unwrap_or(0)` for scenes with no parent storage). Recomputing roots every frame is the ~250 µs/frame regression at Megaton scale
-- `animation_system` (now in `byroredux/src/systems/animation.rs`) hoists `events` / `seen_labels` scratches out of the per-entity loop and uses `clone` (not `mem::take`) so capacity persists (#828 ECS-PERF-06). Per-iteration allocation is the regression pattern. Helpers `ensure_subtree_cache`, `write_root_motion`, `apply_bool_channels` factored out by `2bdbc36`; `write_lazy!` macro collapses 5 color-target match arms — drift in any of these helpers risks DRY-undo
-- `footstep_system` (`byroredux/src/systems/audio.rs`) writes to the `FootstepScratch: Resource` (#932 PERF-CPU-02) using `mem::take` + restore pattern preserving Vec capacity across frames. Per-frame `Vec::new` is the regression
-- `World::despawn` poisoned-lock panic uses a `type_names` side-table to name the offending component (#466 E-03). Removing the side-table means panic messages lose the type name — bisecting takes 10× longer
+### 7. Component Lifecycles (load/unload, transient, idempotency)
+
+- **M40 streaming** (`byroredux/src/streaming.rs`): cell-load attaches
+  components, cell-unload removes them — verify no orphaned components after a
+  load/unload cycle.
+- **M41 NPC spawn** (`byroredux/src/npc_spawn.rs`): ACHR/REFR → entity dispatch
+  is idempotent (same REFR FormId never spawns twice).
+- **Scripting transient markers** (`crates/scripting/src/events.rs`):
+  `ActivateEvent` / `HitEvent` / `TimerExpired` are removed by
+  `event_cleanup_system` (registered `add_exclusive(Stage::Late, …)`) — verify
+  single-frame lifetime.
+- **ScriptTimer** (`crates/scripting/src/timer.rs`): `timer_tick_system`
+  decrements per-frame, fires `TimerExpired` on hit — verify no negative-time
+  accumulation.
+- **Animation controller** (`crates/core/src/animation/controller.rs`):
+  controller vs `AnimationPlayer` lifecycle — no dangling clip refs after unload.
+- **AnimationClipRegistry** (`crates/core/src/animation/registry.rs`): #790
+  dedupes by lowercased path so cell streaming doesn't grow it unboundedly —
+  losing case-folding interning leaks one keyframe set per cell load (steady RAM
+  growth across exterior streaming).
+- **DebugDrainSystem** (`crates/debug-server/src/system.rs`): registered
+  `add_exclusive(Stage::Late, …)` (`crates/debug-server/src/lib.rs`) — verify no
+  World mutation outside the drain (per-client TCP threads enqueue commands,
+  never mutate).
+- **AudioWorld** (`crates/audio/src/lib.rs`, M44): `audio_system` runs
+  `add_exclusive(Stage::Late, …)`; `OneShotSound` markers are pruned once kira
+  reaches `PlaybackState::Stopped` — verify no infinite-marker leak. Spatial
+  sub-track handle drop must precede listener handle drop (kira invariant).
+- **Particle emitter** (NIFAL typed-block path):
+  `byroredux/src/systems/particle.rs::apply_emitter_params` (registered
+  `add_exclusive(Stage::PostUpdate, particle_system)`) populates `ParticleEmitter`
+  (`crates/core/src/ecs/components/particle.rs`) from
+  `ImportedEmitterParams` (`crates/nif/src/import/types.rs`, built by
+  `extract_emitter_params` / `extract_emitter_rate` in
+  `crates/nif/src/import/walk/mod.rs` from the typed
+  `NiPSysEmitter`/`…Ctlr`/`…CtlrData`/`NiPSysGrowFadeModifier` blocks in
+  `crates/nif/src/blocks/particle.rs`). Pin the override semantics: authored size
+  is `initial_radius × base_scale.unwrap_or(1.0)` (Oblivion has no `base_scale`)
+  and color is NOT clobbered — see `apply_emitter_params_size_defaults_base_scale_to_one`
+  and `apply_emitter_params_overrides_kinematics_and_size_not_color`. Regression:
+  zero-sizing the emitter or overwriting the preset color. See `/audit-nifal`.
+- **Character / light-anim** (`byroredux/src/systems/character.rs`,
+  `byroredux/src/systems/light_anim.rs`): `character.rs` owns KCC state via
+  `byroredux_physics::CharacterController` (+ `RapierHandles`);
+  `animate_lights_system` reads `LightFlicker` (`crates/core/src/ecs/components/light.rs`)
+  against `LightSource`. Verify no orphaned `CharacterController` / `LightFlicker`
+  after a cell load/unload cycle, matching the `streaming.rs` orphan invariant.
+
+### 8. Hot-Path Performance Invariants (regression guards)
+
+- **Lock-tracker held-set collection is `cfg(debug_assertions)`-gated** (#823):
+  the `held_others: Vec` built before `record_and_check` in `lock_tracker.rs`
+  (`track_read`) is gated as one block — release builds skip the alloc entirely.
+  Re-enabling for release rebuilds ~100 small allocs/frame for a no-op.
+- **`NameIndex.map` in-place refill** (#824): `animation_system`
+  (`byroredux/src/systems/animation.rs`, the `idx.map.clear()` block) refills the
+  `HashMap` in place (`clear` + `reserve` + reinsert) instead of `new()` +
+  `swap`. The fresh-map pattern costs a ~3 ms cell-stream-in spike.
+- **Transform-propagation change detection** (#825 + #1371):
+  `make_transform_propagation_system` (`crates/core/src/ecs/systems.rs`) keys a
+  cached `roots` set on `(Transform::len(), Parent-len-or-0, next_entity_id())`
+  AND tracks `Parent` / `Children` `structural_generation()` plus the drained
+  `Transform` dirty set. The FAST PATH skips the whole BFS when the dirty set is
+  empty and the full state is unchanged — a static cell with a moving camera
+  touches ~1 subtree, not all entities (~250 µs/frame regression at Megaton if
+  recomputed every frame). Uses `drain_dirty_into(&mut transform_dirty)` to keep
+  the scratch capacity across frames (#1371), NOT `take_dirty`. Any path that
+  stops bumping `structural_gen` / `mark_dirty` silently breaks this fast path
+  (escalate — wrong `GlobalTransform` is a correctness bug, not just perf).
+- **`animation_system` scratch hoisting** (#828): `events` / `seen_labels`
+  scratches are hoisted out of the per-entity loop and use `clone` (not
+  `mem::take`) so capacity persists; helpers `ensure_subtree_cache` /
+  `write_root_motion` / `apply_bool_channels` + the `write_lazy!` macro
+  (5 color-target arms) were factored out by `2bdbc36` — DRY-undo drift there is
+  a finding.
+- **`footstep_system` scratch** (#932): `byroredux/src/systems/audio.rs` writes a
+  `FootstepScratch: Resource` via `mem::take` + restore to preserve Vec capacity;
+  per-frame `Vec::new` is the regression. (Registered
+  `add_exclusive(Stage::PostUpdate, footstep_system)`.)
+- **Poison side-table** (#466): `World::despawn` names the offending component
+  via the `type_names` side-table; removing it loses the type name in panic
+  messages (10× harder bisects).
 
 ### 9. NIFAL Canonical Material in the Component Layer
 
-The NIFAL canonical-translation tier resolves PBR scalars once, at the single `ImportedMesh → Material` boundary, so the renderer never re-classifies per draw. The ECS-owned `Material` component is the landing zone for that contract; this dimension guards it. See also `/audit-nifal` (the NIF→canonical translation layer audit) for the upstream boundary.
+The NIFAL tier resolves PBR scalars once, at the single `ImportedMesh → Material`
+boundary, so the renderer never re-classifies per draw. The ECS-owned `Material`
+component is the landing zone for that contract. See `/audit-nifal` for the
+upstream boundary.
 
-- **Plain-`f32` contract**: `Material` (`crates/core/src/ecs/components/material.rs`) carries `metalness: f32` and `roughness: f32` — fully resolved, NOT `Option<f32>`. The renderer reads `GpuMaterial.metalness` / `.roughness` directly. A regression to `Option`/`None` re-introduces per-draw classification
-- **Single mutation site**: `byroredux/src/material_translate.rs::translate_material` is the SOLE boundary that translates `ImportedMesh → Material`. `Material::resolve_pbr` (`crates/core/src/ecs/components/material.rs`, defined ~line 588) is the only fill-the-gap helper — it runs the shared keyword classifier (`classify_pbr_keyword`) and fills only the unset slot. No per-draw `classify_pbr` fallback survives in the render path (`byroredux/src/render/static_meshes.rs` documents the removal: "no per-draw keyword scan / classify_pbr fallback")
-- **`resolve_pbr` is idempotent + preserves translator values**: calling `resolve_pbr` twice yields the same result, and it never overwrites scalars the upstream translator already supplied — pinned by `resolve_pbr_is_idempotent` and `resolve_pbr_preserves_upstream_translator_values` (plus `resolve_pbr_fills_only_missing_slot` / `resolve_pbr_clamps_authored_out_of_range`) in the `material.rs` test module. A change that clobbers authored metalness/roughness or makes resolve non-idempotent is an audit finding
-- **ECS-adjacent material producers**: `crates/sfmaterial/` (Starfield CDB consumer) output flows into the canonical `Material`; if that path bypasses `translate_material` / `resolve_pbr` it breaks the single-boundary invariant. `crates/debug-ui/` (egui overlay) must not register or mutate gameplay components — note the boundary if it does. (19 crates total under `crates/`.)
+- **Plain-`f32` contract**: `Material` (`crates/core/src/ecs/components/material.rs`)
+  carries `metalness: f32` / `roughness: f32` — fully resolved, NOT `Option<f32>`.
+  A regression to `Option`/`None` re-introduces per-draw classification (HIGH).
+- **Single mutation site**: `byroredux/src/material_translate.rs::translate_material`
+  is the SOLE `ImportedMesh → Material` boundary; `Material::resolve_pbr`
+  (`crates/core/src/ecs/components/material.rs`) is the only fill-the-gap helper
+  (runs the shared `classify_pbr_keyword`, fills only the unset slot). No
+  per-draw `classify_pbr` fallback survives in `byroredux/src/render/static_meshes.rs`.
+- **`resolve_pbr` idempotent + preserves translator values**: pinned by
+  `resolve_pbr_is_idempotent`, `resolve_pbr_preserves_upstream_translator_values`,
+  `resolve_pbr_fills_only_missing_slot`, `resolve_pbr_clamps_authored_out_of_range`
+  in the `material.rs` test module. Clobbering authored scalars or breaking
+  idempotency is a finding.
+- **ECS-adjacent producers**: Starfield CDB output (`crates/sfmaterial/`) must
+  flow through `translate_material` / `resolve_pbr`; `crates/debug-ui/` (egui
+  overlay) must not register or mutate gameplay components.
 
 ## Process
 
-1. Read each file in `crates/core/src/ecs/`
-2. Run `cargo test -p byroredux-core` to verify all tests pass
-3. Check each dimension
-4. Save report to `docs/audits/AUDIT_ECS_<TODAY>.md`
+1. Read each file in `crates/core/src/ecs/` (paginate the >1500-line ones:
+   `resources.rs`, `world_tests.rs`, `scheduler.rs`).
+2. Run `cargo test -p byroredux-core` and `cargo test -p byroredux` — verify the
+   scheduler/storage/query suites are green (test counts live in ROADMAP, not
+   here; do not pin a number).
+3. Check each dimension top-down (lock ordering first).
+4. Save report to `docs/audits/AUDIT_ECS_<TODAY>.md`.

--- a/.claude/commands/audit-fnv/SKILL.md
+++ b/.claude/commands/audit-fnv/SKILL.md
@@ -1,102 +1,150 @@
 ---
-description: "Per-game audit of Fallout New Vegas compatibility — reference title, ESM + cells + RT lighting"
+description: "Per-game audit of Fallout New Vegas compatibility — reference title, ESM + cells + RT lighting + ragdoll"
 argument-hint: "--focus <dimensions>"
 ---
 
 # Fallout New Vegas Compatibility Audit
 
-Deep audit of ByroRedux readiness for **Fallout: New Vegas** content. FNV is the **reference title** — the most validated end-to-end path in the engine. Audits here look for regressions and unshipped features more than missing foundations.
+Deep audit of ByroRedux readiness for **Fallout: New Vegas** content. FNV is the **reference title** — the most-validated end-to-end path in the engine and the *reference realization* for the canonical translation layers (NIFAL material/physics, PHYSAL ragdoll). Audits here hunt regressions and unshipped polish, not missing foundations: a foundation that broke on FNV is the single highest-severity finding this command can produce.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for the master project-layout map, key reference docs, game-data locations, methodology, dedup rules, and finding format. See `.claude/commands/_audit-severity.md` for severity.
 
 ## Game Context
 
-| Aspect              | State                                                                                   |
-|---------------------|-----------------------------------------------------------------------------------------|
-| NIF format          | v20.2.0.7 (BSVER 34)                                                                    |
-| BSA format          | v104 ✓                                                                                  |
-| ESM parser          | Long-tail dispatch closed — #808 (PROJ + EFSH + IMOD + ARMA + BPTD), #809 (REPU + EXPL + CSTY + IDLE + IPCT + IPDS + COBJ), #810 (31 long-tail records bulk-dispatched). The `unknown_records` catch-all bucket has since been removed from `crates/plugin/src/esm/` entirely. Audit guard (positive): the long-tail dispatch arms remain present in `crates/plugin/src/esm/records/mod.rs` (PROJ/EFSH/IMOD/ARMA/BPTD + the #809/#810 set) and FNV parse rate holds 100% — a dropped arm or a fallen parse rate is the regression. |
-| Parse rate          | 100.00% (14881 / 14881)                                                                 |
-| Interior cells      | ✓ — Prospector Saloon: 809 entities, 48 FPS with full RT shadows + 25 point lights     |
-| Exterior cells      | ✓ — WastelandNV 3×3 / 7×7 grid, M32 landscape, M33 sky/clouds, M34 sun                 |
-| RT pipeline         | ✓ — M22 (shadows + reflections + 1-bounce GI) + M31.5 streaming RIS + M37.5 TAA        |
-| Reference data      | `/mnt/data/SteamLibrary/steamapps/common/Fallout New Vegas/Data/`                       |
+| Aspect         | State                                                                                  |
+|----------------|----------------------------------------------------------------------------------------|
+| NIF format     | v20.2.0.7 · `bsver` 34 (`bsver::FO3_FNV` in `crates/nif/src/version.rs`)                |
+| BSA format     | v104 — `crates/bsa/src/archive/`                                                        |
+| ESM parser     | Long-tail dispatch closed; `unknown_records` catch-all removed                          |
+| Ragdoll        | PHYSAL slice 1 *reference* (classic bhk chain) — `byroredux/src/ragdoll.rs`             |
+| Reference data | `/mnt/data/SteamLibrary/steamapps/common/Fallout New Vegas/Data/`                       |
+
+**Authoritative status** — do NOT hardcode counts here (they rot). Pull live from:
+- `ROADMAP.md` — per-game compat matrix (FNV parse rate, the Prospector bench-of-record entity/FPS/fence/draw numbers + the commit they were taken at), Known Issues.
+- `docs/feature-matrix.md` — what works at runtime on FNV per subsystem.
+
+The Prospector Saloon bench is the FNV bench-of-record; treat any drop below the ROADMAP-recorded numbers (at the recorded commit) as the regression baseline. The full pre-collider FNV baseline has not been recovered — see ROADMAP Known Issues before flagging fence/FPS as a fresh regression.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 7.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 8.
 
 ## Phase 1: Setup
 
 1. Parse `$ARGUMENTS`.
 2. `mkdir -p /tmp/audit/fnv`.
-3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
+3. Dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
 4. Confirm `Fallout New Vegas/Data/` exists (required — FNV is the baseline).
+5. Read the FNV row of `ROADMAP.md`'s compat matrix + `docs/feature-matrix.md` to capture the *current* baseline numbers and commit. Every "regression" claim is judged against those, not against numbers written into this skill.
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: NIF Parser — FNV Regression Guard
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/blocks/*.rs`, `crates/nif/tests/parse_real_nifs.rs`
-**Checklist**: Every previously-fixed FNV bug stays fixed — reference N23.4 (Fallout 3/NV validation) and related issues. `NiTexturingProperty` decal-slot off-by-one. `BSMultiBound*` family. `BSDecalPlacementVectorExtraData`. Parse rate holds at 100%. Block histogram from `nif_stats` matches the expected distribution (if the histogram shifts meaningfully, a new block type is being mis-dispatched). `import_nif_scene` returns expected mesh counts on canonical cells (Prospector Saloon sub-meshes).
-**#1277 NIF refactor regression guards (2026-05-28)**:
-- `extract_collision` per-variant dispatch + `CollisionAuthoring` discriminator at `crates/nif/src/import/collision.rs` (8d3a6861, #1277 Task 1): `examine_collision_kind` must classify FNV chains as `CollisionAuthoring::Classic` (the bhk* path), not `NewPhysicsStub`/`Phantom`/`Unrecognised`. A misclassified discriminator silently drops the rigid body.
-- `NifVariant` raw-`bsver`-compare migration at `crates/nif/src/version.rs` (2bd447d5, #1277 Task 5): the `bsver` constants (`FO3_FNV = 34`, `RIGID_BODY_FLAGS16 = 76`, etc.) must still place FNV (BSVER 34) on the legacy side of every gate — a flipped comparison shifts field layout and corrupts collision/anim reads.
-- Import-walker depth/cycle guard `MAX_NIF_NODE_DEPTH = 128` at `crates/nif/src/import/walk/mod.rs` (#1269, 3d1307d5): guards both the hierarchical and flat walkers against runaway recursion on malformed scene graphs; verify a legit FNV scene never trips the 128-depth bail.
+Dimensions are ordered by current FNV risk: the layers most likely to silently break FNV first (cell load + canonical translation + RT), regression guards last.
+
+### Dimension 1: Cell Loading End-to-End (highest blast radius)
+**Subagent**: `general-purpose`
+**Entry points**: `byroredux/src/cell_loader/` (`cell_loader.rs` is a thin dispatcher), `byroredux/src/scene/world_setup.rs`, `byroredux/src/streaming.rs`
+**Checklist**:
+- Interior load — Prospector Saloon entity count + XCLL lighting + `NiAlphaProperty` decal routing.
+- Exterior 7×7 (radius 3) WastelandNV grid — LAND terrain (`byroredux/src/cell_loader/terrain.rs`), LTEX/TXST splat, WTHR→CLMT→WTHR resolution, cloud texture resolution through the asset provider's `TextureProvider`.
+- `NifImportRegistry` Arc cache (`byroredux/src/cell_loader/nif_import_registry.rs::CachedNifImport`) prevents duplicate parsing across cells.
+- **Cell unload hygiene (regression guard)**: `byroredux/src/cell_loader/unload.rs` must drop BLAS per freed mesh handle and release physics bodies. **#1520 (`34c7a218`): Rapier bodies/colliders are released on unload** — verify the unload path frees them (covered by `byroredux/src/cell_loader/rapier_release_tests.rs`); a leak here compounds per cell-streaming cycle. Also check the `inventory_release_tests.rs` / `unload_skin_cleanup_tests.rs` siblings.
+- M38 water — `byroredux/src/cell_loader/water.rs` spawns `WaterPlane` per cell; `byroredux/src/systems/water.rs::submersion_system` writes camera submersion state on entry.
 **Output**: `/tmp/audit/fnv/dim_1.md`
 
-### Dimension 2: ESM Record Parser — Coverage & Accuracy
-**Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/records/`, `crates/plugin/src/esm/cell/` (post-Session-34 split — walkers / helpers / support / wrld)
-**Checklist**: All 23 record types still parse cleanly. Record counts on FalloutNV.esm match the M24 Phase 1 baseline (items 2643, containers 2478, LVLI 2738, LVLN 365, NPCs 3816, races 22, classes 74, factions 682, globals 218, settings 648). Spot-check specific records: Varmint Rifle stats, NCR faction relations, VATS AVIF entries. CELL XCLL fog_far_color optional field handling. FO4 additions (SCOL/MOVS/PKIN/TXST from session 10) don't inadvertently steal FNV dispatch (post-Session-34 the TXST/XATO/XTNM/XTXR match arms live in `crates/plugin/src/esm/cell/walkers.rs`; an `unreachable_patterns` warning there is a code smell to investigate).
-**Output**: `/tmp/audit/fnv/dim_2.md`
-
-### Dimension 3: Cell Loading End-to-End
-**Subagent**: `general-purpose`
-**Entry points**: `byroredux/src/cell_loader/{load,unload,exterior,references,spawn,partial,refr,terrain,water}.rs` (cell_loader.rs is thin re-export), `byroredux/src/scene/{nif_loader,world_setup}.rs` (scene.rs is thin re-export)
-**Checklist**: Interior cell load — Prospector Saloon entity count, XCLL lighting, NiAlphaProperty decal routing. Exterior 7×7 grid load from WastelandNV — LAND terrain mesh, LTEX/TXST splatting, WTHR→CLMT→WTHR resolution chain, M33 cloud texture resolution through `TextureProvider`. Reference count consistency across multiple cell loads. `CachedNifImport` Arc cache prevents duplicate parsing (session 6). `CellLoadResult` exposes WeatherRecord for `scene/world_setup.rs` consumption. Watch for memory leaks across cell unload/load cycles. M38 water-plane spawn from cell water references — verify `cell_loader/water.rs` spawns WaterPlane components and `submersion_system` writes camera state on entry.
-**Output**: `/tmp/audit/fnv/dim_3.md`
-
-### Dimension 4: RT Lighting Pipeline — FNV Scenes
-**Subagent**: `renderer-specialist`
-**Entry points**: `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/shaders/triangle.frag`, `crates/renderer/shaders/composite.frag`
-**Checklist**: TLAS frustum culling correctness — no lights dropped for in-view fragments. Streaming RIS (M31.5, Phase 19 upgrade) — 16 reservoirs/fragment from full cluster (was 8; doubled by Phase 19 for lower shadow variance), unbiased W estimator, 64× clamp engaged. Shadow ray budget caps. Distance-based shadow / GI ray fallback. BLAS compaction (M36) — occupancy query succeeds, compact copy replaces original. **BLAS LRU eviction at the dynamic VRAM-derived budget** (`device_local_bytes / 3`, floored at `MIN_BLAS_BUDGET_BYTES = 256 MB` per `crates/renderer/src/vulkan/acceleration/predicates.rs::blas_budget_bytes`; ~4 GB on a 12 GB-VRAM dev box, NOT the stale-doc "1 GB" figure). SVGF temporal accumulation uses motion vectors + mesh_id disocclusion. TAA Halton jitter + YCoCg variance clamp + luma blend α=0.1. M33 sky gradient + cloud layer blends correctly with tone-mapped geometry. **Disney BSDF gating regression guard (#1248-#1252)**: zero FNV materials author BGSM (BGSM is FO4+), so `MAT_FLAG_PBR_BSDF` must be 0 across the FalloutNV.esm material universe — the Disney lobe at `triangle.frag` is unreachable for FNV. Audit pattern: if any FNV scene activates Burley retro-reflection / anisotropic GGX / per-material-IOR Fresnel, the gate has regressed. **Today's `8b5d77c1` sun-sprite mip 0 force** at `composite.frag::compute_sky` (textureLod with explicit 0.0 — without it, the driver picks a high mip for the tiny screen-space sun disc, producing pixelation). **#1125 skyTint interior gate** at `triangle.frag` reflection + refraction miss fallbacks (2 sites) — FNV interior cells (Prospector Saloon, every Vault interior) must drop to cell ambient alone, not default zenith blue.
-**NIFAL collision-shape no-drop guard (9c6096aa)**: `BhkMultiSphereShape` and `BhkConvexListShape` now translate to `CollisionShape` (Compound of `Ball` children / `ConvexHull` respectively) via `crates/nif/src/import/collision.rs::resolve_shape` — they were silently dropped before. Audit pattern: any FNV mesh whose Havok shape is a multi-sphere or convex-list must surface a `CollisionShape`, not a missing rigid body. (Disney BSDF gate + collision translation both feed the canonical material/physics tier — see also `/audit-nifal`.)
-**Output**: `/tmp/audit/fnv/dim_4.md`
-
-### Dimension 5: Real-Data Validation
-**Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, demo CLI invocations
-**Checklist**: Run `cargo run -- --esm FalloutNV.esm --cell GSProspectorSaloonInterior --bsa Meshes.bsa --textures-bsa Textures.bsa --textures-bsa Textures2.bsa --debug` and capture `/cmd stats` at T+3s. Compare entity / mesh / texture / draw-call counts vs roadmap numbers (809 entities, 784 draws at 48 FPS target). Run exterior: `--grid <x>,<y> --radius 3` for a WastelandNV cell. Capture screenshots for visual regression baseline. Validate `tex.missing` + `tex.loaded` debug commands return sensible output (session 10).
-**Output**: `/tmp/audit/fnv/dim_5.md`
-
-### Dimension 6: Animation & Skinning (FNV) + M41 NPC Spawn Long-Tail
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/anim/` (Session 35 split: `entry`, `sequence`, `controlled_block`, `transform`, `bspline`, `channel`, `keys`, `coord`; `types.rs` + `tests.rs`), `crates/core/src/animation/`, `byroredux/src/anim_convert.rs`, `byroredux/src/npc_spawn.rs`
-**Checklist**: `.kf` file loading from BSA (`--kf meshes/anim.kf`). AnimationClipRegistry populated correctly. NiTransformInterpolator + NiFloatInterpolator + NiBoolInterpolator channels sample correctly. Text key events collected from NiTextKeyExtraData. Cycle types Clamp / Loop / Reverse all honored. KFM state machine parser. FixedString interning at clip load time (#340) — no per-frame StringPool locks. Skinning data extraction from NiSkinData sparse weights still parses (M29 GPU skinning + #178 SkinnedMesh palette are shipped — this is a regression check, not a foundation check; confirm the palette stays correct on the now-live GPU path).
-**NIFAL typed-emitter particle pin (5708b5b9 / 9db60714 / 8f856d35)**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are now typed structs in `crates/nif/src/blocks/particle.rs` (previously NiUnknown-demoted). `crates/nif/src/import/walk/mod.rs::extract_emitter_params` + `::extract_emitter_rate` feed `byroredux/src/systems/particle.rs::apply_emitter_params`. Audit pattern: FNV's heavy particle stacks (`BSPSysSimpleColorModifier` etc.) must drive the system from the **authored** birth-rate / emitter size / `base_scale`, not preset kinematics — `apply_emitter_params` overrides the placeholder kinematics + size when the typed blocks decode. (Particle translation is part of the canonical NIFAL tier — see also `/audit-nifal`.)
-**M41.0 long-tail regression guards (Session 29)**:
-- B-spline pose-fallback (#772, 3c32a5e): gated on a `FLT_MAX` sentinel. Without the gate, NPCs vanish under FNV `BSPSysSimpleColorModifier` particle stacks that share keyframe time-zero with the actor's animation player. **Note**: B-splines (`NiBSplineCompTransformInterpolator`) ARE reachable on FNV/FO3 (`feedback_bspline_not_skyrim_only.md`) — do not rule them out by game era.
-- AnimationClipRegistry dedup (#790, da99d15): registry deduplicates by lowercased path so cell streaming doesn't grow it unboundedly. Without dedup, one full keyframe set leaks per cell load (observable as steady RAM growth on exterior streaming).
-- NPC hand-mesh load (#793 / M41-HANDS, da8d7e2): `lefthand.nif` + `righthand.nif` loaded alongside `upperbody.nif` on kf-era NPCs. Audit any NPC body assembly that loads only `upperbody` — every Doc Mitchell, Sunny Smiles, Megaton dweller would otherwise render with no hands.
-**Output**: `/tmp/audit/fnv/dim_6.md`
-
-### Dimension 7: NIFAL Canonical Translation — FNV Slice
+### Dimension 2: NIFAL Canonical Translation — FNV Slice
 **Subagent**: `legacy-specialist`
 **Entry points**: `byroredux/src/material_translate.rs`, `crates/core/src/ecs/components/material.rs`, `crates/nif/src/import/collision.rs`, `docs/engine/nifal.md`
-**Checklist**: FNV is the **reference title** for the canonical translation tier (NIFAL), so this boundary must be exercised on the most-validated content. `byroredux/src/material_translate.rs::translate_material` is the **single** `ImportedMesh → Material` boundary (3ce98db8) — no second per-game material path may exist. Verify FNV materials land with `Material.metalness` / `Material.roughness` as **plain resolved `f32`** (`crates/core/src/ecs/components/material.rs` lines ~204–222), not `Option`, and that `Material::resolve_pbr` (→ `classify_pbr_keyword`) runs **once** at translation — the old render-time `Material::classify_pbr` is deleted, so there must be no per-draw keyword scan in `byroredux/src/render/static_meshes.rs`. Glass is classified once post-resolve (roughness gate), not re-derived per fragment. **EmissiveSource regression guard**: FNV legacy emissive uses `EmissiveSource::Material` (the genuine `NiMaterialProperty.emissive_mult` scalar) — confirm the multi-variant `EmissiveSource` enum (`Material` / `Lighting` / `Effect`, `crates/core/src/ecs/components/material.rs` line 354) leaves the FNV `Material` path's ~1.0 scale untouched (Skyrim+ `Lighting` and FO4+ `Effect` variants must not bleed into FNV). Cross-check against the NIFAL spec at `docs/engine/nifal.md`. **No-fabrication invariant**: translation may not invent PBR values FNV content never authored — keyword-classified dielectric defaults are fine, fabricated metalness is not. See also `/audit-nifal` for the dedicated single-boundary / no-fabrication / no-render-time-fallback audit.
+**Checklist**: FNV is the reference content for this boundary, so it must be exercised here first.
+- `material_translate.rs::translate_material` is the **single** `ImportedMesh → Material` boundary — no second per-game material path may exist.
+- FNV materials land with `Material::metalness` / `roughness` as **plain resolved `f32`** (`material.rs`), not `Option`. `Material::resolve_pbr` (→ `classify_pbr_keyword`) runs **once** at translation — there must be no per-draw keyword scan in `byroredux/src/render/static_meshes.rs` (the old render-time `Material::classify_pbr` is deleted).
+- **EmissiveSource guard**: FNV legacy emissive uses `EmissiveSource::Material` (the genuine `NiMaterialProperty.emissive_mult` scalar). The `EmissiveSource` enum (`material.rs`) carries `Material` / `Lighting` / `Effect` variants; Skyrim+ `Lighting` and FO4+ `Effect` must not bleed into the FNV `Material` path (~1.0 scale untouched).
+- **Collision-shape no-drop guard (`9c6096aa`)**: `BhkMultiSphereShape` + `BhkConvexListShape` translate to `CollisionShape` via `collision.rs::resolve_shape` (Compound of `Ball` children / `ConvexHull`) — previously silently dropped. Any FNV mesh with a multi-sphere / convex-list Havok shape must surface a `CollisionShape`.
+- **No-fabrication invariant**: translation may not invent PBR values FNV never authored; keyword-classified dielectric defaults are fine, fabricated metalness is not.
+- See `/audit-nifal` for the dedicated single-boundary / no-fabrication / no-render-time-fallback audit.
+**Output**: `/tmp/audit/fnv/dim_2.md`
+
+### Dimension 3: RT Lighting Pipeline — FNV Scenes
+**Subagent**: `renderer-specialist`
+**Entry points**: `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/shaders/triangle.frag`, `crates/renderer/shaders/composite.frag`, `docs/engine/lighting-from-cells.md`
+**Checklist**:
+- TLAS frustum culling — no lights dropped for in-view fragments.
+- ReSTIR-DI direct lighting in `triangle.frag` — `NUM_RESERVOIRS = 16` reservoirs/fragment, unbiased `W = resWSum / (K · w_sel)` estimator, shadow-ray budget caps, distance-based shadow/GI ray fallback.
+- BLAS compaction + **LRU eviction at the dynamic VRAM-derived budget**: `predicates.rs::blas_budget_bytes` = `device_local_bytes / 3` floored at `MIN_BLAS_BUDGET_BYTES` (~4 GB on a 12 GB-VRAM dev box — NOT any stale "1 GB" figure).
+- SVGF temporal accumulation uses motion vectors + `mesh_id` disocclusion; TAA Halton jitter + YCoCg variance clamp.
+- M33 sky gradient + cloud layer blends correctly with tone-mapped geometry.
+- **Disney BSDF gate guard (#1248–#1252)**: zero FNV materials author BGSM (FO4+), so `MAT_FLAG_PBR_BSDF` (`crates/renderer/shaders/include/shader_constants.glsl` = 32u) must be 0 across the FalloutNV.esm material universe — the Disney lobe at `triangle.frag` is unreachable for FNV. If any FNV scene activates Burley retro-reflection / anisotropic GGX / per-material-IOR Fresnel, the gate regressed.
+- **#1125 skyTint interior gate** at `triangle.frag` reflection + refraction miss fallbacks (2 sites) — FNV interiors (Prospector, every Vault) must drop to cell ambient alone, not default zenith blue.
+- Sun-sprite mip-0 force (`8b5d77c1`) at `composite.frag::compute_sky` — explicit `textureLod` 0.0 avoids pixelating the tiny screen-space sun disc.
+**Output**: `/tmp/audit/fnv/dim_3.md`
+
+### Dimension 4: ESM Record Parser — Coverage & Accuracy
+**Subagent**: `general-purpose`
+**Entry points**: `crates/plugin/src/esm/records/`, `crates/plugin/src/esm/cell/` (post-split: `walkers.rs` / `helpers.rs` / `support.rs` / `wrld.rs`)
+**Checklist**:
+- Record counts on FalloutNV.esm match the ROADMAP / `feature-matrix` baseline (do not transcribe a fixed count into this skill — diff against the living doc).
+- Spot-check semantics: Varmint Rifle stats, NCR faction relations, VATS AVIF entries (the FNV gameplay-record path in `crates/plugin/src/esm/records/index.rs` + `crates/plugin/src/esm/records/misc/effects.rs`).
+- CELL `XCLL` `fog_far_color` optional-field handling.
+- FO4 additions (SCOL/MOVS/PKIN/TXST) must not steal FNV dispatch — the TXST/`XATO`/`XTNM`/`XTXR` match arms live in `crates/plugin/src/esm/cell/walkers.rs`; an `unreachable_patterns` warning there is a code smell.
+- LVLI leveled-list flattening — `crates/plugin/src/equip.rs::expand_leveled_form_id` resolves NPC default-outfit LVLI refs into base ARMO/WEAP; FNV NPCs whose outfits reference LVLI must spawn gear, not empty.
+**Output**: `/tmp/audit/fnv/dim_4.md`
+
+### Dimension 5: NIF Parser — FNV Regression Guard
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/blocks/`, `crates/nif/tests/parse_real_nifs.rs`, `crates/nif/examples/nif_stats.rs`
+**Checklist**:
+- Parse rate holds at the ROADMAP FNV figure; block histogram from `nif_stats` matches expected distribution (a meaningful shift = a block type being mis-dispatched).
+- `NiTexturingProperty` decal-slot off-by-one; `BSMultiBound*`; `BSDecalPlacementVectorExtraData` all stay fixed (reference N23.4 FO3/FNV validation).
+- **#1277 collision/version guards**:
+  - `collision.rs::examine_collision_kind` classifies FNV chains as `CollisionAuthoring::Classic` (the bhk* path), not `NewPhysicsStub`/`Phantom`/`Unrecognised` — a misclassified discriminator silently drops the rigid body.
+  - `version.rs` raw-`bsver`-compare migration: `bsver::FO3_FNV = 34`, `RIGID_BODY_FLAGS16 = 76`, `NI_BS_LTE_16 = 16` etc. must still place FNV (`bsver` 34, `> NI_BS_LTE_16`) on the post-Oblivion side of every gate — a flipped comparison shifts field layout and corrupts collision/anim reads.
+- **#1269 walker guard**: `MAX_NIF_NODE_DEPTH = 128` in `crates/nif/src/import/walk/mod.rs` guards both hierarchical + flat walkers; a legit FNV scene must never trip the 128-depth bail (covered by `crates/nif/src/import/walk/tests.rs`).
+**Output**: `/tmp/audit/fnv/dim_5.md`
+
+### Dimension 6: Animation, Skinning & Particles (FNV)
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/anim/`, `crates/core/src/animation/`, `byroredux/src/anim_convert.rs`, `byroredux/src/npc_spawn.rs`, `byroredux/src/systems/particle.rs`
+**Checklist**:
+- `.kf` load from BSA; AnimationClipRegistry populated; `NiTransformInterpolator` + `NiFloatInterpolator` + `NiBoolInterpolator` channels sample correctly; NiTextKeyExtraData text events collected; Clamp/Loop/Reverse cycle types honored; FixedString interning at clip-load (#340) — no per-frame StringPool locks.
+- Skinning regression (NOT a foundation check — GPU skinning M29 + #178 SkinnedMesh palette are live): NiSkinData sparse weights still parse; bone palette stays correct on the GPU path.
+- **B-spline pose-fallback (#772)**: gated on a `FLT_MAX` sentinel; without it NPCs vanish under FNV `BSPSysSimpleColorModifier` particle stacks that share time-zero with the actor's player. `NiBSplineCompTransformInterpolator` IS reachable on FNV/FO3 — do not rule it out by game era.
+- **AnimationClipRegistry dedup (#790)**: dedup by lowercased path so cell streaming doesn't grow it unboundedly (else one keyframe set leaks per cell load).
+- **NPC hand-mesh load (#793)**: `lefthand.nif` + `righthand.nif` load alongside `upperbody.nif` on kf-era NPCs (`npc_spawn.rs`) — any body assembly loading only `upperbody` leaves Doc Mitchell / Sunny Smiles handless.
+- **Typed-emitter particle pin (`5708b5b9` / `9db60714`)**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are typed structs in `crates/nif/src/blocks/particle.rs`. `walk/mod.rs::extract_emitter_params` + `::extract_emitter_rate` feed `systems/particle.rs::apply_emitter_params` — FNV's heavy particle stacks must drive from the **authored** birth-rate / emitter size / `base_scale`, not preset kinematics. (Particle translation is part of the NIFAL tier — see `/audit-nifal`.)
+**Output**: `/tmp/audit/fnv/dim_6.md`
+
+### Dimension 7: PHYSAL Ragdoll — FNV Reference Slice
+**Subagent**: `legacy-specialist`
+**Entry points**: `byroredux/src/ragdoll.rs`, `crates/nif/src/import/collision.rs` (ragdoll + constraint decode), `crates/nif/src/blocks/collision/`, `docs/engine/physal.md`
+**Checklist**: FNV is the *reference realization* for PHYSAL slice 1 (the classic bhk chain — `0a0bc3ce` / `2c21a470`, 2026-06-14). Newly shipped, so audit for correctness, not just regression.
+- The importer hands `ImportedRagdoll` (bone *names* + `ImportedJointKind`); `ragdoll.rs::activate_ragdoll` resolves it against the skeleton's `GlobalTransform`, and `ragdoll_writeback_system` writes solver results back to bone transforms. Verify name resolution doesn't silently drop a joint on a real FNV creature/NPC skeleton.
+- Per PHYSAL, the *only* per-game seam is the constraint CInfo decode — confirm no per-game branch leaked into `ragdoll.rs` or the solver bridge (`crates/physics/`).
+- FNV's dominant constraint form is a `bhkMalleableConstraint` wrapping a Ragdoll (see `docs/engine/physal.md` §FO3/FNV) — confirm that decode path in `crates/nif/src/blocks/collision/constraints.rs` + `ragdoll.rs` survives and produces a jointed body, not a single rigid blob.
+- Writeback must not corrupt the skinned bone palette feeding the GPU skin path (cross-check Dimension 6).
 **Output**: `/tmp/audit/fnv/dim_7.md`
+
+### Dimension 8: Real-Data Validation & Bench-of-Record
+**Subagent**: `general-purpose`
+**Entry points**: `crates/nif/examples/nif_stats.rs`, demo CLI invocations
+**Checklist**:
+- **CWD matters** (ROADMAP repro note): bare `--bsa` / `--textures-bsa` names resolve against CWD, not the `--esm` folder. Run with CWD = `Fallout New Vegas/Data/`, else archives silently fail and the scene loads near-empty (~36 entities / spurious FPS).
+- Interior bench-of-record:
+  `cargo run --release -- --esm FalloutNV.esm --cell GSProspectorSaloonInterior --bsa Meshes.bsa --textures-bsa Textures.bsa --textures-bsa Textures2.bsa --bench-frames 300 --bench-hold`
+  then attach `byro-dbg` (port 9876) and capture `stats`. Compare entity / draw / FPS / fence against the **ROADMAP FNV row** (not numbers in this skill).
+- Exterior: `--grid <x>,<y> --radius 3` on WastelandNV.
+- Validate `tex.missing` / `tex.loaded` return sensible output (FNV ships base textures split across `Fallout - Textures.bsa` + DLC archives — `tex.missing` first when surfaces look chrome/posterized).
+**Output**: `/tmp/audit/fnv/dim_8.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/fnv/dim_*.md` files.
-2. Combine into `docs/audits/AUDIT_FNV_<TODAY>.md` with structure:
-   - **Executive Summary** — FNV is the baseline. Any regressions against the roadmap's validated numbers are CRITICAL.
-   - **Dimension Findings** — Grouped by severity per dimension.
-   - **Baseline Comparison Table** — Roadmap number vs observed number for entity count, draw count, FPS, parse rate, record count.
-   - **Regression Guard List** — Previously-fixed issues this audit verified are still correct.
+1. Read all `/tmp/audit/fnv/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_FNV_<TODAY>.md`:
+   - **Executive Summary** — FNV is the baseline; any regression against the ROADMAP-recorded numbers is at least HIGH (CRITICAL if it breaks a shipped foundation).
+   - **Dimension Findings** — grouped by severity per dimension.
+   - **Baseline Comparison Table** — ROADMAP number vs observed for entity count, draw count, FPS, fence, parse rate, record count (cite the ROADMAP commit you compared against).
+   - **Regression Guard List** — previously-fixed issues this audit verified still correct.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_FNV_<TODAY>.md`

--- a/.claude/commands/audit-fo3/SKILL.md
+++ b/.claude/commands/audit-fo3/SKILL.md
@@ -7,102 +7,150 @@ argument-hint: "--focus <dimensions>"
 
 Deep audit of ByroRedux readiness for **Fallout 3** content.
 
+FO3 rides the **FNV path** almost end-to-end: same NIF era (v20.2.0.7 / BSVER 34),
+same BSA format (v104), same ESM parser, same cell loader, same RT lighting. So
+this audit is NOT a re-run of `/audit-fnv` — it hunts the **divergences**: where
+FO3 content exercises a path FNV doesn't, where the shared code carries an
+FNV-only assumption, and where a feature is verified on FNV but only *assumed* on
+FO3. Order below is by FO3 risk, highest first.
+
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game data locations,
+methodology, deduplication, and finding format. See `.claude/commands/_audit-severity.md`
+for the severity scale (including the NIFAL canonical-translation rows).
 
 ## Game Context
 
-| Aspect            | State                                                                |
-|-------------------|----------------------------------------------------------------------|
-| NIF format        | v20.2.0.7 (BSVER 34)                                                 |
-| BSA format        | v104 ✓                                                               |
-| ESM parser        | Shares parser with FNV (same record set)                             |
-| Parse rate        | 100.00% (10989 / 10989)                                              |
-| Validation demo   | Megaton Player House (1609 entities, 199 textures, 42 FPS)           |
-| Reference data    | `/mnt/data/SteamLibrary/steamapps/common/Fallout 3 goty/Data/`       |
+| Aspect          | State                                                                       |
+|-----------------|-----------------------------------------------------------------------------|
+| NIF format      | v20.2.0.7 (BSVER 34) — same as FNV                                          |
+| BSA format      | v104 ✓                                                                       |
+| ESM parser      | Shared with FNV (`crates/plugin/src/esm/`); no FO3-specific arm             |
+| NIF parse rate  | 100.00% (10 989) — ROADMAP compat matrix                                    |
+| ESM records     | 44 657 = 37 459 structured + 7 198 NAVMs (re-verified 2026-05-26)           |
+| Interior        | ✓ — Megaton, **929 REFRs** (parse-side baseline; NOT the stale 1609 figure) |
+| Exterior        | Wired (Capital Wasteland WRLD); **fresh GPU bench pending (R6a-stale-15)**   |
+| Scripting       | 1 257 SCPT records parse; no runtime executes them (M47.0; tail M47.2)      |
+| Reference data  | `/mnt/data/SteamLibrary/steamapps/common/Fallout 3 goty/Data/`              |
 
-### Known Specifics
+### FO3-vs-FNV divergence map (the actual audit surface)
 
-- NIF shader chain: `BSShaderPPLightingProperty` with refraction / parallax / bump map / normal map (normal map is a dedicated slot in FO3+; Oblivion still reads normals from the bump slot).
-- FO3 shader flags use the legacy single-u32 layout, not the FO4 u32-pair.
-- Block types: `BSSegmentedTriShape` (biped body parts), legacy particle stack, `BSShaderNoLightingProperty`.
-- Havok blocks (30 types) parse via the size table (v20.2.0.7 has it). Unhandled shapes recover via `block_size`, but `BhkMultiSphereShape` / `BhkConvexListShape` now **translate** to `CollisionShape` (see Dimension 7) rather than being dropped.
-- XCLL interior lighting identical to FNV — uses the same `CellLightingRes` path.
+- **Inline shader stack only.** FO3 ships `BSShaderPPLightingProperty` /
+  `BSShaderNoLightingProperty` with the legacy single-u32 flag layout — never
+  `BSLightingShaderProperty` (Skyrim+) and never BGSM external materials (FO4+).
+  Disney-BSDF and BGSM paths must be provably unreachable.
+- **Earlier authoring conventions** than FNV: pre-FNV record subforms (NPC_,
+  DIAL/INFO), `BSSegmentedTriShape` biped parts, FO3-era particle stacks. These
+  are the FNV-shared paths most likely to hit an untested edge on FO3 data.
+- **Different worldspace.** Capital Wasteland is a distinct WRLD form ID with its
+  own origin/CLMT curves — any FNV-hardcoded worldspace name or coord is a bug.
+- **B-splines are reachable** (`NiBSplineCompTransformInterpolator`) — do not
+  rule them out by game era (`feedback_bspline_not_skyrim_only.md`).
+- **SpeedTree 5.x** (`crates/spt/`) is the FO3/FNV `.spt` generation — placeholder
+  billboard fallback only.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 7.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,4`). Default: all 7.
 
 ## Phase 1: Setup
 
 1. Parse `$ARGUMENTS`.
 2. `mkdir -p /tmp/audit/fo3`.
-3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
+3. Dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
 4. Confirm `Fallout 3 goty/Data/` exists; if not, note which dimensions lose real-data validation.
+5. Before reporting a status/count claim, reconcile against the ROADMAP per-game
+   compat matrix and `docs/feature-matrix.md` — both carry live FO3 numbers.
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: NIF v20.2.0.7 Parser Correctness (FO3 subset)
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs`, `crates/nif/src/blocks/*.rs`, `crates/nif/src/blocks/particle.rs`, `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` / `extract_emitter_rate`), `byroredux/src/systems/particle.rs` (`apply_emitter_params`)
-**Checklist**: `BSShaderPPLightingProperty` field completeness (refraction strength, refraction period, parallax passes, parallax scale, bump map tiling). Normal-map slot location in `BSShaderTextureSet` (slot 1 in FO3, differs from Oblivion which uses the bump slot via NiTexturingProperty). `BSShaderNoLightingProperty` (UI/sky). `BSSegmentedTriShape` vertex index handling. Stream position audits — any block types that pass on FNV but might be FO3-only.
-**Typed particle emitters (NIFAL particle slice)**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are now TYPED blocks (`crates/nif/src/blocks/particle.rs` — see `parse_box_emitter` / `parse_sphere_emitter` / `parse_grow_fade_modifier`), not the old opaque controller stack. `extract_emitter_params` / `extract_emitter_rate` decode the authored base kinematics + birth rate + GrowFade `base_scale` into `apply_emitter_params`. Dispatch in `blocks/mod.rs` is version-agnostic, so FO3-era smoke / fire / dust emitters hit this path — but the NIFAL decode doc-comments verify only against FNV + Oblivion, so **FO3 is an unverified gap**: confirm FO3 authored emitter params + rate + GrowFade scale extract correctly. Commits `5708b5b9` / `9db60714` / `8f856d35`. See also `/audit-nifal`.
+### Dimension 1: FO3 Rendering Path — Inline Shaders (highest divergence)
+**Subagent**: `renderer-specialist`
+**Entry points**: `crates/nif/src/import/material/mod.rs` (+ `walker.rs`, `shader_data.rs`), `byroredux/src/material_translate.rs` (`translate_material`), `crates/core/src/ecs/components/material.rs` (`resolve_pbr`, `EmissiveSource`, `classify_pbr_keyword`), `crates/nif/src/shader_flags.rs`, `crates/renderer/shaders/triangle.frag`
+**Checklist**:
+- `BSShaderPPLightingProperty` flag bits mapped correctly (decal, alpha-test, two-sided, glow, window). **Per-game flag bit positions differ across FO3/FNV/Skyrim** — confirm FO3 uses the legacy single-u32 layout via `crates/nif/src/shader_flags.rs`, not the FO4 u32-pair.
+- Normal map handle resolved from the dedicated `BSShaderTextureSet` normal slot (FO3+), NOT the bump slot — Oblivion reads normals from the bump slot via `NiTexturingProperty`; FO3 must not regress into that path.
+- `BSShaderNoLightingProperty` (UI / sky / glow / blood-splat) routes through the **fullbright** path (`c351e0b6`) and its decal flags are honored (`crates/nif/src/import/material/mod.rs` — the pre-#454 NoLighting branch had no flags2 check). Self-illumination must not dim with distance.
+- **NIFAL single boundary (#1241 / #1244, `3ce98db8`)**: FO3 materials flow through the SINGLE `material_translate::translate_material` (`ImportedMesh` + `ResolvedPaths` → canonical `Material`). `Material.metalness` / `Material.roughness` are plain resolved `f32` (no `Option`, no per-draw classify). FO3 authors no BGSM, so they arrive as the NaN sentinel and `Material::resolve_pbr` fills them via `classify_pbr_keyword`. Confirm concrete `f32` scalars out of the one boundary; no second per-game material site.
+- **`EmissiveSource` discriminator (#1280, `2e884741`)**: FO3 `BSShaderPPLighting`/`NoLighting` self-illumination maps to `EmissiveSource::Material` (legacy `NiMaterialProperty.emissive_mult` slot). All three variants currently share the `emissive_mult` slot — the discriminator is provenance, not yet a render branch. Skyrim+ `Lighting` / FO4+ `Effect` variants must not bleed into the FO3 ~1.0 scale.
+- **Disney-BSDF gate (#1248–#1252)**: zero FO3 materials author BGSM, so `MAT_FLAG_PBR_BSDF` (`triangle.frag`, `(1u << 5)`) must be 0 across the Fallout3.esm material universe — the Burley/anisotropic-GGX/per-material-IOR lobe is unreachable for FO3. If any FO3 scene activates it, the gate regressed.
+- **`WaterShaderProperty` (#1243, `3509482a`)**: FO3 water materials route through `MaterialInfo` for distinct `GpuMaterial` entries (no dedup collapse with glass).
+- See also `/audit-nifal`.
 **Output**: `/tmp/audit/fo3/dim_1.md`
 
-### Dimension 2: BSA v104 Archive (Meshes + Textures)
-**Subagent**: `general-purpose`
-**Entry points**: `crates/bsa/src/archive/`
-**Checklist**: Verify `Fallout - Meshes.bsa` lists + extracts cleanly. Texture archives (`Fallout - Textures.bsa`) DDS extraction produces valid BC1/BC3/BC5 headers. Sound archives — not needed for rendering but should open without error. Folder hash collisions across Fallout 3's ~150 subdirectories. Compare metrics vs FNV (same format, should behave identically).
+### Dimension 2: NIF v20.2.0.7 Parser — FO3 Block Subset
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/blocks/properties.rs`, `crates/nif/src/blocks/shader.rs`, `crates/nif/src/blocks/particle.rs`, `crates/nif/src/blocks/mod.rs` (dispatch), `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` / `extract_emitter_rate`), `byroredux/src/systems/particle.rs` (`apply_emitter_params`)
+**Checklist**:
+- `BSShaderPPLightingProperty` field completeness (refraction strength/period, parallax passes/scale, bump-map tiling) and `BSShaderNoLightingProperty` decode.
+- `BSSegmentedTriShape` (biped body parts) vertex-index handling.
+- Stream-position audit: any block type that passes on FNV but trips on FO3-era authoring. The dispatch arm count is in `crates/nif/src/blocks/mod.rs` — a histogram shift from `nif_stats` flags a mis-dispatched block.
+- **Typed particle emitters (NIFAL particle slice, `5708b5b9` / `9db60714` / `8f856d35`)**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are TYPED blocks (`crates/nif/src/blocks/particle.rs` — `parse_box_emitter` / `parse_sphere_emitter` / `parse_grow_fade_modifier`), not the old opaque controller stack. `extract_emitter_params` / `extract_emitter_rate` decode authored base kinematics + birth rate + GrowFade `base_scale` into `apply_emitter_params`. Dispatch is version-agnostic so FO3 smoke/fire/dust emitters hit this path — **but the NIFAL decode doc-comments verify only against FNV + Oblivion, so FO3 is an UNVERIFIED gap**: confirm FO3 authored emitter params + rate + GrowFade scale extract correctly. See also `/audit-nifal`.
 **Output**: `/tmp/audit/fo3/dim_2.md`
 
 ### Dimension 3: ESM Record Coverage (Fallout3.esm)
 **Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/records/`, `crates/plugin/src/esm/cell/` (post-Session-34 split — walkers / helpers / support / wrld), `byroredux/src/cell_loader/refr_texture_overlay_tests.rs`
-**Checklist**: Parse `Fallout3.esm` through the shared FNV parser. Are there FO3-unique record types absent from FalloutNV.esm (e.g., pre-FNV formats for NPC_, DIAL, INFO)? Compare category counts: items, containers, NPCs, factions, globals, settings vs the FNV baseline of 13,684 structured records. CELL record XCLL/RCLR layout identity vs FNV. Water records (WATR) for rivers / ponds — parsed or skipped? NAVM differences?
-**REFR per-instance texture overrides (XATO/XTNM/XTXR — #584)**: FO3 cell REFRs can carry per-instance texture-set overrides. These resolve against `EsmCellIndex.texture_sets` and feed the `ResolvedPaths` struct consumed by `material_translate::translate_material` (Dimension 4). Confirm FO3 cell REFR overlays produce distinct resolved paths (not collapsed to the base mesh material). Regression tests live in `refr_texture_overlay_tests.rs`.
+**Entry points**: `crates/plugin/src/esm/records/`, `crates/plugin/src/esm/cell/` (post-Session-34 split — `walkers.rs` / helpers / support / `wrld.rs`), `byroredux/src/cell_loader/refr_texture_overlay_tests.rs`
+**Checklist**:
+- Parse `Fallout3.esm` through the shared parser. Reconcile against the live baseline: **44 657 records = 37 459 structured + 7 198 NAVMs** (re-verified 2026-05-26). A drop here is the regression signal — do NOT use any older "13 684 structured" figure.
+- FO3-unique authoring vs FNV: pre-FNV subforms for NPC_, DIAL, INFO. Earlier SCHR-flag layout (the parser deliberately keeps the Oblivion-vs-FO3+ dead-branch truncation semantics — `crates/plugin/src/esm/sub_reader.rs` migration, R2 Phase B).
+- CELL XCLL / RCLR layout identity vs FNV (FO3 interior lighting uses the same `CellLightingRes` path — confirm, don't assume).
+- WATR (rivers/ponds) and NAVM differences. WTHR / CLMT pulled through the shared parser.
+- **REFR per-instance texture overrides (XATO/XTNM/XTXR — #584)**: FO3 cell REFRs can carry per-instance texture-set overrides that resolve against `EsmCellIndex.texture_sets` and feed the `ResolvedPaths` consumed by `translate_material` (Dim 1). Confirm FO3 overlays produce distinct resolved paths, not a collapse to the base mesh material. Regression tests: `byroredux/src/cell_loader/refr_texture_overlay_tests.rs`.
+- **TXST/XATO/XTNM/XTXR dispatch** lives in `crates/plugin/src/esm/cell/walkers.rs`; an `unreachable_patterns` warning there is a smell.
 **Output**: `/tmp/audit/fo3/dim_3.md`
 
-### Dimension 4: Rendering Path for FO3 Shaders
-**Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/import/material/{mod,walker,shader_data}.rs`, `byroredux/src/material_translate.rs` (`translate_material`), `crates/core/src/ecs/components/material.rs` (`resolve_pbr`, `EmissiveSource`), `byroredux/src/render/`, `crates/renderer/shaders/triangle.frag`
-**Checklist**: `BSShaderPPLightingProperty` flag bits mapped correctly (decal, alpha-test, two-sided, glow, window — per-game flag bit positions are NOT identical across FO3/FNV/Skyrim). Normal map handle extracted from `BSShaderTextureSet[1]`, not from the bump slot (Oblivion trap). Parallax depth / parallax map slot routed to the parallax branch in the fragment shader (if enabled). Cubemap / environment map slot. Refraction strength → glass tint path. Decal z-bias uses the NIF-flagged decal detection (not heuristic). **#1243 `WaterShaderProperty` consumer wired at import** (`3509482a`): FO3 water materials route through `MaterialInfo` for distinct GpuMaterial entries (no dedup collapse with glass).
-**NIFAL canonical material boundary (#1241 / #1244, `3ce98db8`)**: FO3 materials must flow through the SINGLE `material_translate::translate_material` boundary (`ImportedMesh` + `ResolvedPaths` → canonical `Material`), not the two old duplicated literal sites. `Material.metalness` / `Material.roughness` are now plain resolved `f32` (no `Option`, no per-draw classify): for legacy inline-shader FO3 content (no BGSM-authored PBR scalars — BGSM is FO4+) they arrive as the NaN sentinel and `Material::resolve_pbr` fills them from the keyword classifier (`classify_pbr_keyword`). Confirm FO3 materials land in this one boundary and resolve to concrete `f32` scalars. See also `/audit-nifal`.
-**EmissiveSource discriminator (#1280, `2e884741`)**: FO3 `BSShaderPPLighting` / `NoLighting` self-illumination maps to `EmissiveSource::Material` (the legacy Gamebryo `NiMaterialProperty.emissive_mult` slot). All three variants (`Material`/`Lighting`/`Effect`) currently flow into the same `emissive_mult` slot — the discriminator is provenance for a future split, not a render-time branch yet. `BSShaderNoLightingProperty` now renders fullbright (`c351e0b6`) so self-illumination doesn't dim with distance — confirm FO3 NoLighting (UI / sky / glow) routes to the fullbright path.
-**Disney BSDF gating regression guard (#1248-#1252)**: zero FO3 materials author BGSM (BGSM is FO4+), so `MAT_FLAG_PBR_BSDF` (`triangle.frag` `(1u << 5)`) must be 0 across the Fallout3.esm material universe — the Disney lobe at `triangle.frag` (Burley 2012 / GLSL-PathTracer MIT attribution block, gated on `MAT_FLAG_PBR_BSDF`) is unreachable for FO3. Audit pattern matches FNV: if any FO3 scene activates Burley retro-reflection / anisotropic GGX / per-material-IOR Fresnel, the gate has regressed.
+### Dimension 4: FO3 Cell Loading End-to-End (interior + exterior)
+**Subagent**: `general-purpose`
+**Entry points**: `byroredux/src/cell_loader/{load,unload,exterior,references,spawn}.rs`, `byroredux/src/scene/{nif_loader,world_setup}.rs`
+**Checklist**:
+- FO3 interior loads via the SAME `--esm Fallout3.esm --cell <id>` CLI as FNV. Megaton parse-side baseline: **929 REFRs** (down from 1609 pre-NIF-expand; #455+, cell-loader stale-comment cleanup #822 / `ca6be24`). Any audit citing 1609 references pre-expand stats — confirm against current `cell_loader/*.rs` comments first.
+- **Exterior is WIRED** (ROADMAP: "Exterior wired; fresh GPU bench pending"). Capital Wasteland is a distinct WRLD form ID — audit `cell_loader/exterior.rs` + `crates/plugin/src/esm/cell/wrld.rs` for any FNV-hardcoded worldspace name, origin coord, or default grid that would mis-place FO3 exterior cells. The open item is a fresh GPU bench (R6a-stale-15), not a missing feature.
+- No FNV-only branch in the shared cell loader. WTHR→CLMT→WTHR resolution and FO3 CLMT sun-position curves resolve through the shared weather path.
+- `CachedNifImport` Arc cache prevents duplicate parsing; no leak across FO3 unload/load cycles.
 **Output**: `/tmp/audit/fo3/dim_4.md`
 
-### Dimension 5: Real-Data Validation
-**Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
-**Checklist**: Current parse rate on `Fallout - Meshes.bsa` (expect 100% / 10989). `BYROREDUX_FO3_DATA=... cargo test -p byroredux-nif --test parse_real_nifs -- --ignored fo3` passes. Pick Megaton Player House interior (already validated — should match 1609 entity baseline). Load one creature mesh (e.g. deathclaw), verify skinning data extraction. Pick a UI/menu element (NoLighting shader) and verify it routes through the non-Phong path. Pick one FaceGen head mesh — parses but may not render fully.
+### Dimension 5: FO3 Collision Import (Havok → CollisionShape)
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/import/collision.rs` (`extract_collision`, `examine_collision_kind`, `resolve_shape`, `CollisionAuthoring`)
+**Checklist**:
+- FO3 Havok content is no longer merely skipped via `block_size` — `extract_collision` walks `bhk*CollisionObject` → `BhkRigidBody` → shape into `CollisionShape` + `RigidBodyData`. `examine_collision_kind` must classify FO3 chains as `CollisionAuthoring::Classic` (BSVER 34, legacy side), not `NewPhysicsStub` / `Phantom` / `Unrecognised` — a misclassified discriminator silently drops the rigid body.
+- **#1277 / `9c6096aa`**: `BhkMultiSphereShape` (→ sphere path) and `BhkConvexListShape` (→ `CollisionShape::Compound`, mirroring `BhkListShape`) now translate — they were dropped before. FO3 uses these in static/clutter collision; confirm FO3 meshes carrying them yield a non-`None` `extract_collision`, not a discarded shape.
+- Cross-check the Dim 2 "skips via block_size" note — that is now only true for shape kinds WITHOUT a translator. See also `/audit-nifal` (collision is part of the canonical tier) and `/audit-nif` for raw block decode.
 **Output**: `/tmp/audit/fo3/dim_5.md`
 
-### Dimension 6: Blockers & Game-Specific Quirks
+### Dimension 6: BSA v104 + Real-Data Validation
 **Subagent**: `general-purpose`
-**Entry points**: `ROADMAP.md`, `byroredux/src/cell_loader/{load,exterior,references,spawn}.rs`, `byroredux/src/npc_spawn.rs`
-**Checklist**: Can Fallout 3 cells be loaded end-to-end via the same `--esm Fallout3.esm --cell <id>` CLI as FNV? Any hardcoded FNV-only paths in the cell loader? Weather (WTHR) / CLMT records — FO3 has them; are they pulled from the FNV-shared parser correctly? Exterior worldspace loading — FO3's Wasteland is a different WRLD form ID; any FNV-hardcoded assumptions (e.g. specific worldspace names, origin coords)? FO3-specific CLMT sun position curves.
-**M41.0 long-tail regression guards (shared with FNV — Session 29)**:
-- B-spline pose-fallback (#772, 3c32a5e): gated on `FLT_MAX` sentinel. B-splines are reachable on FO3 just as on FNV (`feedback_bspline_not_skyrim_only.md`).
-- AnimationClipRegistry dedup (#790, da99d15): case-insensitive interning by lowercased path; without it, one keyframe set leaks per cell load.
-- NPC hand-mesh load (#793 / M41-HANDS, da8d7e2): `lefthand.nif` + `righthand.nif` loaded alongside `upperbody.nif` on kf-era NPCs. Megaton dwellers depend on this — bodies with no hands = #793 regression.
-- Megaton parse-side baseline (Session 12, #455+): 929 REFRs (down from 1609 post-NIF-expand). Cell-loader stale-comment cleanup landed in #822 FNV-D3-DOC (ca6be24). Any audit citing the 1609 number is referencing pre-expand stats — confirm against current `cell_loader/*.rs` comments (post-Session-34 split) before reporting.
+**Entry points**: `crates/bsa/src/archive/`, `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
+**Checklist**:
+- `Fallout - Meshes.bsa` lists + extracts cleanly; current NIF parse rate **100% / 10 989** (`nif_stats`). `Fallout - Textures.bsa` DDS extraction yields valid BC1/BC3/BC5 headers. Folder-hash collisions across FO3's subdirectories. Format is identical to FNV — divergence here would be a v104 regression, not a format gap.
+- Pick **Megaton** interior (validated baseline — should match 929 REFRs / current entity count; capture `/cmd stats` and compare to feature-matrix, NOT the stale 1609/199-tex/42-FPS numbers).
+- Load a creature mesh (e.g. deathclaw): verify NiSkinData skinning extraction (`crates/nif/src/import/mesh/skin.rs`).
+- Pick a UI/menu `BSShaderNoLightingProperty` element: verify the fullbright (non-Phong) route.
+- Pick one FaceGen head mesh (`crates/facegen/`): parses; may not render fully — note the gap, don't fail the dimension.
+- Load a `.spt` (SpeedTree 5.x, `crates/spt/`): confirm placeholder-billboard fallback, not a hard parse error.
 **Output**: `/tmp/audit/fo3/dim_6.md`
 
-### Dimension 7: FO3 Collision Import (Havok → CollisionShape)
+### Dimension 7: FO3 Animation / NPC Spawn + Scripting Gap
 **Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/import/collision.rs` (`extract_collision`)
-**Checklist**: FO3 Havok content is no longer merely skipped via `block_size` — `extract_collision` walks `bhk*CollisionObject` → `BhkRigidBody` → shape into a `CollisionShape` + `RigidBodyData`. Per-variant dispatch (`#1277` Task 1, `8d3a6861`) routes each shape kind. **#1277 / `9c6096aa`**: `BhkMultiSphereShape` + `BhkConvexListShape` now translate (were previously dropped) — MultiSphere via the sphere path, ConvexList → `CollisionShape::Compound` (mirrors `BhkListShape`). FO3 uses these shapes in static / clutter collision; confirm FO3 meshes carrying them produce a non-`None` `extract_collision` result rather than discarding the shape. Cross-check the Dimension 1 note that Havok "skips via block_size" — that is now only true for shape kinds without a translator. See also `/audit-nifal`.
+**Entry points**: `crates/nif/src/anim/` (Session-35 split: `entry`, `sequence`, `controlled_block`, `transform`, `bspline`, `channel`, `keys`, `coord`), `crates/core/src/animation/`, `byroredux/src/anim_convert.rs`, `byroredux/src/npc_spawn.rs`
+**Checklist** — M41.0 long-tail regression guards (shared with FNV, Session 29; verify they hold on FO3 data):
+- B-spline pose-fallback (#772, `3c32a5e`): gated on the `FLT_MAX` sentinel. B-splines are reachable on FO3 (`feedback_bspline_not_skyrim_only.md`) — don't rule them out by era.
+- `AnimationClipRegistry` dedup (#790, `da99d15`): case-insensitive interning by lowercased path; without it one keyframe set leaks per cell load (RAM growth on FO3 exterior streaming).
+- NPC hand-mesh load (#793 / M41-HANDS, `da8d7e2`): `lefthand.nif` + `righthand.nif` loaded alongside `upperbody.nif` on kf-era NPCs (`byroredux/src/npc_spawn.rs`). Megaton dwellers depend on this — bodies with no hands = #793 regression. FO3 kf-era spawn works because its `skeleton.nif` resolves (unlike FO4).
+- **Scripting gap (FO3-distinctive)**: 1 257 FO3 SCPT records parse but **no runtime executes them** (M47.0 event-hook + M47.1 condition-eval landed; M47.2 closes the loop). This is the largest FO3-specific functional gap — note it as a known blocker for FO3 quest/world interactivity, not a bug to file.
 **Output**: `/tmp/audit/fo3/dim_7.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/fo3/dim_*.md` files.
-2. Combine into `docs/audits/AUDIT_FO3_<TODAY>.md` with structure:
-   - **Executive Summary** — Compatibility level, delta vs FNV baseline (what's the same, what diverges).
+1. Read all `/tmp/audit/fo3/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_FO3_<TODAY>.md`:
+   - **Executive Summary** — Compatibility level + delta vs FNV (what's shared, what diverges).
    - **Dimension Findings** — Grouped by severity per dimension.
-   - **FNV-Shared Surface** — Explicit list of record types / block types / shader paths that FO3 inherits from FNV coverage. Any FO3-only gaps in those paths.
-   - **Validation Status** — Interior cell load status, exterior cell load status, creature / NPC status.
+   - **FNV-Shared Surface** — Record types / block types / shader paths FO3 inherits from FNV coverage, plus any FO3-only gap inside them.
+   - **FO3-Distinctive Gaps** — Inline-shader-only material universe, Capital Wasteland worldspace, the 1 257-SCPT scripting runtime gap.
+   - **Validation Status** — Interior (Megaton 929 REFRs) + exterior (wired, bench pending) + creature/NPC.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_FO3_<TODAY>.md`

--- a/.claude/commands/audit-fo4/SKILL.md
+++ b/.claude/commands/audit-fo4/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Per-game audit of Fallout 4 compatibility — BA2, half-float verts, BGSM materials, SCOL architecture"
+description: "Per-game audit of Fallout 4 compatibility — BA2, half-float verts, BGSM materials, M49 precombines (CSG)"
 argument-hint: "--focus <dimensions>"
 ---
 
@@ -9,28 +9,42 @@ Deep audit of ByroRedux readiness for **Fallout 4** content.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game data locations, key reference docs, methodology, deduplication rules, and finding format. See `.claude/commands/_audit-severity.md` for severity. This file only carries FO4-specific context — do not duplicate the common map here.
+
+## What's Landed (audit as regression guards, not blockers)
+
+FO4 is one of the more complete game paths. Treat each item below as **shipped** — the audit job is to confirm it still holds, not to re-propose it.
+
+- **NIF** — BSVER 130 + Next-Gen patch range parses. Half-float vertices, BSTriShape, BSGeometry, inline tangents, BSSubIndexTriShape.
+- **BA2** — exhaustive version match `{1, 2, 3, 7, 8}` (GNRL + DX10); unknown majors bail at `open()`.
+- **BGSM/BGEM materials** — full external-material parser crate `crates/bgsm/`, merged into the mesh before NIFAL translate.
+- **ESM architecture records** — SCOL / MOVS / PKIN / TXST parsed; SCOL/PKIN placements expand into individual statics.
+- **M49 precombined geometry (CSG)** — **closed Session 45, 2026-06-02** (#1351 / #1188 Stage A). `.csg` reader, NIF precombine decode, cell-loader spawn, per-tier LOD selection, owning-REFR texture slot routing all shipped. ROADMAP language describing M49 as "blocked / no spec" is stale — the format was cracked from first principles, spec written, pipeline landed.
+- **FO4 metalness from spec chromaticity** (#1476) — legacy spec-glossiness BGSMs derive metalness from spec-color **saturation**, not luminance (luminance made all vanilla concrete read chrome).
+
+Still open (legitimate forward scope): `_precomb.nif` collision, `.uvd` occlusion volumes, MOVS physics runtime, FaceGen NIF truncation tail, deeper cell coverage (LIGH power state / CONT leveled items / NPC_ face morph), Havok behavior-graph driving.
 
 ## Game Context
 
-| Aspect            | State                                                                                |
-|-------------------|--------------------------------------------------------------------------------------|
-| NIF format        | BSVER 130 (and Next-Gen patches)                                                     |
-| BA2 format        | v1 ✓ / v2 / v3 / v7 ✓ / v8 ✓ exhaustive `match` over `{1, 2, 3, 7, 8}` (#811 FO4-D2-NEW-01, f480337) — unknown majors bail at `open()` time, no silent v1-fallback. GNRL + DX10 variants. |
-| ESM parser        | Stub + SCOL / MOVS / PKIN / TXST records added in session 10. TXST DODT decal-data sub-record + DNAM flags now parsed (#813 / #814, 6941da6 — was silently dropping authoring on 207/382 (DODT) + 382/382 (DNAM) vanilla TXSTs). SCOL / PKIN placements now **expand into individual statics** in the cell loader (`byroredux/src/cell_loader/refr.rs::expand_scol_placements` / `expand_pkin_placements`, depth-capped by `MAX_PKIN_DEPTH = 4`, #1180 / #1182), wired via `cell_loader/references.rs`. |
-| Parse rate        | 100.00% (34995 / 34995)                                                              |
-| Rendering         | Individual mesh + material diagnostics; FO4 cell loading is **wired** (`Fallout4.esm` SCOL/PKIN expansion + `cell_loader/precombined.rs` PreCombined-Mesh spawn, exterior Phase-3a). BGSM/BGEM materials parsed (`crates/bgsm/`) and merged. |
-| Reference data    | `/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data/`                            |
+| Aspect       | State |
+|--------------|-------|
+| NIF format   | BSVER 130 + Next-Gen patches; `FALLOUT4..FO4_DLC_UPPER` (130..=139) carries DLC trailing fields (`crates/nif/src/version.rs`) |
+| BA2 format   | Exhaustive `match` over `{1, 2, 3, 7, 8}` in `crates/bsa/src/ba2.rs` (consts `BA2_V_FO4=1`, `BA2_V_FO4_NEXT_GEN_TEX=7`, `BA2_V_FO4_NEXT_GEN_MESH=8`); GNRL + DX10 |
+| ESM records  | SCOL / MOVS / PKIN / TXST in `crates/plugin/src/esm/records/`; SCOL/PKIN expand in `byroredux/src/cell_loader/refr.rs` |
+| Precombines  | M49 CSG pipeline landed — `crates/bsa/src/csg.rs` → `crates/nif/src/import/precombine.rs` → `byroredux/src/cell_loader/precombined.rs` |
+| Parse rate   | 100.00% clean on both vanilla mesh archives per #1457 (`parse_rate_fo4_all_meshes`, 2026-06-14); the FaceGen truncation tail the 2026-06-02 ROADMAP snapshot recorded is gone. The ROADMAP compat-matrix figure (96.46%) lags — re-run the harness before citing a parse rate. |
+| Rendering    | Interior cells render end-to-end (MedTekResearch01 bench, ~21k entities). BGSM/BGEM merged; precombined entities spawned interior + exterior. |
+| Reference    | `/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data/` |
+| Bench        | `--cell MedTekResearch01` (see ROADMAP for the full `--bsa`/`--textures-ba2`/`--materials-ba2` invocation) |
 
-### Known Specifics
+### Known FO4 Specifics
 
-- **Half-float vertices** — `VF_FULL_PRECISION` bit controls whether positions/normals are stored as f32 or u16 half-precision. FO4 defaults to half.
-- **FO4 shader flags** — `BSLightingShaderProperty` flags are a **u32 pair** (two 32-bit masks: shader_flags_1 + shader_flags_2), not the single mask of FO3/FNV/Skyrim.
-- **Trailing fields** — FO4 adds subsurface_color, subsurface_strength, rimlight_power, backlight_power, wetness params (Unknown 1 from BSVER > 130).
-- **BGSM / BGEM materials** — FO4 stores PBR-ish material parameters in external `.bgsm` / `.bgem` files. `BSLightingShaderProperty.net.name` holds the path; the parser **stops and returns a material-reference stub** when BSVER ≥ 155 and Name is a BGSM/BGEM path. BGSM parser itself is out of scope — the Name path flows through `ImportedMesh.material_path` for diagnostics.
-- **Architecture records** — `SCOL` (static collections / prefabs), `MOVS` (movable statics), `PKIN` (packins), `TXST` (texture sets). Added in session 10; SCOL / PKIN placements now expand into individual statics in `byroredux/src/cell_loader/refr.rs` (`expand_scol_placements` / `expand_pkin_placements`, recursion bounded by `MAX_PKIN_DEPTH = 4`, #1180 / #1182; tests at `cell_loader/{scol_expansion_tests,pkin_expansion_tests}.rs`). MOVS physics semantics are still parse-only.
-- **Specialty blocks** — BSSubIndexTriShape, BSClothExtraData, BSConnectPoint::Parents/Children, BSBehaviorGraphExtraData, BSInvMarker, BSSkin::Instance / BSSkin::BoneData.
-- **Inline per-vertex tangents** (#795 / #796, b63ab0c) — when `VF_TANGENTS | VF_NORMALS` are both set on the packed-vertex flag, FO4+ BSTriShape ships tangents inline in the packed-vertex blob, NOT in a separate `NiBinaryExtraData`. Distinct from the Skyrim-via-`NiBinaryExtraData` path of Oblivion / FO3 / FNV (#786 / 5dde345). Any FO4 audit proposing to consolidate the two paths into one is a regression of #795/#796.
+- **Half-float vertices** — `VF_FULL_PRECISION` controls f32 vs u16 binary16 positions/normals; FO4 defaults to half.
+- **FO4 shader flags** — `BSLightingShaderProperty` flags are a **u32 pair** (shader_flags_1 + shader_flags_2), not the single mask of FO3/FNV/Skyrim.
+- **DLC trailing fields** — subsurface, rimlight, backlight, fresnel, wetness in the `FALLOUT4..FO4_DLC_UPPER` BSVER band.
+- **External materials** — PBR-ish params live in `.bgsm`/`.bgem` files; the NIF carries only the path. The block parser returns a material-reference stub when BSVER ≥ 155 and Name is a BGSM/BGEM path; `crates/bgsm/` parses the file.
+- **Inline per-vertex tangents** (#795 / #796) — when `VF_TANGENTS | VF_NORMALS` are both set, FO4+ BSTriShape ships tangents **inline** in the packed-vertex blob, NOT via a separate `NiBinaryExtraData` (the Skyrim/FO3/FNV path, #786). Consolidating the two into one is a regression of #795/#796.
+- **Architecture records** — SCOL (prefab collections), MOVS (movable statics), PKIN (packins), TXST (texture sets w/ DODT decal-data + DNAM flags).
 
 ## Parameters (from $ARGUMENTS)
 
@@ -40,80 +54,116 @@ See `.claude/commands/_audit-common.md` for project layout, game data locations,
 
 1. Parse `$ARGUMENTS`.
 2. `mkdir -p /tmp/audit/fo4`.
-3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
+3. Dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
 4. Confirm `Fallout 4/Data/` exists; if not, note which dimensions lose real-data validation.
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: NIF BSVER 130 + Half-Float Vertices
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (BSTriShape parser; split out into `tri_shape/bs_tri_shape.rs` post-#1118), `crates/nif/src/import/mesh/bs_tri_shape.rs`, `crates/nif/src/import/collision.rs` (FO4 collision translate)
-**Checklist**: VF_FULL_PRECISION flag resolution — default-half unless set. Half-float decode matches IEEE 754 binary16 (including denormals and NaN). BSSubIndexTriShape segment data walked correctly (FO4 uses this extensively for actors). Skinned-vertex bone indices + weights extraction honors packed layout. BSVER 130 trailing fields on BSLightingShaderProperty: subsurface, rimlight, backlight, fresnel, wetness (Unknown 1 for BSVER > 130). Next-Gen patch NIFs (slightly different BSVER values) still dispatch correctly. **FO4 collision (regression pin)**: `BhkMultiSphereShape` (`collision.rs:301`) + `BhkConvexListShape` (`collision.rs:397`) now translate to `CollisionShape` instead of falling through to the "unsupported" log and being dropped — FO4 power-armor / settlement / destructible debris collision depends on this; if either downcast arm reverts to a drop it's a regression target.
+Dimensions are ordered by FO4 risk: the precombine pipeline, BGSM material translation, and the BA2 reader are the hot, recently-churned areas.
+
+### Dimension 1: M49 Precombined Geometry — CSG + Decode + Spawn (highest FO4 risk)
+**Subagent**: `general-purpose`
+**Entry points**: `crates/bsa/src/csg.rs` (`CsgArchive::open`, `read_psg`), `crates/nif/src/import/precombine.rs` (`decode_shared_geom_object`, `psg_vertex_stride`, `PrecombineGeometry::into_imported_mesh`, `collect_precombine_geom_refs`, `PrecombineMaterial::apply`), `byroredux/src/cell_loader/precombined.rs` (`spawn_precombined_meshes`), `byroredux/src/cell_loader/load.rs` (the `pc_spawned` / `absorbed_refs` gate), `crates/plugin/src/esm/cell/wrld.rs` + `crates/plugin/src/esm/cell/mod.rs` (`precombined_mesh_hashes`). Spec: `docs/engine/fo4-csg-format.md`.
+**Checklist**:
+- **Vertex stride** — `psg_vertex_stride(vertex_desc)` must match the `BSPackedGeomObject` packed layout; an off-by-N stride silently shifts every vertex. Cross-check against the spec doc.
+- **Y-up convert** — `into_imported_mesh` applies the Z-up→Y-up + per-instance transform. Confirm the instance transform composes (no double-apply with `cell_origin`).
+- **CSG resolve** — `spawn_precombined_meshes` opens the companion `<Plugin> - Geometry.csg` once per cell; missing CSG must fall back to per-REFR (return 0 spawns) rather than panic.
+- **REFR de-dup gate** (#1188) — `cell.absorbed_refs` are suppressed **only when `pc_spawned > 0`**; verify the `load.rs` gate renders absorbed REFRs when the precombine spawns nothing (no double-draw, no holes).
+- **LOD selection** — one tier per object, not all three (the `a30c088a` fix); a regression here triples precombine geometry.
+- **Texturing** — precombine shapes texture through the owning REFR's shape-slot indices (`2900de70`); a regression renders untextured/checker precombines.
+- **Exterior path** — `cell_origin = cell_grid_to_world_yup(gx, gy)` for exterior (#1221 / #1222); without it exterior precombines stack at world origin.
 **Output**: `/tmp/audit/fo4/dim_1.md`
 
-### Dimension 2: BA2 Reader — GNRL + DX10 Variants (Exhaustive Version Match)
+### Dimension 2: BGSM / BGEM Consumption + Metalness-from-Chromaticity (regression pin #1476)
 **Subagent**: `general-purpose`
-**Entry points**: `crates/bsa/src/ba2.rs`
-**Checklist**: Version dispatch is now an **exhaustive `match` over `{1, 2, 3, 7, 8}`** (#811 FO4-D2-NEW-01, f480337) — unknown majors bail at `open()` time, no silent v1-fallback. Audit any reintroduction of cascading `if v == 1 { ... } else if v == 7 { ... }` chains: that pattern is the regression. Mirrors the BSA reader's allowlist discipline now at `crates/bsa/src/archive/open.rs` (the `archive.rs` file was split into the `crates/bsa/src/archive/` dir — `{open,extract,hash,mod,tests}.rs`; the in-code `archive.rs:165-173` comment in `ba2.rs` is stale and points at the pre-split file). GNRL (general files — meshes, scripts): extract a mesh and a script and verify byte-exact. DX10 (textures): DDS header reconstruction from width/height/format/mip count. DXT1/DXT5/BC5/BC7 format encoding in `dxgi_format`. Mip chunk assembly — mip0 (largest) vs mip_last (smallest) ordering. Compression flag per-archive (zlib vs uncompressed). Verify against the ROADMAP claim of 100% on 34995 NIFs + the Textures archives.
+**Entry points**: `crates/bgsm/src/` (`lib`, `base`, `bgsm`, `bgem`, `reader`, `template`), `byroredux/src/asset_provider.rs` (`merge_bgsm_into_mesh`).
+**Checklist**:
+- **Single data source** — `merge_bgsm_into_mesh` is the FO4 material merge: albedo/diffuse tint, specular, emissive, smoothness→roughness, translucency suite (#1147), model-space-normals bit, texture-slot paths. It runs **before** `translate_material`.
+- **Metalness from saturation, NOT luminance** (#1476, `08ed03be`) — for legacy spec-glossiness BGSMs (`leaf.pbr == false`, ~all vanilla architecture), metalness = `(max-min)/max` of `specular_color` (mult-invariant saturation): white spec `[1,1,1]` → 0 (concrete is dielectric), tinted spec → metallic. **Any reversion to luminance (`0.2126·r + …`) for the non-pbr branch is the #1476 regression — it makes vanilla concrete read chrome.** The luminance path is correct *only* for `leaf.pbr == true`.
+- **smoothness→roughness applied exactly once at parse** — `mesh.roughness_override = Some((1.0 - leaf.smoothness).clamp(0.04, 1.0))`. Audit any downstream re-application of the `1.0 - smoothness` inversion.
+- **Magic-vs-extension reconciliation** (#758 footgun) — the `.bgsm`/`.bgem`/`.mat` arm dispatches on file content; verify it logs and does not blindly trust the extension.
+- **Cycle-aware template resolve** (#1148) — `template.rs::resolve` / `resolve_depth` track `visited` lowercase keys and break `A→B→A` self-refs (vanilla `defaulttemplate_wet.bgsm`); verify the cycle-break + `DEPTH_LIMIT` still fire.
 **Output**: `/tmp/audit/fo4/dim_2.md`
 
-### Dimension 3: FO4 Shader Flags & BGSM Material Reference + Disney BSDF Path
-**Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs` (BSLightingShaderProperty), `crates/nif/src/import/material/` (mod, walker, shader_data), `crates/renderer/shaders/triangle.frag` (Disney lobe gate sites)
-**Checklist**: Shader flags — u32 pair read correctly (shader_flags_1 + shader_flags_2, two separate fields). Flag bit positions for FO4 differ from Skyrim — verify decal, alpha-test, skinned, glow, window, refraction, parallax, facegen bits are read from the correct mask + bit. BSLightingShaderProperty stopcond on BGSM Name path — when the material is external, parser returns early without reading the Phong trailing fields (those belong in the BGSM). `ImportedMesh.material_path` flows through to `Material.material_path` so diagnostics show BGSM references. `mesh.info <entity_id>` debug command surfaces material_path when texture_path is absent (session 10 behavior). **BSShaderTextureSet slot routing on `BSLightingShaderType`** (#563, d9bc363): SkinTint and HairTint sample from different slots than the default LSP path — verify the per-shader-type slot map is in lockstep with what the fragment shader reads.
-**Disney BSDF / PBR path (FO4 is PBR-canonical, see audit-renderer Dim 21)**:
-- **FO4 BGSM authoring sets `MAT_FLAG_PBR_BSDF`** at import — verify `crates/nif/src/import/material/walker.rs` routes BGSM through the PBR flag (NOT the legacy Phong/Lambert path). #1241 (`a82366e9`) surfaces `smoothness / IOR / specular_strength` from `BSLightingShaderProperty` into `MaterialInfo` so the Disney lobe has data to consume
-- **Regression pattern (FO4-specific)**: BGSM-authored material that **falls back to Lambert** (does NOT set the PBR flag) — the opposite of the FNV/FO3 regression. Audit pattern: scan an FO4 cell, count materials with `material_kind` matching BGSM authoring, confirm the PBR flag count matches
-- **BGSM smoothness → glossiness conversion** (`98383caf`): BGSM authors `smoothness` (0..1, 1=mirror); the Disney lobe consumes `roughness` (0..1, 0=mirror). Verify the conversion `roughness = 1.0 - smoothness` happens ONCE at parse and not double-applied at consume
-- **#1242 `FO4_ENV_SCALE` renamed to `FO4_DLC_UPPER`** (`9883ed88`): the BSVER constant that was misnamed now reflects its actual semantic (DLC bsver upper bound). Any code that referenced `FO4_ENV_SCALE` is a regression target — verify nothing in `crates/nif/` or `crates/plugin/` references the old name
-- **#1244 `BSShaderPropertyBaseOnly` consumer wired at import** (`6163b5f7`): bare-stub BSShaderProperty without subclass data is now routed through MaterialInfo. Verify FO4 fallback meshes don't render with default-everything
-- The per-game→canonical material handoff (BGSM PBR flag packing, smoothness→roughness, metalness/roughness resolution) now lives at the single NIFAL boundary — covered in depth by **Dimension 7** below. **See also `/audit-nifal`** for the cross-game canonical-translation invariants (single boundary, no fabrication, no render-time fallback)
+### Dimension 3: BA2 Reader — GNRL + DX10 (Exhaustive Version Match)
+**Subagent**: `general-purpose`
+**Entry points**: `crates/bsa/src/ba2.rs`.
+**Checklist**:
+- **Exhaustive dispatch** (#811, `f480337`) — version handling is a `match` over the supported set; unknown majors (0, 4, 5, 6, 9, …) bail at `open()`. Any reintroduction of a cascading `if v == 1 { … } else if v == 7 { … }` chain with a silent v1 fallback is the regression. Mirrors the BSA allowlist now at `crates/bsa/src/archive/open.rs` (the old `archive.rs:165-173` comment in `ba2.rs` referencing the pre-split file is stale).
+- **GNRL** — extract a mesh and a script, byte-exact.
+- **DX10** — DDS header reconstruction from width/height/`dxgi_format`/mip count; DXT1/DXT5/BC5/BC7 encoding; mip chunk assembly (mip0 largest → mip_last); per-archive zlib-vs-uncompressed flag.
+- **Cross-version** — `BA2_V_FO4` (1) / `BA2_V_FO4_NEXT_GEN_TEX` (7) / `BA2_V_FO4_NEXT_GEN_MESH` (8) all force zlib; confirm the Next-Gen mesh/tex archives extract.
 **Output**: `/tmp/audit/fo4/dim_3.md`
 
-### Dimension 4: ESM Architecture Records (SCOL / MOVS / PKIN / TXST)
-**Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/records/`, `crates/plugin/src/esm/cell/` (post-Session-34/35 split: `cell/{mod,walkers,support,wrld}.rs` + `cell/tests/`)
-**Checklist**: SCOL record structure — a prefab that contains placements of child statics + scale/rotation per instance. Are these parsed into a structure the cell loader can expand? MOVS — movable statics (physics-driven). PKIN — packins (grouped content bundles). TXST — texture sets referenced by NIF material paths. **TXST DODT + DNAM** (#813 / #814, 6941da6): decal-data sub-record + flags now parsed via `DecalData`. Pre-fix: 207/382 (DODT) + 382/382 (DNAM) vanilla TXSTs silently dropped their authoring. Audit any path that reads TXST without `DecalData` — that's the regression pattern. Post-Session-34/35, `cell.rs` was split into `crates/plugin/src/esm/cell/{mod,walkers,support,wrld}.rs` + `cell/tests/` (8 per-topic test siblings); the TXST match arms live in `cell/walkers.rs`. If an `unreachable_patterns` warning surfaces there (or `grep -n 'unreachable_patterns' crates/plugin/src/esm/cell/` returns anything) it suggests `b"TXST"` matches before reaching the intended arm — investigate. How many SCOL / MOVS / PKIN / TXST records exist in `Fallout4.esm`? Minimum record set needed for a hello-world FO4 cell load. **FO4-architecture map exposure**: 5 FO4-architecture maps must surface in `categories()` index (#817 FO4-D4-NEW-05, af9f4de) — missing entries hide the records from any caller iterating by category. Real-data FO4 ESM parse-rate harness lives at `#819 FO4-D4-NEW-07` (d8f859d) — re-run before reporting parse-rate findings.
+### Dimension 4: NIF BSVER 130 + Half-Float Vertices + FO4 Collision
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs`, `crates/nif/src/import/mesh/bs_tri_shape.rs`, `crates/nif/src/import/mesh/bs_geometry.rs`, `crates/nif/src/import/collision.rs`.
+**Checklist**:
+- VF_FULL_PRECISION resolution (default-half unless set); half-float decode matches IEEE 754 binary16 incl. denormals/NaN.
+- BSSubIndexTriShape segment data walked (FO4 actors lean on it); skinned bone indices/weights honor packed layout.
+- DLC trailing fields on `BSLightingShaderProperty` in the `FALLOUT4..FO4_DLC_UPPER` band (subsurface/rimlight/backlight/fresnel/wetness). Next-Gen patch BSVER values still dispatch.
+- **#1242 constant rename** — the BSVER bound is `FO4_DLC_UPPER` (= 140), not the old misnamed `FO4_ENV_SCALE`. Any reference to the old name anywhere under `crates/nif/` or `crates/plugin/` is a regression target.
+- **FO4 collision (regression pin)** — `BhkMultiSphereShape` and `BhkConvexListShape` translate to `CollisionShape` in `collision.rs` (search the two `downcast_ref` arms) instead of falling through to the "unsupported" log + drop. Power-armor / settlement / destructible-debris collision depends on this; either arm reverting to a drop is a regression (NIFAL "parsed then dropped" leak class).
 **Output**: `/tmp/audit/fo4/dim_4.md`
 
-### Dimension 5: Real-Data Validation
-**Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
-**Checklist**: Parse rate holds at 100% on 34995 FO4 NIFs via `BYROREDUX_FO4_DATA=... cargo test -p byroredux-nif --test parse_real_nifs -- --ignored fo4`. Load a settlement object (workshop crafted item). Load a creature (deathclaw, super mutant). Load a power armor frame (heavy skinning + connect points). Load a weapon (receiver + barrel + stock — uses BSConnectPoint to attach modular parts). For each, trace `import_nif_scene` output: mesh count, material_path (BGSM reference or null), skinned / rigid classification, connect-point extra data presence. Spot-check BSBehaviorGraphExtraData string (references external havok behavior graph — parse-only for now).
+### Dimension 5: FO4 Shader Flags & BGSM PBR Routing (Disney path)
+**Subagent**: `renderer-specialist`
+**Entry points**: `crates/nif/src/blocks/properties.rs` (BSLightingShaderProperty), `crates/nif/src/import/material/` (`mod`, `walker`, `shader_data`), `crates/renderer/shaders/triangle.frag` (Disney lobe gates).
+**Checklist**:
+- **u32 flag pair** read as two separate fields (shader_flags_1 + shader_flags_2). FO4 flag bit positions differ from Skyrim — verify decal / alpha-test / skinned / glow / window / refraction / parallax / facegen bits read from the correct mask + bit.
+- **BGSM Name stopcond** — when the material is external, the block parser returns before reading the inline Phong trailing fields (those belong to the BGSM). `ImportedMesh.material_path` flows to `Material.material_path` for diagnostics; `mesh.info <id>` surfaces it when texture_path is absent.
+- **BSShaderTextureSet slot routing** (#563) — SkinTint / HairTint `BSLightingShaderType` variants sample different slots than the default LSP path; verify the per-type slot map is in lockstep with what `triangle.frag` reads.
+- **PBR flag, not Lambert** — `crates/nif/src/import/material/walker.rs` routes BGSM-authored material through the PBR path; the FO4-specific regression is a BGSM material **falling back to Lambert** (opposite of the FNV/FO3 regression). #1241 surfaces smoothness/IOR/specular_strength into `MaterialInfo` so the Disney lobe has data.
+- **#1244 `BSShaderPropertyBaseOnly` consumer** wired at import — bare-stub BSShaderProperty routes through MaterialInfo; verify FO4 fallback meshes aren't default-everything.
+- The per-game→canonical handoff is covered in depth by **Dimension 7**; cross-game canonical invariants live in `/audit-nifal`.
 **Output**: `/tmp/audit/fo4/dim_5.md`
 
-### Dimension 6: Forward Blockers (post-BGSM / post-cell-load)
+### Dimension 6: ESM Architecture Records (SCOL / MOVS / PKIN / TXST)
 **Subagent**: `general-purpose`
-**Entry points**: `ROADMAP.md`, `crates/plugin/src/esm/records/` (FO4 records live alongside FNV / FO3 / Skyrim — the per-game legacy/{fo4,tes4,tes5}.rs stubs were removed under `#390`)
-**Checklist**: The BGSM/BGEM parser is **shipped** as `crates/bgsm/` and the SCOL→static expansion is **implemented** (covered by Dim 8 / Dim 9 respectively — do NOT re-frame either as an unimplemented blocker). Remaining forward scope: **FO4 ESM cell coverage beyond architecture records** — what's still needed for a richer cell load (REFR with more complex placement data, LIGH with power state, CONT with leveled items, NPC_ with face morph data)? **Havok Next-Gen integration** — mostly out of scope but `BSBehaviorGraphExtraData` is parse-only today; verify nothing pretends to drive it. **FO4 PreCombined CSG companion** — `cell_loader/precombined.rs` spawns the `_oc.nif` precombines, but the CSG reader that would tell the loader which original REFRs the precombine subsumes is still pending; verify the REFR-fallback gate (Dim 9) is the honest interim state. **MOVS physics** — movable-static records parse but the physics-driven runtime is not wired.
+**Entry points**: `crates/plugin/src/esm/records/` (`scol.rs`, `movs.rs`, `pkin.rs`, `mswp.rs`; TXST lives in the misc set), `crates/plugin/src/esm/cell/` (`mod`, `walkers`, `support`, `wrld` + `cell/tests/`).
+**Checklist**:
+- SCOL — prefab of child-static placements w/ per-instance scale/rotation, parsed into an expandable structure. PKIN — packins (grouped bundles). MOVS — movable statics (parse-only; physics runtime not wired). TXST — texture sets referenced by NIF material paths.
+- **TXST DODT + DNAM** (#813 / #814) — decal-data sub-record + flags parsed via `DecalData`; pre-fix, 207/382 (DODT) + 382/382 (DNAM) vanilla TXSTs dropped authoring. Any TXST read path without `DecalData` is the regression. The TXST match arms live in `cell/walkers.rs`; an `unreachable_patterns` warning there suggests `b"TXST"` matches before the intended arm.
+- **Category index exposure** (#817) — the FO4-architecture maps must surface in `categories()`; a missing entry hides records from category iteration.
+- Re-run the real-data ESM parse harness (#819) before reporting any parse-rate finding.
 **Output**: `/tmp/audit/fo4/dim_6.md`
 
 ### Dimension 7: NIFAL Canonical Material Translation (FO4 is PBR-canonical)
 **Subagent**: `renderer-specialist`
-**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` — the single boundary), `crates/core/src/ecs/components/material.rs` (`Material`, `Material::resolve_pbr`), `byroredux/src/cell_loader.rs` (`pack_bgsm_material_flags`). Spec: `docs/engine/nifal.md`. **See also `/audit-nifal`** for the full canonical-tier audit.
-**Checklist**: `translate_material(mesh, paths, extra_material_flags)` is the **single** site turning a per-game `ImportedMesh` into the canonical `Material` — both the cell-loader REFR-spawn path and the loose-NIF (`scene`) path must route through it, not the old verbatim ~110-line struct literals. **BGSM PBR flag routing**: `effect_shader_flags` is the OR of `pack_effect_shader_flags` + `pack_bgsm_material_flags(mesh)` + caller `extra_material_flags`; verify BGSM-authored FO4 meshes get `BGSM_PBR` (and, where authored, `BGSM_TRANSLUCENCY` / `BGSM_MODEL_SPACE_NORMALS`) set in `cell_loader.rs::pack_bgsm_material_flags` (maps to the shader-side `MAT_FLAG_PBR_BSDF`). **Resolve-once contract**: `Material.metalness` / `Material.roughness` are now plain `f32` (not `Option` + per-draw classify); they are seeded from `mesh.metalness_override` / `mesh.roughness_override` (or `f32::NAN` sentinel for legacy inline-shader content), then `material.resolve_pbr()` fills any NaN from the keyword classifier and clamps (`metalness` 0..1, `roughness` 0.04..1). `resolve_pbr` is idempotent (tests `resolve_pbr_is_idempotent`, `resolve_pbr_preserves_upstream_translator_values` in `material.rs`) — audit any consumer that re-derives roughness at draw-time or re-runs a classifier; that's the regression. Glass is classified **after** `resolve_pbr` (so forced glass roughness wins) via `helpers::classify_glass_into_material`.
+**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` — the single boundary), `crates/core/src/ecs/components/material.rs` (`Material`, `Material::resolve_pbr`), `byroredux/src/cell_loader.rs` (`pack_bgsm_material_flags`, `pack_effect_shader_flags`). Spec: `docs/engine/nifal.md`. **See also `/audit-nifal`.**
+**Checklist**:
+- **Single boundary** — `translate_material(mesh, paths, extra_material_flags)` is the only `ImportedMesh → Material` site; both the cell-loader REFR-spawn path and the loose-NIF `scene` path must route through it, not verbatim struct literals.
+- **BGSM PBR flag routing** — `effect_shader_flags` ORs `pack_effect_shader_flags` + `pack_bgsm_material_flags(mesh)` + caller `extra_material_flags`. Verify BGSM meshes get `BGSM_PBR` (and where authored `BGSM_TRANSLUCENCY` / `BGSM_MODEL_SPACE_NORMALS`) → shader-side `MAT_FLAG_PBR_BSDF`. Tests: `pack_bgsm_material_flags_tests` in `cell_loader.rs`.
+- **Resolve-once contract** — `Material.metalness` / `Material.roughness` are plain `f32` (not `Option` + per-draw classify), seeded from `mesh.metalness_override` / `mesh.roughness_override` (or `f32::NAN` for legacy inline-shader content), then `resolve_pbr()` fills NaN from the classifier and clamps (metalness 0..1, roughness 0.04..1). `resolve_pbr` is idempotent (tests `resolve_pbr_is_idempotent`, `resolve_pbr_preserves_upstream_translator_values`, `resolve_pbr_fills_only_missing_slot` in `material.rs`). Any consumer re-deriving roughness or re-running a classifier at draw-time is the regression.
+- Glass is classified **after** `resolve_pbr` (forced glass roughness wins) via `helpers::classify_glass_into_material`.
 **Output**: `/tmp/audit/fo4/dim_7.md`
 
-### Dimension 8: BGSM / BGEM Consumption Correctness
+### Dimension 8: FO4 Cell Load End-to-End (SCOL/PKIN Expansion)
 **Subagent**: `general-purpose`
-**Entry points**: `crates/bgsm/src/` (`lib`, `base`, `bgsm`, `bgem`, `reader`, `template`), `byroredux/src/asset_provider.rs` (`merge_bgsm_into_mesh`)
-**Checklist**: The BGSM/BGEM parser ships as crate `crates/bgsm/` (package `byroredux-bgsm`) — **not** a stub and **not** living under `crates/plugin/src/esm/records/`. `asset_provider.rs::merge_bgsm_into_mesh` is the actual FO4 material data source: it merges parsed BGSM fields into `ImportedMesh` (albedo/diffuse tint, specular, emissive, smoothness→glossiness/roughness, translucency suite #1147, model-space-normals bit, texture-slot paths) before `translate_material` runs. **smoothness→roughness applied exactly once at parse**: `merge_bgsm_into_mesh` writes `mesh.roughness_override = Some((1.0 - leaf.smoothness).clamp(0.04, 1.0))` (`asset_provider.rs:1079-1081`) and separately normalizes `mesh.glossiness = bgsm.smoothness * 100.0`; verify the `1.0 - smoothness` inversion is NOT re-applied downstream. **Magic-vs-extension reconciliation** (the #758 footgun guard): `merge_bgsm_into_mesh` dispatches the `.bgsm` / `.bgem` / `.mat` arm by file content, and logs when the extension disagrees with the detected magic — audit for any path that trusts the extension blindly. **Cycle-aware template resolve** (#1148): `template.rs::resolve_depth` tracks `visited` lowercase keys and breaks `A→B→A` self-references (vanilla `defaulttemplate_wet.bgsm` self-refs) instead of overflowing — verify the depth-limit / cycle-break still fires.
+**Entry points**: `byroredux/src/cell_loader/refr.rs` (`expand_scol_placements`, `expand_pkin_placements`), `byroredux/src/cell_loader/references.rs` (wires the expanders), `byroredux/src/cell_loader/exterior.rs` (Phase-3a).
+**Checklist**:
+- `expand_scol_placements` / `expand_pkin_placements` turn a prefab/packin into per-instance synthetic REFRs with composed transform (parent × child), recursion bounded by `MAX_PKIN_DEPTH = 4` (shared, #1180 / #1182; vanilla has zero nesting, the cap guards modded cross-recursion). `references.rs` fires the first matching expander and composes placements.
+- Tests: `cell_loader/scol_expansion_tests.rs`, `cell_loader/pkin_expansion_tests.rs`.
+- Precombine spawn (Dim 1) and SCOL/PKIN expansion are independent carriers of the same cell — confirm no double-draw between an expanded SCOL static and a precombine that subsumed it (the `absorbed_refs` gate in Dim 1 is the de-dup mechanism).
 **Output**: `/tmp/audit/fo4/dim_8.md`
 
-### Dimension 9: FO4 Cell Load End-to-End (SCOL/PKIN Expansion + PreCombined Mesh)
+### Dimension 9: Real-Data Validation + Forward Scope
 **Subagent**: `general-purpose`
-**Entry points**: `byroredux/src/cell_loader/refr.rs` (`expand_scol_placements` / `expand_pkin_placements`), `byroredux/src/cell_loader/references.rs` (wires the expanders), `byroredux/src/cell_loader/precombined.rs` (`spawn_precombined_meshes`), `byroredux/src/cell_loader/exterior.rs` (Phase-3a), `crates/plugin/src/esm/cell/mod.rs` (`precombined_mesh_hashes`)
-**Checklist**: **SCOL / PKIN expansion** — `expand_scol_placements` / `expand_pkin_placements` turn a prefab/packin into per-instance synthetic REFRs with composed transform (parent × child), recursion bounded by `MAX_PKIN_DEPTH = 4` (shared by both, #1180 / #1182; vanilla FO4 has zero nesting, the cap guards modded cross-recursion). `references.rs` fires the first matching expander and composes the placements. Tests: `cell_loader/{scol_expansion_tests,pkin_expansion_tests}.rs`. **PreCombined Mesh spawn** — `precombined.rs::spawn_precombined_meshes` loads the `_oc.nif` precombines referenced by `cell.precombined_mesh_hashes` (populated by the CELL walker, parsed in `cell/mod.rs`), for both interior (Phase-3a) and exterior (`exterior.rs`, #1221 / #1222 world-coord transform). **REFR-fallback gate** (#1188): when precombined geometry is NOT rendered, the XPRI-absorbed REFRs (`cell.absorbed_refs`) are honored as the only carrier of that architecture — verify the gate renders the original REFRs when `pc_spawned == 0` and suppresses double-draw when the precombine spawns. CSG companion is still pending; this gate is the honest interim.
+**Entry points**: `crates/nif/tests/parse_real_nifs.rs` (`parse_rate_fallout_4`, `parse_rate_fo4_all_meshes`), `crates/nif/examples/nif_stats.rs`, `ROADMAP.md`, `docs/feature-matrix.md`.
+**Checklist**:
+- Re-run `BYROREDUX_FO4_DATA=… cargo test -p byroredux-nif --test parse_real_nifs -- --ignored fo4` (`parse_rate_fo4_all_meshes` covers both `Fallout4 - Meshes.ba2` + `Fallout4 - MeshesExtra.ba2`) — both archives parse 100.00% clean per #1457. Report the measured number; do not cite the stale ROADMAP figure without re-running.
+- Trace `import_nif_scene` on: a settlement workshop item, a creature (deathclaw / super mutant), a power-armor frame (heavy skinning + BSConnectPoint), a modular weapon (receiver/barrel/stock via BSConnectPoint). For each: mesh count, material_path (BGSM ref or null), skinned vs rigid, connect-point extra-data presence.
+- **Forward scope** (do NOT re-file as blockers): `_precomb.nif` collision, `.uvd` occlusion volumes, MOVS physics runtime, FaceGen NIF truncation tail, deeper cell coverage (LIGH power state / CONT leveled items / NPC_ face morph), `BSBehaviorGraphExtraData` parse-only (verify nothing pretends to drive it). The BGSM parser, SCOL/PKIN expansion, and the M49 CSG pipeline are **all shipped** — never list them as pending.
 **Output**: `/tmp/audit/fo4/dim_9.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/fo4/dim_*.md` files.
-2. Combine into `docs/audits/AUDIT_FO4_<TODAY>.md` with structure:
-   - **Executive Summary** — Current state: NIF + BA2 at 100%, ESM architecture records landed, BGSM parser (`crates/bgsm/`) + SCOL/PKIN expansion + PreCombined-Mesh spawn all landed; PreCombined CSG companion + deeper cell coverage (LIGH/CONT/NPC_) + MOVS physics pending.
-   - **Dimension Findings** — Grouped by severity per dimension.
-   - **BGSM Consumption Table** — BGSM field × merged-into-ImportedMesh-by-`merge_bgsm_into_mesh` / surfaced-on-canonical-`Material` (post-NIFAL).
-   - **Forward Blocker Chain** — What still must land for richer "FO4 interior renders" (PreCombined CSG reader → REFR de-dup → deeper REFR/LIGH/CONT/NPC_ cell coverage → MOVS physics → ...). Do NOT list BGSM-parser or SCOL-expansion as pending; both are shipped.
+1. Read all `/tmp/audit/fo4/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_FO4_<TODAY>.md`:
+   - **Executive Summary** — NIF + BA2 + BGSM parser + SCOL/PKIN expansion + **M49 CSG precombines** all landed; parse rate per the latest `parse_rate_fo4_all_meshes` run. Pending: precombine collision / `.uvd` volumes, MOVS physics, deeper cell coverage (LIGH/CONT/NPC_).
+   - **Dimension Findings** — grouped by severity per dimension.
+   - **BGSM Consumption Table** — BGSM field × merged-into-`ImportedMesh`-by-`merge_bgsm_into_mesh` / surfaced-on-canonical-`Material` (post-NIFAL).
+   - **Forward Scope Chain** — precombine collision / `.uvd` → MOVS physics → deeper REFR/LIGH/CONT/NPC_ coverage. Do NOT list the CSG reader, BGSM parser, or SCOL expansion as pending.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_FO4_<TODAY>.md`

--- a/.claude/commands/audit-incremental/SKILL.md
+++ b/.claude/commands/audit-incremental/SKILL.md
@@ -1,93 +1,190 @@
 ---
 description: "Delta audit — check only recently changed code for regressions and new bugs"
-argument-hint: "--commits <N> --since <date>"
+argument-hint: "[--working] [--commits <N>] [--range <A>..<B>] [--since <date>]"
 ---
 
 # Incremental / Delta Audit
 
-Audit only code that has changed recently. Faster than a full audit, focused on new regressions.
+Audit **only what changed**, not a whole subsystem. The goal is to catch
+*new* bugs and *regressions* introduced by recent work — fast — by routing
+each changed file to the subsystem/per-game audit dimensions that own it
+and applying their checks to the diff alone.
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+This is a meta-audit: it does not define dimensions, it *dispatches* to the
+real audit skills (each lives at `.claude/commands/audit-<NAME>/SKILL.md`).
+Use those for the authoritative checklist of any one area.
 
-## Parameters (from $ARGUMENTS)
+See `.claude/commands/_audit-common.md` for project layout, severity,
+methodology, deduplication, context rules, and the base finding format.
+See `.claude/commands/_audit-severity.md` for the severity scale + special
+rules (the NIFAL / GPU-struct / AS / SSBO rows are the ones a delta most
+often trips).
 
-- `--commits <N>`: Number of recent commits to audit (default: 10)
-- `--since <date>`: Audit changes since this date (e.g., `2026-04-01`). Overrides `--commits`.
+## Step 1: Determine the diff scope
 
-## Step 1: Gather Changed Files
+Pick the narrowest scope that covers the work under review. Default to the
+working tree if nothing is specified.
+
+| Argument | Scope | Diff command |
+|----------|-------|--------------|
+| *(none)* / `--working` | uncommitted work | `git diff HEAD --name-only` (add `--staged`-less; for staged-only use `git diff --staged --name-only`) |
+| `--commits <N>` | last N commits | `git diff "HEAD~<N>..HEAD" --name-only` |
+| `--range <A>..<B>` | explicit revision range | `git diff "<A>..<B>" --name-only` |
+| `--since <date>` | everything since a date | base=`$(git log --since="<date>" --format="%H" \| tail -1)`; then `git diff "${base}^..HEAD" --name-only` |
+
+Then pull the actual hunks for the same scope (swap `--name-only` for
+nothing, or `-U6` for more context) and the commit log:
 
 ```bash
-git log --oneline -10
-git diff HEAD~10..HEAD --name-only
+git diff HEAD~10..HEAD --stat        # changed-file overview (substitute your scope)
+git diff HEAD~10..HEAD               # the hunks you will actually audit
+git log --oneline HEAD~10..HEAD      # commit themes, PR numbers, milestone tags
 ```
 
-If `--since` provided: `git log --since="<date>" --oneline && git diff $(git log --since="<date>" --format="%H" | tail -1)..HEAD --name-only`
+Audit the **diff**, with just enough surrounding context to confirm each
+finding (`_audit-common.md` § Methodology) — do not re-audit untouched code.
 
-## Step 2: Categorize Changes by Risk
+## Step 2: Route each changed file to its audit dimension
 
-| Domain | File Patterns | Risk |
-|--------|--------------|------|
-| **Vulkan/GPU** | `crates/renderer/src/vulkan/**` | HIGH |
-| **NIFAL / Canonical Translation** | `byroredux/src/material_translate.rs` (single `translate_material` boundary), `crates/core/src/ecs/components/material.rs` (`Material.metalness`/`roughness` plain `f32` + `resolve_pbr` / `classify_pbr_keyword`), `crates/nif/src/import/collision.rs` (`Imported*`→`CollisionShape`) | HIGH |
-| **RT / Accel** | `crates/renderer/src/vulkan/acceleration/`, `svgf.rs`, `gbuffer.rs`, `composite.rs` | HIGH |
-| **Volumetrics (M55)** | `crates/renderer/src/vulkan/volumetrics.rs`, `crates/renderer/shaders/volumetric_*.comp` | HIGH |
-| **Bloom (M58)** | `crates/renderer/src/vulkan/bloom.rs`, `crates/renderer/shaders/bloom_*.comp` | HIGH |
-| **Water (M38)** | `crates/renderer/src/vulkan/water.rs`, `crates/renderer/shaders/water.{vert,frag}`, `byroredux/src/systems/water.rs`, `byroredux/src/cell_loader/water.rs` | HIGH |
-| **Shaders** | `crates/renderer/shaders/**` | HIGH |
-| **ECS Core** | `crates/core/src/ecs/**` | HIGH |
-| **NIF Parser** | `crates/nif/src/blocks/**`, `crates/nif/src/import/**` | HIGH |
-| **BSA/Archive** | `crates/bsa/src/**` | HIGH |
-| **SpeedTree** | `crates/spt/src/**`, `byroredux/src/cell_loader/refr.rs` (.spt route) | MEDIUM |
-| **ESM Parser** | `crates/plugin/src/esm/**` (incl. `records/misc/**` post-Session-34 split: water/character/world/ai/magic/effects/equipment) | MEDIUM |
-| **Animation** | `crates/core/src/animation/**`, `crates/nif/src/anim/` (post-Session-35 split: `entry`, `sequence`, `controlled_block`, `transform`, `bspline`, `channel`, `keys`, `coord`, plus `types.rs` and `tests.rs`) | MEDIUM |
-| **Cell Loader** | `byroredux/src/cell_loader/**` (was monolithic `cell_loader.rs` pre-Session-34) | MEDIUM |
-| **Systems** | `byroredux/src/systems/**` (was monolithic `systems.rs` pre-Session-34) + `byroredux/src/render/**` (was monolithic `render.rs` pre-#1115) | MEDIUM |
-| **Scene Setup** | `byroredux/src/scene/**` (was monolithic `scene.rs` pre-Session-34) | MEDIUM |
-| **Main Loop** | `byroredux/src/main.rs`, `byroredux/src/commands.rs` | MEDIUM |
-| **Asset Provider** | `byroredux/src/asset_provider.rs` (sibling-BSA auto-load, AE pipeline-path strip) | MEDIUM |
-| **Audio** | `crates/audio/src/{lib,tests}.rs` | MEDIUM |
-| **SF Material (CDB)** | `crates/sfmaterial/src/**` (Starfield `materialsbeta.cdb` consumer: `chunk`, `reader`, `string_table`, `value`, `types`) | MEDIUM |
-| **Debug UI** | `crates/debug-ui/src/**` (`lib.rs`, `panels.rs` — egui-ash overlay; touches Vulkan, verify `draw_frame` interaction) | MEDIUM |
-| **Physics** | `crates/physics/src/**` (`world`, `convert`, `sync`, `components`, `config`) | MEDIUM |
-| **FaceGen** | `crates/facegen/src/**` (`egm`, `egt`, `tri`, `eval`) | MEDIUM |
-| **BGSM Materials** | `crates/bgsm/src/**` (`bgsm`, `bgem`, `base`, `template`, `reader`) | MEDIUM |
-| **Tests** | `**/tests/**`, `**/*_tests.rs`, `byroredux/tests/golden_frames.rs` | LOW |
-| **Docs** | `*.md`, `docs/**` | LOW |
+Map every changed path to the audit skill(s) that own it, then apply that
+skill's checks to the diff. A file can hit multiple rows (e.g. a shader +
+its `#[repr(C)]` host struct → renderer **and** the GPU-struct-sync rule).
+Risk is the *floor* severity for an un-disproven finding in that area.
 
-## Step 3: Audit Each Changed File
+| Changed path | Owning audit(s) | Risk |
+|--------------|-----------------|------|
+| `crates/renderer/src/vulkan/**` (pipeline, sync, descriptors, context/) | `/audit-renderer`, `/audit-safety`, `/audit-concurrency` | HIGH |
+| `crates/renderer/src/vulkan/acceleration/**`, `svgf.rs`, `gbuffer.rs`, `composite.rs` (RT / denoise / G-buffer) | `/audit-renderer` | HIGH |
+| `crates/renderer/src/vulkan/scene_buffer/**`, `material.rs` (`#[repr(C)]` GPU structs) | `/audit-renderer`, `/audit-nifal` | HIGH |
+| `crates/renderer/src/vulkan/volumetrics.rs` + `shaders/volumetrics_*.comp` (M55) | `/audit-renderer` | HIGH |
+| `crates/renderer/src/vulkan/bloom.rs` + `shaders/bloom_*.comp` (M58) | `/audit-renderer` | HIGH |
+| `crates/renderer/src/vulkan/water.rs`, `shaders/water.vert`/`water.frag`, `byroredux/src/systems/water.rs`, `byroredux/src/cell_loader/water.rs` (M38) | `/audit-renderer`, `/audit-fnv` | HIGH |
+| `crates/renderer/shaders/**` (any `.comp`/`.vert`/`.frag`) | `/audit-renderer` (+ GPU-struct-sync rule) | HIGH |
+| `crates/core/src/ecs/**` | `/audit-ecs`, `/audit-concurrency` | HIGH |
+| `crates/nif/src/blocks/**`, `crates/nif/src/import/**`, `crates/nif/src/anim/**` | `/audit-nif`; per-game `/audit-<game>` | HIGH |
+| `crates/bsa/src/**` (BSA / BA2 / CSG) | `/audit-nif` (archive feed), per-game `/audit-<game>` | HIGH |
+| `byroredux/src/material_translate.rs`, `crates/core/src/ecs/components/material.rs`, `crates/nif/src/import/collision.rs` (NIFAL boundary) | `/audit-nifal` | HIGH |
+| `byroredux/src/env_translate.rs` (EXAL boundary) | `/audit-nifal` (mirror), `/audit-renderer` | MEDIUM |
+| `byroredux/src/ragdoll.rs`, `crates/physics/src/**` (PHYSAL / Rapier bridge) | `/audit-safety`, per-game `/audit-<game>` | MEDIUM |
+| `crates/spt/src/**`, `byroredux/src/cell_loader/refr.rs` (.spt route) | `/audit-speedtree` | MEDIUM |
+| `crates/plugin/src/esm/**` (incl. `records/misc/{water,character,world,ai,magic,effects,equipment}.rs`) | per-game `/audit-<game>`, `/audit-legacy-compat` | MEDIUM |
+| `crates/core/src/animation/**` | `/audit-nif` (anim import), `/audit-ecs` | MEDIUM |
+| `byroredux/src/cell_loader/**` | per-game `/audit-<game>` | MEDIUM |
+| `byroredux/src/systems/**`, `byroredux/src/render/**` | `/audit-ecs`, `/audit-renderer`, `/audit-performance` | MEDIUM |
+| `byroredux/src/scene/**` | per-game `/audit-<game>` | MEDIUM |
+| `byroredux/src/main.rs`, `byroredux/src/commands.rs` | `/audit-ecs` | MEDIUM |
+| `byroredux/src/asset_provider.rs` (sibling-BSA auto-load, AE path strip) | per-game `/audit-<game>` | MEDIUM |
+| `crates/audio/src/{lib,tests}.rs` | `/audit-audio` | MEDIUM |
+| `crates/sfmaterial/src/**` (Starfield CDB) | `/audit-starfield` | MEDIUM |
+| `crates/bgsm/src/**` (FO4+ BGSM/BGEM) | `/audit-fo4`, `/audit-nifal` | MEDIUM |
+| `crates/facegen/src/**` | per-game `/audit-<game>` | MEDIUM |
+| `crates/debug-ui/src/**`, `crates/renderer/src/vulkan/egui_pass.rs` (egui overlay → touches `draw_frame`) | `/audit-renderer`, `/audit-concurrency` | MEDIUM |
+| `crates/papyrus/src/**`, `crates/scripting/src/**` | `/audit-tech-debt` (no dedicated skill) | MEDIUM |
+| `**/tests/**`, `**/*_tests.rs`, `byroredux/tests/golden_frames.rs` | `/audit-regression` | LOW |
+| `*.md`, `docs/**` | `/audit-tech-debt` (doc rot) | LOW |
 
-For each changed file, read the diff and surrounding context. Check:
+> Layout shifts that often surprise a delta audit: `render.rs`,
+> `systems.rs`, `scene.rs`, and `cell_loader.rs` are all directories
+> now (`byroredux/src/render/`, `systems/`, `scene/`, `cell_loader/`),
+> each with a thin `mod.rs` dispatch + topic submodules + `*_tests.rs`
+> siblings. `crates/renderer/src/vulkan/acceleration/` and `scene_buffer/`
+> are likewise split. The authoritative tree is in `_audit-common.md`
+> § Project Layout — route against it, not against memory.
 
-- [ ] **New bugs**: Logic errors, off-by-ones, wrong byte sizes, missing version checks?
-- [ ] **Unsafe changes**: New unsafe blocks? Changed safety invariants? Missing safety comments?
-- [ ] **Lock scope**: Changed RwLock acquisition? New query patterns? Potential deadlocks?
-- [ ] **Vulkan correctness**: New pipeline/barrier/sync changes? Missing validation? RT acceleration structure changes?
-- [ ] **NIF correctness**: New block parsers consume correct byte count? Version conditionals right?
-- [ ] **Tests**: Corresponding test updates? New code paths tested?
-- [ ] **Contract breaks**: Public API changed — did ALL callers update?
-- [ ] **NIFAL boundary contract**: Diff touches `byroredux/src/material_translate.rs` or `Material`'s resolved `f32` fields (`metalness`/`roughness`)? Confirm `resolve_pbr` still runs at the boundary and the fields are never left as `f32::NAN` at draw time — the `Option`→`f32` migration removed the per-draw `classify_pbr_keyword` safety net. Both load paths (`cell_loader` `spawn`, `scene` `nif_loader`) must still route through `translate_material`. See also `/audit-nifal` for the full single-boundary / no-fabrication / no-render-time-fallback audit.
-- [ ] **NIFAL particle/collision chain**: A particle diff spans three risk rows — typed blocks (`crates/nif/src/blocks/particle.rs`: `NiPSysEmitter`/`NiPSysEmitterCtlr`/`NiPSysEmitterCtlrData`/`NiPSysGrowFadeModifier`) → extraction (`crates/nif/src/import/walk/mod.rs`: `extract_emitter_params`/`extract_emitter_rate`) → system (`byroredux/src/systems/particle.rs`: `apply_emitter_params`). Check all three together. Likewise a collision diff adding shapes (`BhkMultiSphereShape`/`BhkConvexListShape` → `CollisionShape` in `crates/nif/src/import/collision.rs`) is a translation surface, not just a parser change.
+## Step 3: Regression-focused checks on each changed file
 
-## Step 4: Rust-Specific Checks
+For every changed file, read the hunk + minimal context and ask:
 
-For Rust files specifically:
-- [ ] **Lifetime changes**: Borrowed references changed scope? Temporary lifetimes?
-- [ ] **Drop ordering**: Vulkan object destruction order still correct?
-- [ ] **Error handling**: New `unwrap()` calls? Changed error propagation?
-- [ ] **Trait impls**: New trait implementations consistent with existing ones?
+- [ ] **New bug** — logic error, off-by-one, wrong byte width, missing
+      version/era gate (B-splines reach FNV/FO3, not just Skyrim+).
+- [ ] **Contract break** — did a public signature change without *all*
+      call sites updating? (`git grep` the symbol across the workspace.)
+- [ ] **Silent divergence** — was a value built at two sites and only one
+      edited? The classic NIFAL leak: the two `Material` load paths.
+- [ ] **Unsafe delta** — new `unsafe` block, changed safety invariant, or
+      a safety comment that no longer matches the body (`_audit-severity`:
+      MEDIUM floor for unsafe-without-comment).
+- [ ] **Lock / query delta** — changed RwLock scope or a new multi-component
+      query? Verify TypeId-sorted acquisition (deadlock → HIGH floor).
+- [ ] **Vulkan delta** — new pipeline/barrier/sync, AS build/refit, or
+      descriptor write? Missing barrier or wrong AS geometry → see the
+      severity special-rules table (HIGH/CRITICAL floors).
+- [ ] **GPU-struct lockstep** — a touched `#[repr(C)]` struct
+      (`GpuInstance`/`GpuCamera`/`GpuMaterial`/`GpuLight`) **and** its
+      mirror in every shader that reads it. Size/offset drift → HIGH.
+- [ ] **Missing test** — a changed code path with no corresponding test
+      update. Flag in the "Missing Tests" section even if the code is right.
 
-## Extra Per-Finding Fields
+### Rust-specific deltas
 
-- **Changed File**: `<file-path>` (commit: `<hash>`)
+- [ ] **Drop ordering** — Vulkan destruction order still reverse of build?
+- [ ] **Error handling** — new `unwrap()`/`expect()` on a recoverable path?
+- [ ] **Lifetimes** — a borrow whose scope changed (temporary outliving / new dangling borrow)?
+- [ ] **Trait impls** — a new impl consistent with the existing family (Component storage decl, Send+Sync)?
+
+### NIFAL boundary delta (when the diff touches the material rows)
+
+The canonical material contract is **resolve-once at the translation
+boundary, no render-time fallback** — so a wrong value there is silently
+wrong across every game.
+
+- `Material::metalness` / `roughness` are plain resolved `f32`
+  (`crates/core/src/ecs/components/material.rs`), not `Option`. They are
+  finalized by `Material::resolve_pbr`, which clamps and — only when the
+  upstream override arrived `NaN` — falls back to `classify_pbr_keyword`
+  (the surviving keyword classifier; it is a sentinel-backstop for
+  non-pre-classified sources, **not** a per-draw safety net).
+- NIF-imported content is pre-classified at import (`classify_legacy_pbr`)
+  so `resolve_pbr` only clamps; BGSM/BGEM also arrive pre-classified.
+  Confirm a diff did not leave either scalar `NaN` at draw time.
+- Both load paths must still route through `translate_material`:
+  `byroredux/src/cell_loader/spawn.rs` (REFR spawn) and
+  `byroredux/src/scene/nif_loader.rs` (loose-NIF). If a diff adds a field
+  to one and not the other, that is the divergence this layer exists to
+  prevent. Defer to `/audit-nifal` for the full single-boundary checklist.
+
+### NIFAL particle / collision chain (multi-file translation surfaces)
+
+These are not single-file changes — a diff to one tier is incomplete
+without the others:
+
+- **Particle emitter:** typed blocks
+  (`crates/nif/src/blocks/particle.rs`: `NiPSysEmitter` /
+  `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier`)
+  → extraction (`crates/nif/src/import/walk/mod.rs`:
+  `extract_emitter_params` / `extract_emitter_rate`) → system
+  (`byroredux/src/systems/particle.rs`: `apply_emitter_params`). Audit all three.
+- **Collision shape:** a new `Bhk*Shape` parser
+  (`crates/nif/src/blocks/collision/`) is also a translation surface —
+  `crates/nif/src/import/collision.rs` must map it to `CollisionShape`,
+  or it is silently dropped (MEDIUM floor; HIGH if it removes visible
+  game content). PHYSAL now consumes ragdoll constraints, so a collision
+  diff can ripple into `byroredux/src/ragdoll.rs` + `crates/physics/`.
+
+## Step 4: Deduplicate
+
+Run the dedup pass from `_audit-common.md` § Deduplication for every
+finding (existing-issue search + prior-report scan) before recording it.
+A regression of a *closed* issue is reported as "Regression of #NNN".
+
+## Extra Per-Finding Field
+
+In addition to the base format in `_audit-common.md`:
+
+- **Changed in**: `<file-path>` (commit `<hash>` / working tree)
 
 ## Output
 
-Write to: **`docs/audits/AUDIT_INCREMENTAL_<TODAY>.md`**
+Write to: **`docs/audits/AUDIT_INCREMENTAL_<TODAY>.md`** (YYYY-MM-DD).
 
-### Report Structure
-1. **Change Summary** — Files changed, commit range, key themes
-2. **High-Risk Changes** — Files in Vulkan/ECS/NIF/shader domains
-3. **Findings** — New bugs, regressions, or gaps
-4. **Missing Tests** — Changed code paths without test updates
+### Report structure
+1. **Change summary** — scope (range/commits/since), files changed, themes.
+2. **Routing map** — each changed file → dimension(s) it was audited under.
+3. **Findings** — new bugs + regressions (base format + `Changed in`).
+4. **Missing tests** — changed code paths with no test update.
 
-Suggest: `/audit-publish docs/audits/AUDIT_INCREMENTAL_<TODAY>.md`
+Then suggest:
+
+```
+/audit-publish docs/audits/AUDIT_INCREMENTAL_<TODAY>.md
+```

--- a/.claude/commands/audit-legacy-compat/SKILL.md
+++ b/.claude/commands/audit-legacy-compat/SKILL.md
@@ -4,132 +4,230 @@ description: "Audit compatibility gaps between Gamebryo 2.3 and Redux — what's
 
 # Legacy Compatibility Audit
 
-Read `_audit-common.md` and `_audit-severity.md` for shared protocol.
+Read `_audit-common.md` and `_audit-severity.md` for shared protocol (project layout,
+game-data + legacy-source locations, severity scale, NIFAL severity rows, dedup, report format).
 
 ## Purpose
 
-Compare the Gamebryo 2.3 architecture against Redux's current implementation.
-Identify gaps that block NIF loading, animation playback, or content rendering.
+Compare per-game Gamebryo 2.3 / Creation-engine behaviour against Redux's current
+implementation and surface **translation/mapping gaps** — content the source engines
+render or simulate that Redux drops, mis-maps, or diverges on.
+
+This is *not* a "does a parser exist" bootstrap audit (it does). The framing is the three
+**canonical-translation abstraction layers** — every per-game quirk must be folded in at
+**one** explicit boundary, with **no** per-game branch, `Option` resolve-later leak, or
+render-time heuristic downstream:
+
+- **NIFAL** — NIF geometry/material/skin/lights/nodes/particles/collision → ECS (`docs/engine/nifal.md`)
+- **EXAL** — ESM exterior environment (terrain/sky/sun/weather/water/LOD) → renderer (`docs/engine/exal.md`)
+- **PHYSAL** — per-game Havok articulation → one solver-agnostic physics spec (`docs/engine/physal.md`)
+
+A gap is either (a) a leak *inside* a layer (a translatable input silently dropped / a
+second producer site / a downstream per-game branch), or (b) a subsystem the layers do not
+yet cover. Both are findings; documented limitations (FO4+ packed Havok, phantoms) are
+**not**. The per-layer specs maintain leak inventories — cross-check against them so closed
+leaks are not re-filed.
+
+Dimensions are ordered by compat-gap blast radius. NIFAL/EXAL/PHYSAL each have a deep
+sibling — **`/audit-nifal`** (and the per-game audits) drill the contents; this audit owns
+the *cross-layer mapping shape* and subsystem coverage.
 
 ## Dimensions
 
-### 1. Scene Graph Decomposition
-- Read `docs/legacy/api-deep-dive.md` mapping table
-- For each NiAVObject field: does the Redux component exist?
-- Missing components needed for NIF import (Parent, Children, WorldTransform, WorldBound, etc.)
+### 1. Coordinate-system correctness (Z-up → Y-up)
 
-### 2. NIF Format Readiness
-- `crates/nif` is mature (the live dispatch arm count is in `crates/nif/src/blocks/mod.rs`); audit
-  coverage *gaps*, not "does a parser exist" — the bootstrap question is answered.
-- Version coverage: which NIF versions decode? Which Gamebryo object types are still NiUnknown-demoted?
-- Link resolution: are cross-references (`BlockRef`) between objects resolved in the post-link phase?
-- Minimum import set still intact (NiNode, NiTriShape, NiTriShapeData) — and the modern packed
-  variants (BSTriShape, `BSGeometry`) that replaced them per game era.
+The most catastrophic mapping bug class: a wrong transform mis-places or mirrors **all**
+content silently. Reference: `docs/engine/coordinate-system.md` (verified against the tree).
 
-### 3. Transform Compatibility
-- Gamebryo: NiTransform = Matrix3 rotation + Point3 translation + float scale
-- Redux: Transform = Quat rotation + Vec3 translation + f32 scale
-- Is there a conversion function (Matrix3 → Quat) for NIF import?
-- Is world transform propagation implemented (local * parent = world)?
+- **Single source of truth**: the `(x, z, -y)` axis swap + quaternion conversions live in
+  `crates/core/src/math/coord.rs` (`zup_to_yup_pos`, `zup_to_yup_quat_wxyz`,
+  `euler_zup_to_quat_yup`, `normalize_quat`, `cell_grid_to_world_yup`). The NIF-typed flavour
+  (`zup_point_to_yup`, `zup_matrix_to_yup_quat`) wraps them in `crates/nif/src/import/coord.rs`.
+  **Regression guard**: any new duplicated `(x, z, -y)` swap or matrix→quat path that
+  bypasses these (the pre-`#1044` five-site duplication, where only one carried the `#333`
+  unit-quaternion fix) is a finding.
+- **REFR Euler convention**: Bethesda CW-positive, **ZYX** product
+  (`Quat::from_rotation_y(-rz) * from_rotation_z(ry) * from_rotation_x(-rx)`). The pre-`#386aabb4`
+  XYZ-product variant only matched on Z-only REFRs and skewed multi-axis architecture. Pins:
+  `euler_multi_axis_matches_openmw_objectpaging` / `euler_zyx_order_pinned_by_rx_then_rz`.
+  REFR placement routes through the `--rotation-mode` A/B dispatcher
+  (`byroredux/src/cell_loader/euler.rs::euler_zup_to_quat_yup_refr`, default mode 1); XCLL
+  lighting calls the canonical helper directly. Flag any caller that hardcodes a mode or
+  re-derives the formula.
+- **Winding**: NIF CW → projection Y-flip (`camera.rs::projection_matrix`) → CCW front face.
+  Strip de-stitch (`tri_shape/ni_tri_shape.rs::to_triangles`) swaps the **last two** verts on
+  odd triangles (CCW). A D3D-style (first-two) swap re-introduces inside-out geometry.
+- **Exterior grid**: `EXTERIOR_CELL_UNITS = 4096.0` + `cell_grid_to_world_yup` are the sole
+  source (`#1112` collapsed six divergent literals, one with a Z-flip sign bug). New literal
+  `4096.0` cell math is a regression.
 
-### 4. Property → Material Mapping
-- Gamebryo has 12 NiProperty types (alpha, texturing, material, zbuffer, etc.)
-- Which map to Vulkan pipeline state vs per-object components?
-- The `Material` component is mature/canonical (`crates/core/src/ecs/components/material.rs`); the live
-  question is no longer "does it exist" but **"is `translate_material` the single boundary that produces
-  it, and is PBR fully resolved?"** — `metalness`/`roughness` are plain `f32` (no `Option` + per-draw
-  `classify_pbr`), filled from NaN sentinels by `Material::resolve_pbr` (clamps roughness to `[0.04, 1.0]`).
-  This is the NIFAL material slice — **see also `/audit-nifal`** and Dimension 8 below.
-- **NiFogProperty is parsed but intentionally not dispatched** (#1224 / D4-NEW-02
-  closeout). Per-node fog override has no landing site on `Material` and the
-  renderer's fog path reads cell-scope `CellLighting` only; observed corpus is
-  1 vanilla FO3 block. Do not re-file as a finding — see `walker.rs` near the
-  end of `extract_material_info` for the deliberate-skip comment.
+### 2. NIFAL — canonical NIF→ECS translation contract
 
-### 5. Animation Readiness
-- Gamebryo: NiTimeController → NiInterpolator → keyframes
-- Redux: any keyframe data structures? Interpolation system?
-- KF/KFM file format: parser exists?
+The Gamebryo→Redux semantic mapping for everything inside a NIF. Audits the *shape* of the
+three-tier model (raw `Imported*` → `translate()` → canonical ECS); **`/audit-nifal`** owns
+the per-slice contents. Reference: `docs/engine/nifal.md` (§1 tiers, §2 per-category leak
+inventory, §3 material reference realisation).
 
-### 6. String Interning Alignment
-- Gamebryo: NiFixedString with GlobalStringTable
-- Redux: StringPool + FixedString
-- Are they semantically equivalent? Any gaps?
+- Each per-category slice (material / geometry / skinning / lights / nodes / particles /
+  collision / animation / shader-flags) has **exactly ONE `translate()` boundary** — no
+  second site re-derives the canonical form.
+- No `Option` "resolve-later" leak downstream of the boundary (the raw tier may be messy;
+  the canonical tier is the source of truth).
+- No per-game `if game == …` branch downstream of the boundary. The renderer/shader side is
+  verified clean (`per-game-translation-survey.md` §1, "zero `if (game == …)`"); leaks live
+  **upstream** in parser/importer/cell-loader — that is where to look.
+- **Cross-check newly-closed leaks against `nifal.md` §2** so audits stop re-filing them
+  (converged: materials, geometry, skinning, lights, animation, shader-flags; triaged/parked:
+  the four `ImportedNode` fields + the passthrough table — those are *bounded known gaps*,
+  not findings).
 
-### 7. NIFAL Canonical-Translation Contract
-The Gamebryo→Redux semantic mapping is now formalised as the NIF Abstraction Layer
-(three tiers: raw `Imported*` → `translate()` → canonical ECS). This dimension audits the
-*shape* of that mapping; the per-slice dimensions below audit the contents.
-- Entry points: `docs/engine/nifal.md` (§1 three-tier model, §2 per-category leak inventory)
-- Checklist:
-  - Each per-category slice (material / geometry / skinning / lights / nodes / particles / collision)
-    has **exactly ONE `translate()` boundary** — no second site re-derives the canonical form.
-  - No `Option` "resolve-later" leaks downstream of the boundary (the canonical tier is the
-    source of truth; the raw `Imported*` tier is allowed to be messy).
-  - No per-game `if game == …` branches downstream of the boundary (per the format-translation memory).
-  - Cross-check newly-closed leaks against `nifal.md` §2 so audits stop re-filing them.
-  - **See also `/audit-nifal`** for the dimension-level checklist of this layer.
+### 3. Material translation boundary (NIFAL reference slice)
 
-### 8. Material Translation Boundary
-- Entry points: `byroredux/src/material_translate.rs::translate_material` (line 65),
-  `crates/core/src/ecs/components/material.rs::resolve_pbr` (line 588), `nifal.md` §3 (reference realisation)
-- Checklist:
-  - `translate_material` is the **sole** `Material` producer — both spawn paths delegate to it
-    (`byroredux/src/cell_loader/spawn.rs:861` and `byroredux/src/scene/nif_loader.rs:808`); no
-    other site constructs a populated `Material`.
-  - `metalness`/`roughness` are resolved `f32` (NaN sentinel filled by `resolve_pbr` via
-    `classify_pbr_keyword`, then clamped) — the pre-canonical `Option`-override + render-time
-    `classify_pbr` regression must NOT reappear (the deleted path is referenced only in comments,
-    e.g. `byroredux/src/render/static_meshes.rs:270`).
-  - Glass / cloth / metal classification happens once at the boundary, alpha-aware — never re-classified per draw.
-  - Canonical material boundary landed in commit `3ce98db8`. **See also `/audit-nifal`.**
+The reference realisation and the highest-blast-radius single boundary (a wrong `Material`
+is silently wrong for **every** game — `Material::metalness`/`roughness` are plain resolved
+`f32`, no per-draw fallback to mask it; hence the HIGH severity floor in `_audit-severity.md`).
 
-### 9. Particle Emitter Translation Parity
-- Entry points: `crates/nif/src/blocks/particle.rs` (`NiPSysEmitter` / `NiPSysEmitterCtlr` /
-  `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` typed blocks),
-  `crates/nif/src/import/walk/mod.rs::extract_emitter_params` (line 670) / `extract_emitter_rate` (line 713),
-  `byroredux/src/systems/particle.rs::apply_emitter_params` (line 29), `nifal.md` §2 (Particles slice)
-- Checklist:
-  - The four `NiPSys*` blocks decode as typed blocks (not the old opaque controller stack);
-    `extract_emitter_*` lift the authored base kinematics + birth rate + GrowFade `base_scale`.
-  - `apply_emitter_params` lets authored params **override** the name-heuristic presets (not the
-    other way round) — the preset is the fallback when authoring is absent.
-  - Flag any new `NiPSys*` block in the legacy 2.3 source not yet typed/translated.
-  - Slice landed across commits `5708b5b9` / `9db60714` / `8f856d35`. **See also `/audit-nifal`.**
+- `byroredux/src/material_translate.rs::translate_material` is the **sole** populated-`Material`
+  producer — both spawn paths delegate (`byroredux/src/cell_loader/spawn.rs` +
+  `byroredux/src/scene/nif_loader.rs`, both calling `material_translate::translate_material`).
+  No other site constructs a populated `Material`.
+- `metalness`/`roughness` are resolved `f32`, filled from a NaN sentinel by
+  `crates/core/src/ecs/components/material.rs::resolve_pbr` (via `classify_pbr_keyword`, then
+  clamped to `[0,1]` / `[0.04,1]`). The deleted `Option`-override + render-time `classify_pbr`
+  path must NOT reappear (it survives only in the explanatory comments in
+  `byroredux/src/render/static_meshes.rs`).
+- Glass / cloth / metal classified **once** at the boundary, alpha-aware
+  (`material_translate::classify_glass_into_material`, after `resolve_pbr` so forced glass
+  roughness wins) — never re-classified per draw.
+- **Emissive (regression guard, do not re-file)**: the three `EmissiveSource` variants
+  (`Material` / `Lighting` / `Effect`, `material.rs::EmissiveSource`) were measured across
+  Oblivion/FNV/Skyrim/FO4 to share a ~1.0 scale (`nifal.md` §4). No normalization is correct;
+  an "unify emissive scale" finding has a false premise.
+- **`NiFogProperty` (regression guard)**: parsed but **intentionally not dispatched**
+  (`#1224` / D4-NEW-02; see the deliberate-skip comment near the end of
+  `crates/nif/src/import/material/walker.rs::extract_material_info`). Per-node fog has no
+  `Material` landing site; the renderer's fog path reads cell-scope `CellLighting` only.
+  Observed corpus is 1 vanilla FO3 block. Do **not** re-file.
 
-### 10. Havok Collision-Shape Coverage Matrix
-- Entry points: `crates/nif/src/import/collision.rs::resolve_shape` (line 261),
-  `crates/nif/src/blocks/collision/` (13 `bhk*Shape` variants), `nifal.md` §2 (Collision slice)
-- Checklist:
-  - Every parsed `bhk*Shape` resolves to a `CollisionShape` — all 13 dispatched variants have a
-    matching `downcast_ref` arm in `resolve_shape`; no silent "unsupported shape" drop (the closed
-    `BhkMultiSphereShape` → `Compound`/`Ball` and `BhkConvexListShape` → `Compound`-of-sub-shapes
-    leaks were exactly that, commit `9c6096aa`).
-  - Document the known limitations as **limitations, not findings**: `BhkNPCollisionObject`
-    (FO4+ Havok-serialised blob, falls back to `cell_loader/spawn.rs::synthesize_static_trimesh`,
-    commit `15016ee0`) and `BhkPCollisionObject` phantoms (need a `TriggerVolume` ECS path).
-  - **See also `/audit-nifal`.**
+### 4. PHYSAL — per-game Havok articulation → solver
 
-### 11. Translation-Source Gaps (CDB + node passthrough)
-Not every canonical input arrives via inline NIF shader properties; some sources sit *before* the
-translate boundary, and some raw fields are deliberately parked with no consumer.
-- Entry points: `crates/sfmaterial/` (Starfield `materialsbeta.cdb` reader), `byroredux/src/asset_provider.rs`
-  (BGSM merge), `nifal.md` §2 (Nodes slice — passthrough triage), §4 (emissive ground-truth)
-- Checklist:
-  - **Starfield material source**: materials originate from the `sfmaterial` CDB (Component Database),
-    NOT inline NIF shader props; they flow through `asset_provider` before `material_translate`. Verify
-    the CDB→canonical path still funnels through the single `translate_material` boundary.
-  - **Emissive scale**: the `EmissiveSource` discriminator (`Material` / `Lighting` / `Effect`,
-    `crates/core/src/ecs/components/material.rs:354`) is a measured no-op (~1.0 shared scale across
-    Oblivion/FNV/Skyrim/FO4 per `nifal.md` §4) — do not re-file an emissive-normalization finding.
-  - **Node passthrough**: `bs_value_node` / `bs_ordered_node` / `tree_bones` / `range_kind` are
-    raw-tier-parked with zero consumers (deferred deliberately, `nifal.md` §2 Nodes table) — record
-    as known-bounded gaps, not findings.
-  - **See also `/audit-nifal`.**
+Ragdoll/physics translation; **double-ended** (per-game source axis + per-solver sink axis).
+The classic-chain slice landed 2026-06-14. Reference: `docs/engine/physal.md` (§1 double-ended,
+§2 tiers, §3 ragdoll reference realisation, §5 per-concern inventory).
+
+- **The per-game seam is ONLY the constraint CInfo decode** — everything else is game-agnostic
+  by construction. Audit that the seam stays that narrow: the two typed decoders
+  (`crates/nif/src/blocks/collision/constraints.rs::RagdollCInfo` / `LimitedHingeCInfo`, with
+  `parse_oblivion` / `parse_fo3` arms) read only the **common subset** (era-only fields like
+  FO3+ motors / `Perp Axis In B1` are decoded-or-zeroed, never reaching canonical). Byte
+  advancement is asserted per era in `crates/nif/src/blocks/collision/bhk_constraint_tests.rs`.
+- **Extract is already game-agnostic**: `crates/nif/src/import/collision.rs::extract_ragdoll`
+  switches on `BhkConstraintData`, never on game; emits `ImportedRagdoll` in Y-up,
+  `havok_scale`-applied units. A `game ==` branch creeping in here is a finding.
+- **One translate, one build**: `byroredux/src/ragdoll.rs::template_from_imported` (bone-name
+  → `EntityId` resolution into `RagdollTemplate`) + `activate_ragdoll` (world-space
+  `RagdollSpec` seed) are the single translate; `crates/physics/src/ragdoll.rs::build_ragdoll`
+  is the single solver boundary (Rapier types appear nowhere else). `RagdollSpec` /
+  `RagdollJointSpec` carry no Rapier in their signatures.
+- **Writeback rides existing skinning**: `byroredux/src/ragdoll.rs::ragdoll_writeback_system`
+  (Stage::Late) copies stepped poses onto bone `GlobalTransform`s — no renderer change. A
+  writeback that touches the render path is out of contract.
+- **Converged games**: Oblivion (NIF ≤ 20.0.0.5) / FO3 / FNV / Skyrim LE/SE all funnel
+  through one `ImportedRagdoll` → one `RagdollSpec` → one Rapier multibody. Skyrim's
+  `havok_scale` ×69.99 is applied via `havok_scale_for(header)`; its version gate is
+  test-pinned but real-data validation is pending — flag any *new* per-game ragdoll branch.
+- **Documented limitations, NOT findings**: FO4 / FO76 / Starfield ragdolls are blocked on the
+  `BhkNPCollisionObject → BhkSystemBinary` blob decoder (multi-day RE project); the Havok
+  cone+2-plane → Rapier per-axis limit mapping is a known approximation; motors are captured
+  but unused (`physal.md` §3 "Known approximation", §5). Do not re-file these.
+
+### 5. EXAL — per-game exterior environment → renderer
+
+Outdoors translation (terrain/sky/sun/weather/water/LOD). The boundary skeleton + WTHR/sky/
+sun/weather/water slices landed; the LOD slice has a first cut + deferred follow-ups.
+Reference: `docs/engine/exal.md` (§2 per-category leak inventory, §3 boundary, §4 GameVariant
+table, §5 LOD, §7 rollout status).
+
+- **Single boundary**: `byroredux/src/env_translate.rs` is the sole exterior-translate site
+  (`default_water_for_worldspace`, `resolve_water_material`, `translate_sky`,
+  `translate_weather`, `translate_exterior_cell_lighting`, and the `procedural_fallback_*`
+  canonical constructors that replaced the old hardcoded-Mojave render-setup block). Both the
+  bulk `--grid` loader and the streaming bootstrap call these — a second `SkyParamsRes` /
+  `WeatherDataRes` / `WaterMaterial` construction site is a finding.
+- **No render-time fallback**: the "no climate/weather" case is an explicit canonical default
+  (`procedural_fallback_*`), not a branch in the render loop. A reintroduced inline hardcoded
+  sky/lighting block is a leak.
+- **GameVariant table (§4)**: per-game exterior quirks route through one `GameKind`-keyed
+  decision (`crates/plugin/src/esm/reader.rs::GameKind`). The water-default decision in
+  `env_translate::default_water_for_worldspace` is the prototype/only current exterior branch;
+  scattered new `if game == …` exterior logic is a finding. (DALC/XCLL-tail/XCWT quirks live
+  correctly in the parser tier or as canonical `Option` sentinels — not leaks.)
+- **Canonical `Option` sentinels are not leaks**: `WeatherDataRes::skyrim_dalc_per_tod` =
+  `None` on FNV/FO3/Oblivion, `default_water_height` = `None`, encode real game distinctions.
+- **LOD — the largest open gap**: distant **object** LOD has a first cut (Skyrim/FO4 baked
+  `.bto` quads via `byroredux/src/cell_loader/object_lod.rs::stream_object_lod_blocks`,
+  spawned as `IsLodTerrain`, live-verified on Tamriel). Distant terrain still uses heightmap
+  synthesis (`cell_loader/terrain_lod.rs`), **not** the prebaked `.btr`. The
+  Oblivion/FO3/FNV placement scheme (`DistantLOD\*.lod` → `_far.nif`) is **unimplemented**.
+  Per `exal.md` §5.4: runtime LOD is asset-driven — neither NIF LOD nodes nor STAT `MNAM`
+  unblock it; the **VWD / "Has Distant LOD" record-header flag** (to cull full models) is the
+  small parser gap. Findings here are real coverage gaps, not premise errors.
+- **Sun model (regression guard)**: the canonical sun inputs are `tod_hours` +
+  `weather::SUN_SOUTH_TILT` (engine-defined; `exal.md` §9 Q1 verified **no** authored
+  latitude field exists in CLMT/WRLD — `#1019`'s "read a latitude field" premise is false).
+  An "implement worldspace latitude parsing" finding is a false premise.
+
+### 6. Per-game translation-survey gaps (upstream branches)
+
+The structural inventory of where the abstraction is still incomplete. Reference:
+`docs/engine/per-game-translation-survey.md` (§4 findings by layer, §5 cross-cutting
+patterns, §7 "why Fallout is worse than Skyrim").
+
+- **The renderer is clean; the gaps are upstream** — parser/importer/cell-loader carry the
+  per-game branches. Audit by the survey's three leak patterns:
+  - **Pattern A** — hardcoded BSVER constants where a named helper already exists but call
+    sites bypass it (`per-game-translation-survey.md` §5 Pattern A).
+  - **Pattern B** — feature-flag-on-an-enum where the wire format already discriminates the
+    game (the correct shape; flag mis-dispatch, not "needs a trait").
+  - **Pattern C** — variant-enum struct shapes for divergent records.
+- **Fallout is the stress case** (§7): widest BSVER span (FO3 24 → FO76 155), format-breaking
+  changes at every major version; FO-only paths (BGSM, `bhkNPCollisionObject`, CRC32 shader
+  flags, half-float verts, inline tangents) are where silent wrong-default fallbacks cluster.
+  Use the per-game audits (`/audit-fnv`, `/audit-fo3`, `/audit-fo4`, `/audit-oblivion`,
+  `/audit-skyrim`, `/audit-starfield`) for depth; this dimension owns the cross-game pattern.
+
+### 7. Subsystem coverage vs legacy (gaps with no layer yet)
+
+Subsystems the legacy engine drives that Redux maps incompletely or not at all. Cross-check
+the legacy headers (`SDK/Win32/Include/`, `CoreLibs/Ni*/`) against the Redux side.
+
+- **Scene-graph decomposition** (`docs/legacy/api-deep-dive.md` mapping table): each
+  `NiAVObject` field → does the Redux ECS component exist? (Parent, Children, GlobalTransform,
+  WorldBound, Name, flags — the import-critical set is present; audit *fidelity* gaps, not
+  existence.)
+- **Transform model**: Gamebryo `NiTransform` (Matrix3 + Point3 + scale) → Redux `Transform`
+  (Quat + Vec3 + f32). Matrix3→Quat at import (Shepperd + SVD repair), world propagation
+  (`local * parent`) — covered by Dimension 1; flag fidelity gaps (non-uniform scale is
+  collapsed to uniform `f32`).
+- **Property → pipeline mapping**: the 12 `NiProperty` types — which map to dynamic pipeline
+  state (cull mode, blend, stencil two-sided) vs `Material`/per-object components? Flag any
+  property whose authored effect is dropped (NiFogProperty is a *documented* skip — D3 above).
+- **Animation model**: `NiTimeController` → `NiInterpolator` → keys, converged at import
+  (`nifal.md` §"Animation"; B-spline/Euler/TBC all resolved to quaternion keys, KF + embedded
+  through `anim_convert::convert_nif_clip`). Parked: per-light ambient + morph-weight channels.
+- **String interning**: Gamebryo `NiFixedString` + `GlobalStringTable` vs Redux `StringPool` +
+  `FixedString` — semantic equivalence; flag any interning gap that breaks bone-name → entity
+  resolution (load-bearing for skinning and PHYSAL bone binding).
 
 ## Process
 
-1. Read Redux component implementations in `crates/core/src/ecs/components/`
-2. Cross-reference against Gamebryo headers in the legacy source
-3. For each gap: classify as CRITICAL (blocks NIF loading), HIGH (blocks rendering), MEDIUM (blocks full fidelity), LOW (cosmetic)
-4. Save report to `docs/audits/AUDIT_LEGACY_COMPAT_<TODAY>.md`
+1. Read the live spec for the layer under audit (`nifal.md` / `exal.md` / `physal.md`) — its
+   leak inventory is the baseline; do not re-file what it already records as closed/limitation.
+2. Trace each claimed boundary to its callers (grep the symbol) — confirm single-producer.
+3. Cross-reference Redux components/translate sites against the legacy headers + the
+   per-game-translation-survey for upstream branches.
+4. Classify per `_audit-severity.md` (NIFAL/translation rows: wrong/divergent canonical out of
+   a `translate()` = HIGH; translatable block silently dropped = MEDIUM, escalate if it removes
+   visible content). Disprove each finding before keeping it.
+5. Finalize per `_audit-common.md` "Report Finalization" (save to
+   `docs/audits/AUDIT_LEGACY_COMPAT_<TODAY>.md`; do not open issues directly).

--- a/.claude/commands/audit-nif/SKILL.md
+++ b/.claude/commands/audit-nif/SKILL.md
@@ -1,116 +1,134 @@
 ---
-description: "Deep audit of NIF parser — block correctness, version handling, stream position, coverage"
-argument-hint: "--focus <dimensions> --game <fnv|skyrim|oblivion|fo4> --corpus <path>"
+description: "Deep audit of NIF parser — stream position, version gating, block dispatch coverage, geometry handoff"
+argument-hint: "--focus <dimensions> --game <fnv|fo3|skyrim|oblivion|fo4|fo76|starfield> --corpus <path>"
 ---
 
 # NIF Parser Audit
 
-Deep audit of the NIF binary format parser for correctness across all game versions. Tests against real game data when available.
+Deep audit of the NIF binary-format parser (`crates/nif/src/`) for byte-accurate
+correctness across the Oblivion → Starfield version span. Tests against real game
+data when a corpus is available.
+
+The recurring NIF failure mode is **stream-position drift**: a block over-reads
+or under-reads its payload, the consumed-byte count diverges from the header
+`block_sizes` entry, and either the `block_size` reconciliation masks it (parse
+"succeeds" with silent corruption) or — on Oblivion-era files that ship *no*
+`block_sizes` table — every following block is misaligned and the scene
+truncates. Dimensions below are ordered by that risk.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout (its NIF Blocks / NIF
+Import / NIF Animation lines map the full `crates/nif/src/` tree), game-data
+locations, methodology, deduplication, severity, context rules, path-reference
+convention, and the base finding format. Do not duplicate any of that here.
+
+`docs/engine/nif-parser.md` is the code-verified reference for this domain
+(module map, parse pipeline, version-handling thresholds, per-game coverage
+matrix, per-block recovery). Prefer it over re-deriving facts from source.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 7.
-- `--game <name>`: Focus on specific game variant: `fnv`, `fo3`, `skyrim`, `oblivion`, `fo4`, `fo76`, `starfield`. Default: all detected.
-- `--corpus <path>`: Path to a directory of extracted NIF files for bulk testing.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g. `1,2`). Default: all 6.
+- `--game <name>`: Restrict to one variant: `fnv`, `fo3`, `skyrim`, `oblivion`, `fo4`, `fo76`, `starfield`. Default: all detected.
+- `--corpus <path>`: Directory of extracted `.nif` files for bulk testing.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: Block Parsing | Version Handling | Stream Position | Import Pipeline | Coverage | Stream Allocation | NIFAL Translation
-- **Game Affected**: Which NifVariant(s) are affected
+- **Dimension**: Stream Position | Version Gating | Block Dispatch Coverage | Geometry Handoff | Collision/Shader Parsing | Allocation Hygiene
+- **Game Affected**: Which `NifVariant`(s) the finding applies to (cite the `bsver` band)
 
 ## Phase 1: Setup
 
-1. Parse `$ARGUMENTS`
-2. `mkdir -p /tmp/audit/nif`
-3. Fetch dedup baseline
-4. Check which game data directories exist (from `_audit-common.md` game data locations)
+1. Parse `$ARGUMENTS`.
+2. `mkdir -p /tmp/audit/nif`.
+3. Fetch the dedup baseline (see `_audit-common.md` → Deduplication).
+4. Check which game-data directories exist (`_audit-common.md` → Game Data Locations).
+5. Skim `docs/engine/nif-parser.md` § "Per-game NIF coverage" so you measure
+   findings against the current clean/recoverable rates rather than re-counting.
 
 ## Phase 2: Launch Dimension Agents
 
-### Dimension 1: Block Parsing Correctness
-**Entry points**: `crates/nif/src/blocks/*.rs` (all block parsers)
-**Checklist**: Every field read matches nif.xml spec (compare struct fields vs nif.xml `<add>` elements), NiObjectNETData.parse() called correctly by all blocks, NiAVObjectData.parse() vs parse_no_properties() used correctly, BSShaderPropertyData.parse_fo3() used by FO3-era shaders only, block_size adjustment warnings (compile list from real NIF files if corpus available), boolean type correctness (read_bool vs read_byte_bool per nif.xml type annotation).
-**2026-05-04/05 architectural pins (regression guards)**:
-- **`NiLodTriShape`** (#838 SK-D5-NEW-07): inherits from `NiTriBasedGeom`, NOT from `BSTriShape`. nif.xml is authoritative. Routing it through `BSTriShape` produces a 23-byte over-read on every Skyrim tree LOD. The wrapper layout is `NiTriShape + 3 LOD-size u32s`. If the dispatch in `blocks/mod.rs` reverts to BSTriShape, Skyrim Meshes0 sweep loses its `100.00% / 0 truncated / 0 recovered / 0 realignment WARN` baseline
-- **`BsLagBoneController`** + **`BsProceduralLightningController`** (#837 SK-D5-NEW-03): both have dedicated parsers. Without them, ~120 by-design `block_size` WARN events fire per Skyrim Meshes0 sweep
-- **BSTriShape `data_size` warning** (#836 SK-D5-NEW-02): gated on `num_vertices != 0`. Removing the gate fires 67 false-positive WARNs/parse on the SSE skinned-body reconstruction path
-- **`DecalData`** (#813 / #814): FO4 TXST `DODT` sub-record + `DNAM` flags must be parsed; without them, 207/382 (DODT) and 382/382 (DNAM) vanilla TXSTs silently drop their authoring
-- **FO4+ BSTriShape inline tangents** (#795 / #796, b63ab0c): when `VF_TANGENTS | VF_NORMALS` are both set, tangents ship inline in the packed-vertex blob (NOT in a separate `NiBinaryExtraData`). Distinct from the Skyrim path; FO4 inline decode lives in `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (Session 35 split — was `tri_shape.rs`), in the `BSTriShape` packed-vertex loop (`for _ in 0..num_vertices`, ~line 435). The Bethesda authored-blob path (Oblivion / FO3 / FNV) reads from `NiBinaryExtraData` named `"Tangent space (binormal & tangent vectors)"` and MUST honor the `[tangents..., bitangents...]` swap (`tangents` field actually holds ∂P/∂V — see #786 / 5dde345)
-**2026-05-28 typed-particle pin (regression guard)**:
-- **Typed particle decode** (5708b5b9 / 9db60714 / 8f856d35): `NiPSysEmitter`, `NiPSysEmitterCtlr`, `NiPSysEmitterCtlrData`, `NiPSysGrowFadeModifier` are now TYPED structs in `crates/nif/src/blocks/particle.rs` (was opaque NiPSysBlock). Their authored params flow `extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs`) → `apply_emitter_params` (`byroredux/src/systems/particle.rs`, re-exported as `crate::systems::apply_emitter_params`). Regression patterns: reverting to an opaque block, or dropping the authored birth-rate (`NiPSysEmitterCtlr`) / base-scale (`NiPSysGrowFadeModifier`) so the runtime falls back to a hardcoded preset. Verify the typed structs still carry the on-disk fields and that `apply_emitter_params` overrides the preset kinematics + size (not color). See `/audit-nifal` for the canonical-translation side of authored-param resolution.
+### Dimension 1: Stream Position Integrity (PRIMARY)
+**Entry points**: `crates/nif/src/lib.rs` (`parse_nif` → `parse_nif_with_options` block loop, `parse_block_with_name_arc` calls), `crates/nif/src/stream.rs` (`position`, `skip`, the `read_*` cursor primitives), every block parser's `parse()`.
+**Checklist**:
+- Each block consumes exactly its `block_sizes` entry when one exists. The loop in `lib.rs` already diffs consumed-vs-`block_size` and logs both the over-read (recovers by seeking to expected end) and the under-read ("parsed Ok but consumed != block_size") paths — a finding here is a *block whose drift the reconciliation is silently absorbing*, not the reconciliation itself.
+- Oblivion-era files (NIF v20.0.0.4/5 and the v10.x NetImmerse family) ship **no** `block_sizes` table (`header.block_sizes.is_empty()` → `no_block_sizes` branch). There is no per-block recovery anchor — one wrong field cascades. Audit these parsers for unconditional reads that assume a later-game layout.
+- No read may exceed the block boundary unconditionally; version-gated trailing fields (see Dim 2) must be guarded, not always-read.
+- Boolean width correctness: `read_bool` (version-dependent 1-or-4-byte, see `stream.rs:203` + `read_bool_version_dependent` test) vs `read_byte_bool` (always 1 byte) must match the nif.xml type annotation per field. A phantom or missing bool is the classic 1-/3-byte drift (cf. the resolved `NiTriStripsData`/`NiTriShapeData` v10.0.1.x phantom-bool and `NiGeomMorpherController` phantom-weight cases — keep them from regressing).
+- `BSShaderPropertyData::parse_fo3` (`crates/nif/src/blocks/base.rs`) is the shared FO3-era shader prelude — confirm only FO3/FNV-era shaders call it and that it returns the `(Self, texture_clamp_mode)` byte-for-byte.
+**If corpus available**: parse every NIF and report consumed-vs-`block_size` mismatches grouped by block type with frequency counts; flag any non-zero count on a *known* block type (drift), and separately any `no_block_sizes` truncation.
+**Regression guards** (resolved drift — verify still fixed, do not re-report):
+- **Oblivion v10.x truncation family**: `#1509` (`NiGeomMorpherController` bsver=9 over-read on v10.2 morph rigs), the v10.1.0.x `NiBlendInterpolator` bands + `ControlledBlock` blend fields, v10.x `NiPSysData` + emitter trailing fields, `#1337` (full v10.0.1.x format), `#1329` (v10.0.1.0 Havok chain), `#1310`/`#1301`/`#1302` (`NiTriStripsData`/`NiTriShapeData`/`NiGeomMorpherController` phantom bool/weight). Method of record: extract → `trace_block` → byte-decode the stride drift (see memory "NIF v10.x stride drift resolved").
+- **Starfield `BSLightingShaderProperty` over-read** (`#1510`): drove 1036 `NiUnknown` → 0. Regression = a Starfield (`bsver >= FO76 = 155`) shader reading the FO4 field tail.
+- **Root-NiNode / inline-type-name truncation** (`#688` / `#698`): truncate on inline type-name read failure (`#698`) rather than hard-`Err`; `#688` refuted the "v=20.0.0.5" framing — keep the recovery semantics.
 **Output**: `/tmp/audit/nif/dim_1.md`
 
-### Dimension 2: Version Handling
-**Entry points**: `crates/nif/src/version.rs`, all `stream.variant()` and `stream.version()` calls in block parsers
-**Checklist**: NifVariant::detect() covers all known user_version/user_version_2 combinations, feature flags match nif.xml version conditions (has_properties_list, has_shader_alpha_refs, etc.), bsver() return values are correct, version comparisons use correct operators (>= vs >, < vs <=), Oblivion v20.0.0.5 handling (no block sizes, u16 flags, inline strings).
-**2026-05-28 NifVariant-helper pin (regression guard)**:
-- **NifVariant feature-flag helper canonicalization** (#1277 Task 5, 2bd447d5): variant-aligned raw `bsver` literal comparisons were migrated to named `NifVariant` helpers in `crates/nif/src/version.rs` — `has_dedicated_shader_refs`, `uses_bs_lighting_shader`, `has_shader_alpha_refs`, `uses_fo4_shader_flags`, `has_dynamic_effect_fields` (verify exact set against `version.rs`). These helpers are now the canonical version-band surface; a new block parser that hardcodes a raw `bsver < N` literal for a feature already covered by a helper is the regression. Cross-link the Dim 6 #1239/#1240 version-gate pins (NiPSysEmitter / NiTextureEffect) — those gate on the same BSVER bands and should route through the helper surface too. Note also the **`ShaderFlags` typed variant view** (#1277 Task 6, 525a2262, `crates/nif/src/shader_flags.rs`) that wraps the FO3/FNV `BSShaderFlags`+`BSShaderFlags2` u32 pair vs the Skyrim+ single-word storage.
+### Dimension 2: Version Gating
+**Entry points**: `crates/nif/src/version.rs` (`NifVersion` constants, `NifVariant::detect`, `bsver()`, the feature-flag helper methods), `crates/nif/src/shader_flags.rs` (`ShaderFlags` typed view), all `stream.variant()` / `stream.version()` call sites in block parsers.
+**Checklist**:
+- `NifVariant::detect` covers every known `(version, user_version, user_version_2)` combination (cross-check the `detect_*` unit tests in `version.rs` against the seven shipping games + the FO3-dev edge case).
+- Feature presence routes through the **named helper surface** on `NifVariant`, not raw `bsver < N` literals. The canonical helpers (verify the live set in `version.rs`) include `has_dedicated_shader_refs`, `uses_bs_lighting_shader`, `has_shader_alpha_refs`, `uses_fo4_shader_flags`, `uses_fo76_shader_flags`, `has_dynamic_effect_fields`, `has_properties_list`, `has_effects_list`, `has_culling_mode`, `uses_bs_tri_shape`, `has_legacy_binary_extra_data`, plus the v10.x-era `has_quat_transform_trs_valid` / `has_interp_controller_manager_controlled` / `uses_old_rigid_body_layout`. **A new parser that hardcodes a raw `bsver` literal for a feature a helper already covers is the regression.** New gates should add a helper, not a literal.
+- `bsver` band thresholds are named constants in `version.rs` (`OBLIVION = 11`, `FO3_FNV = 34`, `RIGID_BODY_FLAGS16 = 76`, `SKYRIM_LE = 83`, `SKYRIM_SE = 100`, `FALLOUT4 = 130`, `FO4_DLC_UPPER = 140`, `FO76 = 155`, `STARFIELD = 172`, …). Confirm comparisons use the right operator and the right constant (off-by-one band membership is a silent cross-game corruptor).
+- `ShaderFlags` (`shader_flags.rs`) wraps the FO3/FNV `BSShaderFlags`+`BSShaderFlags2` u32 *pair* vs the Skyrim+ single-word storage — verify each game reads its own storage shape.
+- Oblivion v20.0.0.5 specifics: no block sizes (→ Dim 1), u16 flags below `FLAGS_U32_THRESHOLD = 26`, inline strings (no string table below `STRING_TABLE_THRESHOLD`).
+**Regression guards**:
+- **Per-game `NiPSysEmitter` / `NiTextureEffect` version gating** (`#1239` / `#1240`): `NiPSysEmitter` routes through the nif.xml version gate so Oblivion (`bsver < 26`) parses correctly; `NiTextureEffect`'s embedded `NiDynamicEffect` base is gated `bsver < FALLOUT4` (FO4+ removed it). Regression = a parser hardcoding one layout without a band check.
 **Output**: `/tmp/audit/nif/dim_2.md`
 
-### Dimension 3: Stream Position Integrity
-**Entry points**: `crates/nif/src/lib.rs` (parse_nif block loop), all block parsers
-**Checklist**: Every parsed block consumes exactly block_size bytes (when known), no unconditional reads that may exceed block boundaries, skip logic for unknown blocks works correctly, SVD decomposition doesn't read extra bytes, NiTexturingProperty consistent 1-byte shortfall (known issue — diagnose root cause).
-**If corpus available**: Parse all NIFs in corpus and report stream position mismatches by block type with frequency counts.
+### Dimension 3: Block Dispatch Coverage
+**Entry points**: `crates/nif/src/blocks/mod.rs` (`parse_block` / `parse_block_with_name_arc` + the `impl_ni_object!` macro that *generates* the dispatch arms), the test-infra baselines.
+**Checklist**:
+- The dispatch is macro-generated — count live arms by counting `impl_ni_object!` registrations in `blocks/mod.rs` (do **not** quote a stale number; if you need a figure, count it fresh or cite `docs/engine/nif-parser.md` § "Block coverage").
+- From a corpus or BSA/BA2 listing, enumerate block-type names that appear in real NIFs but fall through to the `NiUnknown` placeholder. Count `NiUnknown` fallbacks per game and flag any that cascade (a missing block with no `block_sizes` anchor in Oblivion truncates the rest of the scene — link Dim 1).
+- A block that *parses but is silently dropped downstream* is a Dim 4/5 finding, not a coverage gap — keep the boundary clean.
+**Test-infra signal** (extend, don't reinvent):
+- `crates/nif/tests/per_block_baselines.rs` (opt-in `--ignored`, needs `nif_stats --tsv` + game data) compares per-type `parsed` vs `unknown` against checked-in 7-game TSV baselines and fails on `unknown` growth / `parsed` shrinkage. `crates/nif/tests/block_coverage_baselines.rs` is the sibling coverage surface. `BYROREDUX_REGEN_BASELINES=1` regenerates after an intentional change. New coverage findings should land as a baseline-test extension. Note from memory: FO76 can sit silently RED on `NiPSysBlock`, and `#BS_F76# == 155` while Starfield ≠ FO76 (different shader tail) — keep the two apart.
 **Output**: `/tmp/audit/nif/dim_3.md`
 
-### Dimension 4: Import Pipeline Correctness
-**Entry points**: `crates/nif/src/import/mod.rs` (thin dispatch — `import_nif`, `import_nif_scene`), `crates/nif/src/import/types.rs` (ImportedNode / ImportedMesh / ImportedScene types, post-Session-34 split), `crates/nif/src/import/tests.rs`, `crates/nif/src/import/walk/` (walk_node_hierarchical, walk_node_flat), `crates/nif/src/import/mesh/` (Session 35 split: `ni_tri_shape::extract_mesh`, `bs_tri_shape::extract_bs_tri_shape`, `bs_geometry::extract_bs_geometry`, `tangent::synthesize_tangents`, `sse_recon::try_reconstruct_sse_geometry`, `material_path::material_path_from_name`, `decode::*`, `skin::extract_skin_*`; in-directory test siblings: `bs_tri_shape_shader_flag_tests`, `bs_tri_shape_partition_remap_tests`, `material_path_capture_tests`, `shader_type_fields_tests`, `skin_tests`, `sse_skin_geometry_reconstruction_tests`, `tangent_convention_tests`), `crates/nif/src/import/material/` (walker.rs `extract_material_info` / `extract_material_info_from_refs` — the texture/material resolution entry; mod.rs flag helpers `is_decal_from_legacy_shader_flags` / `is_decal_from_modern_shader_flags` / `is_two_sided_from_modern_shader_flags` / `apply_alpha_flags`; shader_data.rs; *_tests.rs siblings), `crates/nif/src/import/transform.rs`, `crates/nif/src/import/coord.rs`, `crates/nif/src/import/collision.rs`
-**Checklist**: All NiAVObject fields accessed via `.av.*` (no stale field access), shader property lookup covers all shader types for each game variant, texture path resolution works for NiTexturingProperty (Oblivion), BSShaderPPLightingProperty (FO3/FNV), BSLightingShaderProperty (Skyrim), BSEffectShaderProperty (Skyrim+), coordinate conversion (Z-up to Y-up) applied consistently, decal flag detection covers all shader flag bit positions per game.
-**2026-05-28 collision-translation pins (regression guards)**:
-- **Collision-shape translation completeness** (9c6096aa): `crates/nif/src/import/collision.rs::extract_collision` MUST translate `BhkMultiSphereShape` + `BhkConvexListShape` to `CollisionShape` (they were silently dropped before this fix — verify the `downcast_ref::<BhkMultiSphereShape>()` / `downcast_ref::<BhkConvexListShape>()` arms are still present). Regression = a future collision shape that parses but never reaches `extract_collision`.
-- **Per-variant collision dispatch** (#1277 Task 1, 8d3a6861): `examine_collision_kind(scene, collision_ref) -> CollisionAuthoring` classifies the authoring before `extract_collision` runs. The `CollisionAuthoring` enum (in `collision.rs`) must distinguish `None` / `Classic` / `NewPhysicsStub` / `Phantom` / `Unrecognised` (note British spelling). Regression = collapsing the discriminator so Skyrim+ phantoms (`BhkPCollisionObject` wrapping `bhkPhantom`) get force-translated as rigid bodies instead of routed to a future TriggerVolume path. See `/audit-nifal` for the canonical-Material side of per-variant translation dispatch.
+### Dimension 4: Geometry Extraction & Import Handoff
+**Entry points**: `crates/nif/src/import/mod.rs` (thin dispatch — `import_nif`, `import_nif_scene`), `crates/nif/src/import/types.rs` (`ImportedNode` / `ImportedMesh` / `ImportedScene`), `crates/nif/src/import/walk/mod.rs` (`walk_node_hierarchical` / `walk_node_flat`; also `extract_emitter_params` / `extract_emitter_rate`), `crates/nif/src/import/mesh/` (`ni_tri_shape`, `bs_tri_shape`, `bs_geometry`, `tangent`, `sse_recon`, `skin`, `material_path`, `decode`), `crates/nif/src/import/material/walker.rs` (`extract_material_info` / `extract_material_info_from_refs`) + `import/material/mod.rs` flag helpers, `crates/nif/src/import/transform.rs`, `crates/nif/src/import/coord.rs`.
+**Checklist** (this is the *parse → ECS* handoff; per-game **material** classification lives at the `material_translate.rs` boundary — audit that under `/audit-nifal`, not here):
+- All `NiAVObject` fields accessed via the `.av.*` sub-struct (no stale flat-field access after the split).
+- Per-game geometry path selected correctly: classic `NiTriShape` (Oblivion/FO3/FNV) vs Skyrim SE+ packed-half `BSTriShape` vs Starfield `BSGeometry` (`bsver 155`). Each decodes its own vertex stride and index format.
+- Tangent handoff: FO4+ `BSTriShape` ships tangents **inline** in the packed-vertex blob when `VF_TANGENTS | VF_NORMALS` are both set (decoded in `import/mesh/bs_tri_shape.rs`); the Bethesda authored-blob path (Oblivion/FO3/FNV) reads `NiBinaryExtraData` named `"Tangent space (binormal & tangent vectors)"` and MUST honor the `[tangents…, bitangents…]` swap (the `tangents` field actually holds ∂P/∂V — `#786`); content with neither uses `tangent::synthesize_tangents` (Mikkelsen). Distinct paths — don't cross-wire them.
+- SSE skinned-geometry reconstruction (`sse_recon::try_reconstruct_sse_geometry`) and skin extraction (`skin::*`, partition-local → global bone remap) consume the right counts.
+- Coordinate conversion (Z-up Gamebryo → Y-up renderer, `coord.rs`) applied consistently to positions, normals, and rotations.
+**Regression guards**:
+- **Typed particle decode**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are TYPED structs in `crates/nif/src/blocks/particle.rs` (formerly opaque `NiPSysBlock`). Their params flow `extract_emitter_params` / `extract_emitter_rate` (`import/walk/mod.rs`) → `apply_emitter_params` (`byroredux/src/systems/particle.rs`). Regression = reverting to an opaque block, or dropping the authored birth-rate / base-scale so the runtime falls back to a hardcoded preset. `apply_emitter_params` overrides kinematics + size, *not* color (see its unit tests).
+- **Geometry bulk-read fast paths** (perf, but also a correctness handoff): `BSGeometry` extracts via the `read_pod_vec` fast path; `NiTriShape` tangent extraction uses `std::mem::take` on the `Vec<f32>` to avoid a per-mesh clone (`#1263`/`#1265`). Regression = a re-introduced `Vec::with_capacity` + per-vertex loop, or a clone instead of `mem::take`.
 **Output**: `/tmp/audit/nif/dim_4.md`
 
-### Dimension 5: Coverage Gaps
-**Entry points**: `crates/nif/src/blocks/mod.rs` (parse_block dispatch), `docs/legacy/nif.xml`
-**Checklist**: List all block type names that appear in real game NIFs (from corpus or BSA listing) but are not in the parse_block dispatch table, count NiUnknown fallbacks per game, identify which missing block types cause cascading failures (blocks without block_size in Oblivion format), estimate coverage percentage per game.
-**2026-05-28 translation-coverage pin (test-infra signal)**:
-- **Per-game translation-completeness harness** (#1277 epic): `crates/nif/tests/translation_completeness.rs::cross_game_translation_completeness` is the per-game material-translation coverage regression surface — parallel to how `crates/nif/tests/heap_allocation_bounds.rs` (#1247) guards allocation count for Dim 6. Parse-block coverage (this dimension) measures whether a block *parses*; the completeness harness measures whether a parsed block *translates* to a canonical `Material`. Future translation-coverage findings should extend this test rather than add an ad-hoc check. See `/audit-nifal` for the translation-tier audit this harness anchors.
+### Dimension 5: Collision & Shader Block Parsing
+**Entry points**: `crates/nif/src/blocks/collision/` (`collision_object`, `rigid_body`, `ragdoll`, `shape_primitive`, `shape_compound`, `shape_mesh`, `compressed_mesh`, `constraints`, `phantom_action`), `crates/nif/src/blocks/shader.rs`, `crates/nif/src/import/collision.rs` (`extract_collision`, `examine_collision_kind`).
+**Checklist**:
+- **`bhk*` field-for-field**: rigid-body flag width changes across the band (`uses_old_rigid_body_layout`, `RIGID_BODY_FLAGS16 = 76`, `RIGID_BODY_EXTRA_FLOATS = 9`); MOPP offset / Havok strips scale presence is version-gated (`has_mopp_offset`, `has_havok_strips_scale`); constraint `CInfo` decode is per-game (`constraints.rs` carries `parse_fo3` arms). The PHYSAL per-game seam is *only* the constraint CInfo decode — keep it confined there (memory "PHYSAL").
+- **`BSLightingShaderProperty::parse`** (`shader.rs`) is a thin `bsver` dispatcher → `parse_skyrim` (83–129) / `parse_fo4` (130–154) / `parse_fo76_plus` (≥155). Each variant must read **only** its own field set (Skyrim-only lighting-effect fields, no FO4 subsurface / FO76 trailing). A variant reading another's tail is the over-read in `#1510`.
+- Shader-type trailing data: `BSLightingShaderProperty` has 0–7 type-specific trailing fields — confirm the per-`shader_type` field count matches nif.xml.
+**Regression guards**:
+- **Collision-shape translation completeness** (`import/collision.rs::extract_collision`): MUST translate `BhkMultiSphereShape` + `BhkConvexListShape` to `CollisionShape` (the `downcast_ref::<…>()` arms must stay). Regression = a shape that parses but never reaches `extract_collision`.
+- **Per-variant collision dispatch** (`examine_collision_kind` → `CollisionAuthoring`): the enum must keep distinguishing `None` / `Classic` / `NewPhysicsStub` / `Phantom` / `Unrecognised` (British spelling). Regression = collapsing the discriminator so a Skyrim+ phantom (`BhkPCollisionObject` wrapping `bhkPhantom`) gets force-translated as a rigid body instead of routed to a future TriggerVolume path.
 **Output**: `/tmp/audit/nif/dim_5.md`
 
-### Dimension 6: Stream Allocation Hygiene (PERF — 2026-05-04 batch + 2026-05-23 follow-up)
-**Entry points**: `crates/nif/src/stream.rs` (allocate_vec, read_pod_vec), all `blocks/*.rs` callers, `byroredux/src/streaming.rs::pre_parse_cell`
+### Dimension 6: Allocation Hygiene (PERF)
+**Entry points**: `crates/nif/src/stream.rs` (`allocate_vec`, `read_pod_vec`), all `blocks/*.rs` callers, `byroredux/src/streaming.rs` (`pre_parse_cell`).
 **Checklist**:
-- `stream.allocate_vec::<T>(n)?;` carries `#[must_use]`. Bound-check-only call sites that discard the empty Vec are a leak/no-op pattern fixed at 9 sites by #831 NIF-PERF-03; the attribute prevents recurrence — verify it's still on. **#1246 extended the `#[must_use]` discipline** (`a56c9e71`) to the `read_pod_vec` wrappers AND the KFM `allocate_vec` site
-- 6 NIF bulk-array readers go through `read_pod_vec<T>` to collapse double allocation (#833 NIF-PERF-02). Direct allocate-then-loop-and-fill is the regression. The helper has a top-of-module compile-error gate for big-endian hosts; bytemuck is NOT a workspace dep despite some audits claiming it
-- Per-block parse-loop counters use `entry().get_mut() / insert` split, NOT `entry().or_insert(name.to_string())` (#832 NIF-PERF-01) — the to_string path leaks ~150 KB/cell of throwaway short-string allocations on Oblivion
-- #408 blanket `allocate_vec` sweep (60+ sites across 12 NIF files, Session 12): any new bulk-read site MUST use `allocate_vec` or `read_pod_vec`, NOT `Vec::with_capacity` + per-element read in a loop
-- **#1245 `ragdoll.rs` `allocate_vec` adoption** (`8490d829`): the bone-pose / ragdoll-template parse path now uses `allocate_vec` instead of the `check_alloc` idiom. Verify no other bhk*/ragdoll parser in `crates/nif/src/blocks/collision/` regressed back to the old idiom
-- **BSGeometry bulk-read fast path** (#1263 + #1265, `dd02ad3f`): `BSGeometry` (Starfield 155-bsver mesh) extracts vertex/index data via the `read_pod_vec` bulk-read fast path. NiTriShape tangent extraction uses `std::mem::take` on the `Vec<f32>` to avoid a per-mesh clone. Regression pattern: a future BSGeometry change that re-introduces `Vec::with_capacity` + per-vertex loop, OR a clone instead of `mem::take` on tangents. Affects parse perf at Starfield-cell scale
-- **NIF dispatch `Arc<str>` regression + rayon serial fast path** (#1261 + #1262, `6368b077`): per-block dispatch routes through `Arc<str>` for block names (interned). The rayon-parallel parse path has a serial fast-path for small models (`pre_parse_cell` in `byroredux/src/streaming.rs`). Verify both paths are wired — serial fast path is the regression target when small cells go through the parallel overhead path
-- **`pre_parse_cell` serial extract → parallel parse split** (#877, `ba646f8b`): the cell-streaming `pre_parse_cell` worker is now a two-phase pipeline (serial header extraction → rayon-parallel body parse). The serial extract phase is what the #1262 fast path skips on small models. Verify the phase split is intact — collapsing them back into a monolithic parallel pass is the regression
-- **`#[must_use]` extension on `read_pod_vec` wrappers + KFM `allocate_vec`** (#1246, `a56c9e71`): six read_pod_vec helper functions and the KFM allocate_vec call now carry `#[must_use]`. A future helper that doesn't carry the attribute is the regression pattern
-- **dhat-gated allocation-bound regression test landed** (#1247, `88cd8792`): NIF parser allocation count is now pinned by a `cfg(feature = "dhat")`-gated test. The infrastructure gap flagged across earlier audits is partially closed — verify the test is in `crates/nif/tests/` and asserts an upper-bound allocation count on a canonical input. Future alloc-reduction findings can NOW be guarded by extending this test (was the open dhat-infra gap noted in 2026-05-04+)
-- **Per-game NiPSysEmitter / NiTextureEffect version gating** (#1239 + #1240, `97524667` + `9cb93b5b`):
-  - `NiPSysEmitter` now routes through nif.xml's version gate so Oblivion (`bsver < 26`) parses correctly — was previously assuming Skyrim+ field layout
-  - `NiTextureEffect.NiDynamicEffect`-base parsing is gated on `bsver < FALLOUT4` (the FO4+ split removed the embedded NiDynamicEffect)
-  - Regression pattern: a future block parser that hardcodes a single layout without checking BSVER bands
+- `allocate_vec::<T>(count)` and the `read_pod_vec` wrappers carry `#[must_use]` (the message names the fix-up: bind it or `stream.skip()`). A bound-check-only call site that discards the Vec is a no-op/leak pattern. Verify the attribute is present on the helpers and the KFM `allocate_vec` site (`#831`, extended by `#1246`).
+- Bulk arrays go through `read_pod_vec<T>` (collapses the double allocation, `#833`); direct allocate-then-loop-and-fill is the regression. `read_pod_vec` has a top-of-module big-endian compile-error gate. **`bytemuck` is NOT a workspace `Cargo.toml` dep** despite some audits claiming it — `read_pod_vec` bounds `T: AnyBitPattern` via the re-export; confirm before reporting.
+- Per-block parse-loop counters use the `entry().get_mut() / insert` split, not `entry().or_insert(name.to_string())` (`#832`; the `to_string` path leaks throwaway short strings per Oblivion cell).
+- `ragdoll.rs` bone-pose / template parse uses `allocate_vec` (not the old `check_alloc` idiom, `#1245`); verify no other `bhk*`/`ragdoll` parser regressed back.
+- Per-block dispatch interns block names as `Arc<str>` (`#1261`); `pre_parse_cell` (`byroredux/src/streaming.rs`) is a two-phase pipeline — serial header extract → rayon-parallel body parse (`#877`) — with a serial fast path for small models (`#1262`). Verify the phase split is intact and both paths are wired (collapsing them, or routing small cells through the parallel overhead, is the regression).
+**Test-infra signal**: `crates/nif/tests/heap_allocation_bounds.rs` (`parse_skyrim_se_single_node_stays_within_heap_budget`, `cfg(feature = "dhat")`-gated, `#1247`) + `heap_allocation_bounds_geometry.rs` pin an upper-bound allocation count on a canonical input. New alloc-reduction findings should extend these rather than add ad-hoc checks.
 **Output**: `/tmp/audit/nif/dim_6.md`
-
-### Dimension 7: NIFAL Canonical Translation (NEW — 2026-05-28)
-**See also `/audit-nifal`** — the dedicated NIFAL (NIF Abstraction Layer) audit owns the full canonical-translation tier; this dimension is the NIF-parser-side boundary check. Spec: `docs/engine/nifal.md`.
-**Entry points**: `byroredux/src/material_translate.rs::translate_material` (the SINGLE per-game `ImportedMesh` → ECS `Material` boundary — per-game classification happens here, never at render time), `crates/core/src/ecs/components/material.rs` (`Material::resolve_pbr`, `EmissiveSource`, `classify_pbr_keyword`), `crates/nif/src/import/types.rs` (`ImportedMesh` carrying `metalness_override` / `roughness_override` / `bgem_glass` — the BGEM authoritative-glass flag), `byroredux/src/helpers.rs::classify_glass_into_material` (glass classified once, after the PBR resolve)
-**Checklist**:
-- **Single boundary**: `translate_material` is the only place a per-game `ImportedMesh` becomes a `Material`. The project invariant is that per-game material classification stays at this parser→Material boundary and NEVER leaks into the renderer/shader. A new per-game material decision added downstream of this fn is the regression.
-- **PBR resolve-once** (3ce98db8): `Material.metalness` / `Material.roughness` are plain `f32` (NOT `Option`, NOT a per-draw classifier). `translate_material` seeds the `f32::NAN` sentinel for any slot the upstream parser left unauthored (`mesh.metalness_override.unwrap_or(f32::NAN)`), then calls `material.resolve_pbr()` exactly once. `resolve_pbr` fills NaN slots via the shared `classify_pbr_keyword` and is idempotent + only fills the missing slot (does not clobber authored values). Verify the deleted render-time `Material::classify_pbr` method has NOT been reintroduced.
-- **EmissiveSource discriminator** (2e884741): the `EmissiveSource` enum (`None` / `Material` legacy scalar / `Lighting` Skyrim+ / `Effect` FO4+ effect-shader diffuse-tint) records *where* the emissive scalar came from. Verify the discriminator is set at translate time, not inferred per-draw.
-- **BGEM glass authoritative signal** (4a96d50e / #1280): a referenced `.bgem` authoring `glass_enabled = true` sets `ImportedMesh.bgem_glass`, an authoritative glass trigger independent of path/name keywords. `translate_material` runs `classify_glass_into_material` AFTER `resolve_pbr` so the forced glass roughness wins. Regression = an opaque architecture piece getting force-classed as glass off a stuck flag, or the keyword path overriding an authored BGEM glass signal.
-- **Per-variant `BSLightingShaderProperty::parse` dispatch** (#1279, 4e587c3d): `crates/nif/src/blocks/shader.rs` splits the monolithic parse into a thin `bsver` dispatcher → `parse_skyrim` (83–129) / `parse_fo4` (130–154) / `parse_fo76_plus` (≥155). Verify each variant reads only its own field set (e.g. Skyrim-only `lighting_effect_1/2`, no FO4 subsurface / FO76 trailing).
-- **Translation completeness**: `crates/nif/tests/translation_completeness.rs::cross_game_translation_completeness` is the regression surface for per-game material-translation coverage — extend it for any new translation-coverage finding (see Dim 5 pin).
-**Output**: `/tmp/audit/nif/dim_7.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/nif/dim_*.md` files
-2. Combine into `docs/audits/AUDIT_NIF_<TODAY>.md` with structure:
-   - **Executive Summary** — Coverage per game, total mismatches, critical gaps
-   - **Block Type Coverage Matrix** — Table of block types × games (parsed/skipped/unknown)
-   - **Findings** — Grouped by severity
-   - **Prioritized Fix Order** — Blocks needed for rendering first, then animation, then collision
-3. Remove cross-dimension duplicates
+1. Read all `/tmp/audit/nif/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_NIF_<TODAY>.md` (`YYYY-MM-DD`) with:
+   - **Executive Summary** — clean/recoverable rate per game (vs the `nif-parser.md` matrix), total stream-position mismatches, critical coverage gaps.
+   - **Block Type Coverage Matrix** — block types × games (parsed / skipped / NiUnknown).
+   - **Findings** — grouped by severity (per `_audit-severity.md`; note the NIF rows: hard parse failure = HIGH, stream-position mismatch the `block_size` reconciliation covers = MEDIUM).
+   - **Prioritized Fix Order** — rendering-blocking blocks first, then animation, then collision.
+3. Remove cross-dimension duplicates. Per-game **material** translation belongs to `/audit-nifal`; cross-link instead of duplicating.
 
 Suggest: `/audit-publish docs/audits/AUDIT_NIF_<TODAY>.md`

--- a/.claude/commands/audit-nifal/SKILL.md
+++ b/.claude/commands/audit-nifal/SKILL.md
@@ -33,7 +33,11 @@ leaks from the component itself.
 
 See `.claude/commands/_audit-common.md` for project layout, game data locations,
 methodology, deduplication, context rules, and base finding format.
-See `.claude/commands/_audit-severity.md` for the severity scale.
+See `.claude/commands/_audit-severity.md` for the severity scale — it carries
+**dedicated NIFAL rows** (wrong `translate_material` output = HIGH all-game blast
+radius; translatable block silently dropped = MEDIUM, escalate to HIGH if it
+removes visible content) and the matching decision-tree branches. Apply those rows;
+do not re-derive severities here.
 
 **Scope vs `/audit-nif`**: `/audit-nif` owns the *parse* side (block field
 correctness, version handling, stream position, coverage). NIFAL owns the
@@ -43,21 +47,44 @@ bytes are read wrong," it belongs to `/audit-nif`; when it is "the bytes are rea
 fine but the data is dropped, duplicated, or resolved per-game downstream," it
 belongs here.
 
+## The four tier invariants (every dimension is a lens on these)
+
+- **single-boundary** — exactly one `translate()` site per category that needs one.
+  A second construction site that fills a canonical type field-by-field is a
+  violation (caller count is the cheap detector).
+- **no-fabrication** — no invented value / guessed normalization. A new constant
+  must cite a measurement or source (`feedback_no_guessing`). The emissive no-op
+  (Dim 1) and particle colour/size-curve deferrals (Dim 5) are the canonical
+  "measured, then deliberately NOT normalized" examples.
+- **no-leak** — no `Option` "resolve-later" field or raw enum/block-type
+  discriminator on a *canonical* type reaches a consumer that has to re-resolve it.
+  (Raw-tier `Imported*` carrying `Option`s is fine — the leak is the crossing into
+  the canonical/consumer tier.)
+- **no-render-time-fallback** — no classification deferred to a per-draw heuristic.
+  The deleted `classify_pbr` / render-side glass heuristics are the cautionary tale;
+  a re-introduction is a regression, not a new design choice.
+
+**Highest blast radius first.** Order findings by NIFAL risk: (1) a wrong/divergent
+canonical `Material` out of `translate_material` (HIGH, silently wrong on *every*
+game, no per-draw fallback to mask it); (2) a *translatable* parsed block silently
+dropped at an unsupported-shape/skip fallback (removes authored content); (3) a
+no-render-time-fallback violation (classification leaked into shader/render); (4) a
+single-boundary violation (a second construction site that can diverge the paths).
+
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,6`). Default: all 8.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,6`). Default: all 9.
 - `--game <name>`: Focus on a specific variant: `fnv`, `fo3`, `skyrim`, `oblivion`,
   `fo4`, `fo76`, `starfield`. Default: all detected (from `_audit-common.md` game
   data locations).
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: Material | Geometry/Transform | Skinning/Lights | Nodes | Particles | Collision | Completeness
-- **Tier Violated**: which tier rule broke — `single-boundary` (duplicate construction
-  site) | `no-fabrication` (invented value / guessed normalization) | `no-leak`
-  (`Option`/raw discriminator reaches a canonical consumer) | `no-render-time-fallback`
-  (classification deferred to a per-draw heuristic) | `parked-not-leak` (verify a
-  "deferred" field is genuinely unconsumed, not a silent drop)
+- **Dimension**: Material | Geometry/Transform | Skinning/Lights | Nodes | Particles
+  | Collision | Animation | Shader-flags/Effects | Completeness
+- **Tier Violated**: which tier invariant broke — `single-boundary` | `no-fabrication`
+  | `no-leak` | `no-render-time-fallback` | `parked-not-leak` (verify a "deferred"
+  field is genuinely unconsumed, not a silent drop)
 - **Game Affected**: which variant(s) the divergence manifests on
 
 ## Phase 1: Setup
@@ -67,40 +94,41 @@ belongs here.
 3. Fetch dedup baseline:
    `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`,
    and scan `docs/audits/` for prior `AUDIT_NIFAL_*` / `AUDIT_NIF_*` reports.
-4. Read `docs/engine/nifal.md` (the spec) and `docs/engine/material-abstraction.md`
-   (the material-slice predecessor; note its §2 "Leak A"/"Leak B" are recorded
-   **closed** in `nifal.md` §3 — do not re-report them as open).
+4. Read `docs/engine/nifal.md` (the spec — per-category leak inventory in §2,
+   surveyed/converged status per category) and `docs/engine/material-abstraction.md`
+   (the material-slice predecessor; its §2 "Leak A"/"Leak B" are recorded **closed**
+   in `nifal.md` §3 — do not re-report them as open).
 5. Check which game data directories exist.
 
 ## Phase 2: Launch Dimension Agents
 
 ### Dimension 1: Material — the reference realisation (single boundary, no PBR fallback, glass-once)
 **Entry points**:
-- `byroredux/src/material_translate.rs::translate_material(mesh: &ImportedMesh, paths: ResolvedPaths, extra_material_flags: u32) -> Material` — the **single** `ImportedMesh → Material` boundary (`ResolvedPaths` struct also defined in this file).
+- `byroredux/src/material_translate.rs::translate_material(mesh: &ImportedMesh, paths: ResolvedPaths, extra_material_flags: u32) -> Material` — the **single** `ImportedMesh → Material` boundary (`ResolvedPaths` struct also defined here). It calls `Material::resolve_pbr()` then `helpers::classify_glass_into_material` internally.
 - Callers (MUST be exactly two, both routing through the boundary): `byroredux/src/scene/nif_loader.rs` (loose-NIF path) and `byroredux/src/cell_loader/spawn.rs` (cell path).
-- `crates/core/src/ecs/components/material.rs` — the canonical `Material`; `Material::resolve_pbr()`, `classify_pbr_keyword()`, `EmissiveSource` enum.
-- `byroredux/src/helpers.rs::classify_glass_into_material` — the single glass classifier.
+- `crates/core/src/ecs/components/material.rs` — the canonical `Material`; `Material::resolve_pbr()`, `classify_pbr_keyword()` (the `NaN`-sentinel backstop classifier), `EmissiveSource` enum (`None`/`Material`/`Lighting`/`Effect`).
+- `byroredux/src/helpers.rs::classify_glass_into_material` — the single glass classifier (defined once; the many call sites in that file are its unit tests).
 - `byroredux/src/render/static_meshes.rs` — the renderer consumer (reads `m.metalness` / `m.roughness` directly).
 
 **Checklist**:
-- `translate_material` is the ONLY construction site that fills a `Material` from an `ImportedMesh`. Any second site building a `Material` field-by-field from import data is a `single-boundary` violation (the pre-converged state had two ~110-line literals in `spawn.rs` + `nif_loader.rs` — regression pattern).
-- `Material.metalness` / `Material.roughness` are plain `f32` (resolved, clamped `metalness ∈ [0,1]`, `roughness ∈ [0.04,1]`). No `metalness_override: Option<f32>` / `roughness_override: Option<f32>` field on the canonical `Material`, and no per-draw `classify_pbr` fallback in the renderer (`no-leak` + `no-render-time-fallback`).
-- `resolve_pbr()` fills `NaN` sentinels from `classify_pbr_keyword` and clamps; it is idempotent and only fills missing slots (don't let it overwrite an authored BGSM/BGEM override).
-- Glass is classified **once**, alpha-aware, via `classify_glass_into_material`, AFTER the PBR resolve so the forced glass roughness wins. No glass heuristic at render time (`docs/engine/material-abstraction.md` §2 "Leak A" is closed — confirm it stays deleted).
-- `material_kind: u32` is intentionally kept as-is (it is the GPU shader-dispatch contract — the `material_kind == N` ladder in `triangle.frag`). Do NOT flag its `u32`-ness as a leak. **Future-slice invariant**: any `SurfaceClass` enum MUST lower to the exact `triangle.frag` ladder (drift risk vs the shader — a shader-adjacent change).
-- `effect_shader_flags` packs the union of BSEffect SLSF bits + BGSM v>2 bits + the caller's `extra_material_flags` (REFR-overlay model-space-normals on the cell path; `0` on the loose path).
+- `translate_material` is the ONLY site that fills a `Material` from an `ImportedMesh`. Any second site building a `Material` field-by-field from import data is a `single-boundary` violation (the pre-converged state had two ~110-line literals in `spawn.rs` + `nif_loader.rs` — regression pattern).
+- `Material.metalness` / `Material.roughness` are plain `f32` (resolved, clamped `metalness ∈ [0,1]`, `roughness ∈ [0.04,1]` — verify the clamp in `resolve_pbr`). No `metalness_override: Option<f32>` / `roughness_override: Option<f32>` field on the canonical `Material`, and no per-draw `classify_pbr` fallback in the renderer (`no-leak` + `no-render-time-fallback`).
+- `resolve_pbr()` only fills `NaN` sentinels (via `classify_pbr_keyword`) then clamps; for NIF/BGSM content the override is already `Some(…)` at import so the classifier arm is a backstop. It must not overwrite an authored BGSM/BGEM override.
+- Glass is classified **once**, alpha-aware, inside `translate_material` via `classify_glass_into_material`, AFTER `resolve_pbr` so the forced glass roughness wins. Engine-synthesized kinds (`material_kind >= 100`) are never demoted; conductors (`metalness >= 0.3`), non-alpha, and decals are gated out. No glass heuristic at render time (`material-abstraction.md` §2 "Leak A" is closed — confirm it stays deleted).
+- `material_kind: u32` is intentionally kept as-is (it is the GPU shader-dispatch contract — the `material_kind == N` ladder in `triangle.frag`; 0–20 vanilla `shader_type`, 100 GLASS, 101 EFFECT_SHADER). Do NOT flag its `u32`-ness as a leak. **Future-slice invariant**: any `SurfaceClass` enum MUST lower to the exact `triangle.frag` ladder (drift risk vs the shader — a shader-adjacent change).
+- `effect_shader_flags` packs the union of BSEffect SLSF bits (`cell_loader::pack_effect_shader_flags`) + BGSM v>2 bits (`cell_loader::pack_bgsm_material_flags`) + the caller's `extra_material_flags` (REFR-overlay model-space-normals on the cell path; `0` on the loose path).
 
-**Regression pins (this session)**:
+**Regression pins**:
 - **material_translate dedup**: the two duplicate `Material` construction literals were collapsed into `translate_material`. A field added in one load path that doesn't go through the boundary can silently diverge the two paths — the regression this dedup prevents.
-- **Emissive scale = no-op** (spec §4): `Material.emissive_mult` is fed by three `EmissiveSource` variants (`Material` legacy / `Lighting` Skyrim+ / `Effect` FO4+). All three were **measured** across Oblivion/FNV/Skyrim/FO4 and already share a ~1.0 scale — **no normalization is applied or wanted**. A future "emissive normalization constant" is a `no-fabrication` violation (inventing a correction for a divergence the ground truth shows does not exist). The one genuine distinction (`BSEffectShaderProperty.base_color_scale` is a diffuse-tint, not emissive) is captured by the `EmissiveSource::Effect` discriminator and left for a future BSEffect render path. Open question Q2 in `material-abstraction.md` is resolved no-op — do not re-open it. Tooling: `crates/nif/examples/material_dump.rs` (the `emisM` + `emSrc` columns).
+- **Emissive scale = no-op** (spec §4): `Material.emissive_mult` is fed by three `EmissiveSource` variants (`Material` legacy / `Lighting` Skyrim+ / `Effect` FO4+). All three were **measured** across Oblivion/FNV/Skyrim/FO4 and already share a ~1.0 scale — **no normalization is applied or wanted**. A future "emissive normalization constant" is a `no-fabrication` violation (inventing a correction for a divergence the ground truth shows does not exist). The one genuine distinction (`BSEffectShaderProperty.base_color_scale` is a diffuse-tint, not emissive) is captured by the `EmissiveSource::Effect` discriminator and left for a future BSEffect render path (#166 rename note in `import/material/walker.rs`). Open question Q2 in `material-abstraction.md` is resolved no-op — do not re-open it. Tooling: `crates/nif/examples/material_dump.rs` (the `emisM` + `emSrc` columns).
 **Output**: `/tmp/audit/nifal/dim_1.md`
 
 ### Dimension 2: Geometry / Transform — the cleanest category (the template the others match)
 **Entry points**:
 - `crates/nif/src/import/coord.rs` — Z-up (Gamebryo) → Y-up (renderer): `zup_point_to_yup`, `zup_matrix_to_yup_quat` (thin wrappers over `byroredux_core::math::coord`).
 - `crates/nif/src/import/mesh/tangent.rs` — `synthesize_tangents` / `synthesize_tangents_yup` (Mikkelsen synthesis fallback).
-- `crates/nif/src/import/mesh/` per-game extractors — `ni_tri_shape.rs`, `bs_tri_shape.rs`, `bs_geometry.rs`; each sets `ImportedMesh.local_bound_radius` (field on `crates/nif/src/import/types.rs`).
-- `crates/nif/src/rotation.rs` — degenerate-rotation SVD repair: `is_degenerate_rotation`, `repair_rotation_svd_or_identity` (done ONCE at parse time — see #277; NOTE the spec's `transform.rs` attribution drifted, the repair lives in `rotation.rs`).
+- `crates/nif/src/import/mesh/` per-game extractors — `ni_tri_shape.rs`, `bs_tri_shape.rs`, `bs_geometry.rs`; each feeds `ImportedMesh.local_bound_radius` (field on `crates/nif/src/import/types.rs`, derived via `mesh::extract_local_bound`).
+- `crates/nif/src/rotation.rs` — degenerate-rotation SVD repair: `is_degenerate_rotation`, `repair_rotation_svd_or_identity`, `sanitize_rotation` (done ONCE at parse time — see #277; NOTE the repair lives in `rotation.rs`, not `transform.rs`).
 - `crates/nif/src/import/transform.rs::compose_transforms` — parent×child composition (assumes rotations already sanitized).
 - Consumer: `crates/renderer/src/mesh.rs::MeshRegistry::upload` (format-agnostic).
 
@@ -114,23 +142,23 @@ belongs here.
 
 ### Dimension 3: Skinning & Lights
 **Entry points**:
-- Skinning: `crates/nif/src/import/mesh/skin.rs` — `ImportedSkin` (`crates/nif/src/import/types.rs`), `global_skin_transform`, the #613 partition-local→global bone-index remap (done at extraction).
+- Skinning: `crates/nif/src/import/mesh/skin.rs` — `ImportedSkin` (struct on `crates/nif/src/import/types.rs`, with `global_skin_transform`), the #613 partition-local→global bone-index remap (done at extraction).
 - Lights: `crates/nif/src/import/types.rs::LightKind` (`Ambient`/`Directional`/`Point`/`Spot`) + `ImportedLight.radius`; populated in `crates/nif/src/import/walk/mod.rs`.
 
 **Checklist**:
-- **Skinning** (`no-leak` / converged): `ImportedSkin` emits **global** bone indices — partition-local remap done at extraction (#613 / SK-D1-01: pre-#613 silently aliased every vertex past partition 0). The defensive u16-range warning (`skin.rs` ~line 148) must stay. `global_skin_transform` carried through. Palette skinning is game-agnostic downstream — no consumer should re-derive partition layout.
+- **Skinning** (`no-leak` / converged): `ImportedSkin` emits **global** bone indices — partition-local remap done at extraction (#613 / SK-D1-01: pre-#613 silently aliased every vertex past partition 0). The defensive u16-range warning in `skin.rs` (the `bone_refs_slice.len() > u16::MAX` guard) must stay. `global_skin_transform` carried through. Palette skinning is game-agnostic downstream — no consumer should re-derive partition layout.
 - **Lights** (`no-leak` / converged): `ImportedLight` resolves to the `LightKind` enum with a derived effective `radius` (Bethesda units, from attenuation). The renderer must NEVER inspect the source NIF block type (NiAmbientLight / NiDirectionalLight / NiPointLight / NiSpotLight) — that is the raw-tier discriminator collapsed at translate. A downstream `match` on source block type is a leak.
 **Output**: `/tmp/audit/nifal/dim_3.md`
 
-### Dimension 4: Nodes — the four raw-tier-parked passthroughs (verify parked, not silently dropped)
+### Dimension 4: Nodes — raw-tier-parked passthroughs (verify parked, not silently dropped)
 **Entry points**:
-- `crates/nif/src/import/types.rs` — `ImportedNode` fields: `bs_value_node: Option<BsValueNodeData>`, `bs_ordered_node: Option<BsOrderedNodeData>`, `tree_bones: Option<TreeBones>`, `range_kind: Option<BsRangeKind>`.
+- `crates/nif/src/import/types.rs` — parked `ImportedNode` fields: `bs_value_node: Option<BsValueNodeData>`, `bs_ordered_node: Option<BsOrderedNodeData>`, `tree_bones: Option<TreeBones>`, `range_kind: Option<BsRangeKind>`, `lod_group: Option<LodGroupData>`; parked `ImportedMesh` fields: `bs_lod_cutoffs: Option<[u32;3]>`, `bs_sub_index: Option<BsSubIndexTriShapeData>`.
 - Live (canonical) node data consumers: spawn sites in `byroredux/src/scene/nif_loader.rs` + `byroredux/src/cell_loader/spawn.rs` (`name`, `flags`→`SceneFlags`, `collision`→`CollisionShape`/`RigidBodyData`, `billboard_mode`→`Billboard`).
 
 **Checklist**:
 - The live node data (name, flags, collision, billboard_mode) IS consumed at the spawn sites — confirm no canonical node field is dropped.
 - The `ImportedNode → ECS` step is deliberately NOT a single `translate_node` boundary: the two load paths handle nodes structurally differently (loose-NIF spawns the full NiNode hierarchy as entities; cell loader uses a flattened placement-root). Do NOT flag the absence of one boundary as a `single-boundary` violation for nodes — it is documented (spec §2 Nodes).
-- The four fields below are **raw-tier-parked with deferred translation** — verify (per-game) they have **zero canonical ECS consumers** (`parked-not-leak`). They are NOT leaks (they sit on the raw `ImportedNode`, which the tier model permits to carry per-game data, and reach no canonical component). Each is blocked on a not-yet-existing consumer feature. If you find ANY of them now feeding a canonical ECS component without a translate step, THAT is a leak finding:
+- The fields below are **raw-tier-parked with deferred translation** — verify (per-game) they have **zero canonical ECS consumers** (`parked-not-leak`). They sit on the raw `ImportedMesh`/`ImportedNode`, which the tier model permits to carry per-game data, and reach no canonical component. If you find ANY of them feeding a canonical ECS component without a translate step, THAT is a leak finding. (Grep `\.field` / `field:` outside `types.rs`, the parser, and `_tests` — the expected hit count is zero.)
 
   | Field | Source block | Authored data | Blocked on |
   |---|---|---|---|
@@ -138,55 +166,84 @@ belongs here.
   | `bs_ordered_node` | `BSOrderedNode` | alpha-sort bound + draw-order hint | `RenderOrderHint` + `build_render_data` sort key |
   | `tree_bones` | `BSTreeNode` | SpeedTree branch/trunk bone names | SpeedTree wind/bend sim |
   | `range_kind` | `BSRangeNode`/`BSDamageStage`/`BSBlastNode`/`BSDebrisNode` | destructible/blast/debris discriminator | destructible-switching / blast / debris systems |
+  | `lod_group` | `NiLODNode` → `NiRangeLODData` | center + per-level near/far (Y-up); foundation parsed, import walks child 0 only; **content-absent** in shipped archives | per-frame distance-switch system |
+  | `bs_lod_cutoffs` | `BSLODTriShape` | mesh-level LOD0/1/2 triangle-count cutoffs (Skyrim ~43 meshes — the content-bearing in-cell LOD) | in-cell LOD draw-count consumer |
+  | `bs_sub_index` | `BSSubIndexTriShape` | dismemberment / locational-damage segment ids | dismemberment system |
 
-  When a consumer feature lands, its slice must translate the parked field (the data is already captured — no parser change needed). Until then, this table is the bounded-gap record.
+  When a consumer feature lands, its slice must translate the parked field (data already captured — no parser change). Until then, this table is the bounded-gap record. The deeper passthrough inventory (NiTextureEffect, NiSwitchNode identity, BSFurnitureMarker/BSInvMarker, BSBound cell-path) lives in `nifal.md` §2 "Passthroughs" — cross-check against it; do not re-report a documented passthrough as a leak.
 **Output**: `/tmp/audit/nifal/dim_4.md`
 
-### Dimension 5: Particles — authored base params override the name-heuristic preset (one shared apply helper)
+### Dimension 5: Particles — one shared overlay boundary folds every authored emitter override
 **Entry points**:
-- Parser (typed blocks): `crates/nif/src/blocks/particle.rs` — `NiPSysEmitter { params: EmitterBaseParams }` (+ `parse_box_emitter`/volume variants via `read_emitter_base`/`read_volume_emitter_base`), `NiPSysEmitterCtlr { interpolator_ref }`, `NiPSysEmitterCtlrData` (legacy birth-rate), `NiPSysGrowFadeModifier { base_scale }` (`parse_grow_fade_modifier`).
-- Import: `crates/nif/src/import/walk/mod.rs::extract_emitter_params` → `ImportedEmitterParams` (on `crates/nif/src/import/types.rs`, surfaced on `ImportedParticleEmitter(+Flat)`); `extract_emitter_rate` (controller → `NiFloatInterpolator` constant / `NiFloatData` first key; legacy fallback `NiPSysEmitterCtlrData`).
-- Translate / apply: `byroredux/src/systems/particle.rs::apply_emitter_params` — the **one shared helper**, called from BOTH `byroredux/src/scene/nif_loader.rs` (~line 541) and `byroredux/src/cell_loader/spawn.rs` (~line 419) via `crate::systems::apply_emitter_params`.
+- Parser (typed blocks): `crates/nif/src/blocks/particle.rs` — `NiPSysEmitter { params: EmitterBaseParams }` (box/sphere/cylinder/array/mesh variants via `read_emitter_base`/`read_volume_emitter_base`), `NiPSysEmitterCtlr { interpolator_ref }`, `NiPSysEmitterCtlrData` (legacy birth-rate), `NiPSysGrowFadeModifier { base_scale }`.
+- Import: `crates/nif/src/import/walk/mod.rs::extract_emitter_params` → `ImportedEmitterParams` (surfaced on `ImportedParticleEmitter(+Flat)`); `extract_emitter_rate` (controller → `NiFloatInterpolator` constant / `NiFloatData` first key; legacy fallback `NiPSysEmitterCtlrData`).
+- **The boundary**: `byroredux/src/systems/particle.rs::apply_emitter_overlays` — the **single overlay site** (#1513) that folds colour curve + base params + birth rate + force fields onto a name-heuristic preset in place. Called from BOTH `byroredux/src/scene/nif_loader.rs` (~line 526) and `byroredux/src/cell_loader/spawn.rs` (~line 413) via `crate::systems::apply_emitter_overlays` (re-exported by `pub(crate) use particle::*` in `systems.rs`). `apply_emitter_params` is the sub-helper it delegates to for the kinematic/lifetime/size subset — not itself the boundary.
 
 **Checklist** (`no-fabrication` / `single-boundary`):
-- `apply_emitter_params` is the single site that overlays authored params onto the preset. Both load paths route through it — a second inline overlay is a `single-boundary` violation.
-- Authored **kinematic + lifetime** fields (speed, speed_variation, declination, declination_variation, life, life_variation) override the name-heuristic preset guesses where genuinely authored.
-- `initial_color` (white nif.xml default) is **intentionally NOT applied** — colour stays owned by the `color_curve` override. Applying the default white would wash out tuned presets — flag it as a regression (a `no-fabrication` violation in reverse) if a future change starts applying it.
-- Spawn **rate** is authored: `extract_emitter_rate` follows `NiPSysEmitterCtlr.interpolator_ref`; the translate sets `preset.rate` when present (FLT_MAX sentinel rejected). Legacy `NiParticleSystemController` content has no controller → keeps preset rate.
-- Particle **size**: the translate sets constant `start_size = end_size = initial_radius × base_scale` (`base_scale None → 1.0`). `base_scale` is essential (FNV oasis smoke `radius 50 × 0.15 = 7.5`; raw radius alone would be ~7× oversized). The grow→steady→fade bell shape canNOT map to the linear `start_size→end_size` — only the authored *magnitude* is translated (size-over-life curve is documented future work, not a leak).
+- `apply_emitter_overlays` is the single site overlaying authored data onto the preset. Both load paths route through it — a second inline overlay (colour, base params, rate, or force fields written field-by-field at a spawn site) is a `single-boundary` violation. This is the #1513 dedup: before it, the four overlays were copy-pasted inline at both sites.
+- Authored **kinematic + lifetime** fields (speed, speed_variation, declination, declination_variation, life, life_variation) override the name-heuristic preset guesses (via `apply_emitter_params`).
+- `initial_color` is **intentionally NOT applied** — colour stays owned by the `color_curve` override (white nif.xml default would wash out tuned presets). Flag a future change that starts applying it as a `no-fabrication` regression (in reverse).
+- Spawn **rate** is authored: `extract_emitter_rate` follows `NiPSysEmitterCtlr.interpolator_ref`; the overlay sets `preset.rate` when present (FLT_MAX sentinel rejected — #1363/#1364). Legacy `NiParticleSystemController` content has no controller → keeps preset rate.
+- Particle **size**: `apply_emitter_params` sets constant `start_size = end_size = initial_radius × base_scale` (`base_scale None → 1.0`). `base_scale` is essential (FNV oasis smoke `radius 50 × 0.15 = 7.5`; raw radius alone would be ~7× oversized). The grow→steady→fade bell shape canNOT map to the linear `start_size→end_size` — only the authored *magnitude* is translated (size-over-life curve is documented future work, not a leak).
+- **Force fields** are Z-up→Y-up converted at overlay time (`convert_force_fields_zup_to_yup`, #984), not per-particle per-frame.
 
-**Regression pins (2026-05-28)**:
-- **Typed particle blocks**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are typed blocks carrying decoded params (the box/sphere/cylinder/array/mesh parsers read the base via `read_emitter_base` instead of skipping it; byte advancement unchanged, `Radius Variation` interleaved before `Life Span` per nif.xml). A future parser that reverts to skipping the base, or a per-game hardcoded layout without the BSVER gate, is the regression.
-- Tooling: `crates/nif/examples/emitter_dump.rs` (`rate / radius / bscale / speed / declination / life / initColor`).
+**Regression pins**:
+- **Typed particle blocks**: the box/sphere/cylinder/array/mesh parsers read the base via `read_emitter_base` instead of skipping it (byte advancement unchanged, `Radius Variation` interleaved before `Life Span` per nif.xml). A parser reverting to skipping the base, or a per-game hardcoded layout without the BSVER gate, is the regression.
+- Tooling: `crates/nif/examples/emitter_dump.rs` (`rate / radius / bscale / speed / spdVar / decl / declVar / life / lifeVar / initColor`).
 **Output**: `/tmp/audit/nifal/dim_5.md`
 
 ### Dimension 6: Collision — every parsed bhk*Shape resolves to a CollisionShape (no silent drop)
 **Entry points**:
-- `crates/nif/src/import/collision.rs` — `resolve_shape` / `resolve_shape_inner` (recursive bhk-shape → `CollisionShape`); `CollisionShape` / `RigidBodyData` / `MotionType` are `byroredux_core::ecs::components::collision` types (the canonical tier). Havok→engine transform + per-game `havok_scale` (`scene.havok_scale`, ×7.0 TES4/FO3/FNV, ×69.99 Skyrim+) applied uniformly.
+- `crates/nif/src/import/collision.rs` — `resolve_shape` / `resolve_shape_inner` (recursive bhk-shape → `CollisionShape`); `CollisionShape` / `RigidBodyData` / `MotionType` are `byroredux_core::ecs::components::collision` types (the canonical tier). Havok→engine transform + per-game `havok_scale` (`scene.havok_scale`, ×7.0 TES4/FO3/FNV, ×69.99 Skyrim+/FO4) applied uniformly. Recursion depth is bounded (#1385) and non-finite floats guarded (#1409).
 
-**Checklist** (`no-leak` — the "parsed for byte-correctness then dropped at the unsupported-shape fallback" pattern is the prime leak class here):
-- Every parsed `bhk*Shape` variant resolves to a `CollisionShape`. As of 2026-05-28 there are **13** `downcast_ref::<Bhk*Shape>` arms in `resolve_shape_inner`: `BhkSphereShape`, `BhkMultiSphereShape`, `BhkBoxShape`, `BhkCapsuleShape`, `BhkCylinderShape`, `BhkConvexVerticesShape`, `BhkMoppBvTreeShape`, `BhkListShape`, `BhkConvexListShape`, `BhkTransformShape`, `BhkNiTriStripsShape`, `BhkPackedNiTriStripsShape`, `BhkCompressedMeshShape`. A parsed `*Shape` block type with NO resolve arm (falls through to the unsupported-shape fallback) silently vanishes the authored collision — that is a leak finding.
+**Checklist** (`no-leak` — "parsed for byte-correctness then dropped at the unsupported-shape fallback" is the prime leak class):
+- Every parsed `bhk*Shape` variant resolves (directly, by delegation, or as a `Compound`) to a `CollisionShape`. **As of #1360/#1361 there are 15 shape arms in `resolve_shape_inner`** (count `downcast_ref::<Bhk*Shape>` arms, excluding the `BhkCollisionObject`/`BhkNPCollisionObject`/`BhkPCollisionObject`/`BhkRigidBody`/`BhkConstraint` arms which are objects, not shapes): `BhkSphereShape`, `BhkMultiSphereShape`, `BhkBoxShape`, `BhkCapsuleShape`, `BhkCylinderShape`, `BhkConvexVerticesShape`, `BhkMoppBvTreeShape`, `BhkConvexSweepShape`, `BhkListShape`, `BhkConvexListShape`, `BhkTransformShape`, `BhkNiTriStripsShape`, `BhkMeshShape`, `BhkPackedNiTriStripsShape`, `BhkCompressedMeshShape`. A parsed `*Shape` block type with NO resolve arm (falls through to the unsupported-shape fallback) silently vanishes the authored collision — that is a leak finding. (Cross-check the live arm count against the parsed-shape set in `crates/nif/src/blocks/collision/` — the audit is the diff.)
 - Havok→engine transform + `havok_scale` are applied uniformly inside `collision.rs` (Z-up→Y-up `(x, z, -y)`, quaternion swap). No consumer re-applies the scale.
 
-**Regression pins (this session)**:
-- **`BhkMultiSphereShape`** → now a `Compound` of `Ball` children at each sphere's scaled center (single centred sphere unwraps to a plain `Ball`). Pre-fix it fell through the unsupported-shape fallback. A revert is a `no-leak` regression.
-- **`BhkConvexListShape`** → now a `Compound` of resolved convex sub-shapes (mirrors `BhkListShape`; FO3/FNV/Skyrim destructibles + debris). Pre-fix dropped silently.
+**Regression pins** (do NOT re-report these as open leaks — verify they stay resolved):
+- **`BhkMultiSphereShape`** → `Compound` of `Ball` children at each sphere's scaled center (single centred sphere unwraps to a plain `Ball`). Pre-fix fell through the fallback (#9c6096aa).
+- **`BhkConvexListShape`** → `Compound` of resolved convex sub-shapes (mirrors `BhkListShape`; FO3/FNV/Skyrim destructibles + debris). Pre-fix dropped silently (#9c6096aa).
+- **`BhkConvexSweepShape`** (delegates to its inner `shape_ref`) and **`BhkMeshShape`** (resolves tri-strip data with per-axis scale) → added #1360/#1361. A revert is a `no-leak` regression.
 - **Documented limitations (NOT leaks)** — confirm they stay documented in the table at the top of `import/collision.rs`, and do NOT report them as leaks:
-  - `BhkNPCollisionObject` (FO4/FO76/Starfield Havok-serialised blob) — decoder is a separate project; consumer falls back to `cell_loader/spawn.rs::synthesize_static_trimesh` for Architecture meshes.
-  - `BhkPCollisionObject` phantoms (Skyrim+ trigger volumes) — need a `TriggerVolume` ECS path, not a rigid body. A small bookkeeping discriminator (`is::<BhkNPCollisionObject>` / `is::<BhkPCollisionObject>` in `collision.rs`) lets the trimesh fallback distinguish the two — verify it's intact.
+  - `BhkNPCollisionObject` (FO4/FO76/Starfield Havok-serialised `BhkSystemBinary` blob) — decoder is a separate project; consumer falls back to `cell_loader/spawn.rs::synthesize_static_trimesh` for Architecture meshes.
+  - `BhkPCollisionObject` phantoms (Skyrim+ trigger volumes) — need a `TriggerVolume` ECS path, not a rigid body. The `is::<BhkNPCollisionObject>` / `is::<BhkPCollisionObject>` discriminators let the trimesh fallback distinguish the two — verify they're intact.
 **Output**: `/tmp/audit/nifal/dim_6.md`
 
-### Dimension 7: Translation-completeness signal + the cross-cutting tier invariants
+### Dimension 7: Animation / controllers — single NIF→AnimationClip boundary (surveyed converged 2026-06-02)
+**Entry points**:
+- Parser/import: `crates/nif/src/anim/entry.rs::import_kf` (KF sequences) + `import_embedded_animations` (mesh-embedded controllers); both funnel through one set of `extract_*_channel_at` cores in `crates/nif/src/anim/`.
+- **The boundary**: `byroredux/src/anim_convert.rs::convert_nif_clip` — the single NIF→core `AnimationClip` translation (multiple callers — `npc_spawn.rs`, `cell_loader/references.rs` + `partial.rs`, `scene.rs` + `scene/nif_loader.rs`, `systems/animation.rs` — all route through this one fn; multiple callers of one boundary is correct, not a single-boundary violation).
+- Canonical type: ECS `AnimationClip` (`crates/core/src/animation/`).
+
+**Checklist** (`no-leak` / `no-fabrication`):
+- Every per-game variation is resolved at import: B-spline compressed interpolators (FO3/FNV + Skyrim+ — *not* Skyrim-only, per `feedback_bspline_not_skyrim_only`) sampled to linear keys; XYZ-Euler rotation keys composed to quaternions; TBC/Hermite tangents decoded; Z-up→Y-up once. The player/stack consumers must see only game-agnostic quaternion keys — no `Option`/era branch downstream.
+- Text-key events wired: `NiControllerSequence.text_keys_ref` → `AnimationClip.text_keys` → `AnimationTextKeyEvents` ECS → scripting. Embedded controllers set `text_keys: Vec::new()` by design (mesh-local controllers carry no event keys) — verify that's a deliberate empty, not a drop.
+- Intentionally **parked** (captured, no renderer consumer yet, NOT leaks): per-light **ambient** colour channels and **morph-weight** channels. Confirm they reach no canonical consumer.
+**Output**: `/tmp/audit/nifal/dim_7.md`
+
+### Dimension 8: Shader flags / texture sets / effect shaders — per-game vocabularies collapse at parse (surveyed converged 2026-06-02)
+**Entry points**:
+- `crates/nif/src/shader_flags.rs` — namespaced per-game flag vocabularies (`fo3nv_f1`, `skyrim_slsf1`, `fo4_slsf1`, + FO76/Starfield CRC32 arrays), the `ShaderFlags<'a>` typed view, `is_decal()` / `is_two_sided()`, and compile-time equivalence asserts (bits 26/27) guarding bit-meaning collisions.
+- `MaterialInfo` (`crates/nif/src/import/material/`) — decal / two-sided read once per property type; `BSShaderTextureSet` slot→role mapping keyed on `shader_type`.
+- `EmissiveSource::Effect` + `material_kind == 101` — `BSEffectShaderProperty` capture/route.
+
+**Checklist** (`no-render-time-fallback` / `no-leak`):
+- Per-game flag vocabularies are dispatched by **block type** (the wire format already discriminates the game), NOT by a runtime `if game ==`. Verify `triangle.frag` has **zero** `if game ==` branches — the renderer reads `material.is_decal` / `two_sided` with no per-game branch. A per-game branch leaking into the shader is the cardinal `no-render-time-fallback`/leak violation for this dimension.
+- All 9 `BSLightingShaderProperty` shader-type variants forward their trailing data (SkinTint/HairTint/Parallax/MultiLayer/Eye/Sparkle — the pre-#343 8-of-9 drop is closed). A variant dropping its trailing data is a regression.
+- `BSEffectShaderProperty` captured + routed (EFFECT_* flags, `material_kind == 101`). The one *deferred* item is the `base_color_scale` diffuse-tint-vs-emissive render path — tagged via `EmissiveSource::Effect`, not dropped (don't re-report as a leak).
+**Output**: `/tmp/audit/nifal/dim_8.md`
+
+### Dimension 9: Translation-completeness signal + cross-cutting tier invariants
 **Entry points**:
 - `crates/nif/tests/translation_completeness.rs` — `cross_game_translation_completeness` (`#[ignore]`-gated; run with `cargo test -p byroredux-nif --test translation_completeness -- --ignored`), `collect_stats`, `MaterialStats::record/print_row`. Per-game (`Oblivion`/`FNV`/`Skyrim`/…) aggregate fill-rate over the canonical `Material` slots.
 
-**Checklist** (cross-cutting — these are the NIFAL invariants stated in `docs/engine/nifal.md` §1):
-- **single-boundary**: exactly one `translate()` site per category that needs one (Material ✓ `translate_material`; Particles ✓ `apply_emitter_params`; Nodes ✗ by design, see Dim 4). New categories must declare their boundary, not scatter construction.
-- **no-fabrication**: no invented values / guessed normalization. The emissive no-op (Dim 1) and the particle color/size-curve deferrals (Dim 5) are the canonical examples of "measured, then deliberately NOT normalized." Any new constant must cite a measurement or source (`feedback_no_guessing` policy).
-- **no-leak**: no `Option` "resolve-later" field or raw enum discriminator on a canonical type reaches a consumer that has to re-resolve it. (Raw-tier `Imported*` carrying `Option`s is fine — the leak is when it crosses into the canonical/consumer tier.)
-- **no-render-time-fallback**: no classification deferred to a per-draw heuristic (the deleted `classify_pbr` / render-side glass heuristics are the cautionary tale).
-- The completeness harness is the **per-game coverage signal**: a category that converges on FNV but drops to ~0 fill on Starfield is an unverified-game leak even if no single-game audit flagged it. Treat large per-game fill-rate divergence (in the `print_row` output) as a lead, not gospel — verify the underlying extractor.
-**Output**: `/tmp/audit/nifal/dim_7.md`
+**Checklist** (the four tier invariants stated up top, applied across every dimension):
+- **single-boundary**: each category that needs one declares its boundary, not scattered construction — Material ✓ `translate_material`; Particles ✓ `apply_emitter_overlays`; Animation ✓ `convert_nif_clip`; EXAL exterior ✓ `env_translate.rs::translate_*`; Nodes ✗ by design (Dim 4). New categories must declare a boundary.
+- **no-fabrication**: the emissive no-op (Dim 1) and particle colour/size-curve deferrals (Dim 5) are the canonical "measured, then deliberately NOT normalized" examples. Any new constant must cite a measurement or source.
+- **no-leak**: no `Option`/raw discriminator on a canonical type reaches a consumer that re-resolves it.
+- **no-render-time-fallback**: no classification deferred to a per-draw heuristic (the deleted `classify_pbr` / render-side glass heuristics are the cautionary tale; `triangle.frag` `if game ==` count must be zero — Dim 8).
+- The completeness harness is the **per-game coverage signal**: a category that converges on FNV but drops to ~0 fill on Starfield is an unverified-game leak even if no single-game audit flagged it. Treat large per-game fill-rate divergence (in `print_row` output) as a lead, not gospel — verify the underlying extractor.
+**Output**: `/tmp/audit/nifal/dim_9.md`
 
 ## Phase 3: Merge
 
@@ -198,11 +255,12 @@ belongs here.
    - **Per-Category Tier Matrix** — table of category × tier-invariant (single-boundary,
      no-fabrication, no-leak, no-render-time-fallback) marked pass / fail / N-A, with the
      boundary fn cited for each.
-   - **Findings** — grouped by severity, using the base finding format plus the Extra
-     Per-Finding Fields above.
-   - **Documented-limitation ledger** — restate the parked-not-leak items (node
-     passthroughs, FO4+ NP blob, phantoms, size-over-life curve) so they are not
-     re-reported next sweep.
+   - **Findings** — grouped by severity (apply the NIFAL severity rows in
+     `_audit-severity.md`), using the base finding format plus the Extra Per-Finding
+     Fields above.
+   - **Documented-limitation ledger** — restate the parked-not-leak items (node/mesh
+     passthroughs, FO4+ NP blob, phantoms, size-over-life curve, ambient/morph anim
+     channels) so they are not re-reported next sweep.
 3. Remove cross-dimension duplicates.
 
 Run `.claude/commands/_audit-validate.sh` before finalizing (backticked paths must

--- a/.claude/commands/audit-oblivion/SKILL.md
+++ b/.claude/commands/audit-oblivion/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Per-game audit of Oblivion (TES4) compatibility — NIF v20.0.0.5, BSA v103, ESM stubs"
+description: "Per-game audit of Oblivion (TES4) compatibility — NIF v20.0.0.5 + the v10.x NetImmerse family, BSA v103, live ESM path"
 argument-hint: "--focus <dimensions>"
 ---
 
@@ -9,27 +9,72 @@ Deep audit of ByroRedux readiness for **The Elder Scrolls IV: Oblivion** content
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game-data locations,
+key reference docs, methodology, the path-reference convention, deduplication
+rules, and the base finding format. See `.claude/commands/_audit-severity.md`
+for the severity scale. Do not restate any of it here.
 
-## Game Context
+## What Makes Oblivion Different (the audit surface)
 
-| Aspect            | State                                                              |
+Oblivion is the **oldest** title in the lineage and exercises code paths no
+other game reaches. Two NIF eras coexist in vanilla `Oblivion - Meshes.bsa`:
+
+1. **The retail body** — NIF **v20.0.0.5** (`bsver=11`): inline strings, u16
+   flags, **no per-block size table**. This is what most clutter / architecture
+   / creature meshes are.
+2. **The NetImmerse tail** — a long tail of **v10.x** sub-versions (down to
+   pre-Gamebryo v3.3.0.13) authored years earlier. These have subtly different
+   field layouts gated by tight version bands in nif.xml, and — like v20.0.0.5 —
+   **no block_size table**, so a single N-byte under-read truncates the entire
+   downstream subtree.
+
+The v10.x tail is the Oblivion-unique risk. Retail FO3/FNV/Skyrim are all
+BS202 / 20.x and never touch these bands; a regression here is **silent and
+Oblivion-only**. The v10.x stride-drift family (#1506 NiInterpController /
+NiQuatTransform, #1507 NiPSysData + emitter, #1508 NiBlendInterpolator +
+ControlledBlock, #1509 NiGeomMorpherController `bsver > 9` gate) is **resolved**
+as of 2026-06-13; Oblivion-Meshes went from 56 truncated → ~10. This audit
+treats that family as a **regression-guard set**, not open work.
+
+| Aspect            | Current state (verify, don't trust this table blindly)              |
 |-------------------|--------------------------------------------------------------------|
-| NIF format        | v20.0.0.5 (no block sizes, inline strings, u16 flags)              |
-| BSA format        | v103 — archive opens AND extracts cleanly (147 629 / 147 629 vanilla files; nif_stats round-trips 8032 NIFs through the v103 decompression path) |
-| ESM parser        | Stub                                                               |
-| Parse rate        | 96.24% clean (7 730 / 8 032), 99.99% recoverable; 1 hard-fail (`marker_radius.nif`, #698)            |
-| Cell loading      | Interior renders end-to-end (Anvil Heinrich Oaken Halls). Exterior blocked on TES4 worldspace + LAND wiring (same shape as FO3 was — the original "BSA decompression" blocker is empirically refuted) |
+| NIF format        | v20.0.0.5 retail + v10.x NetImmerse tail (both sizeless)            |
+| BSA format        | v103 — opens AND extracts cleanly across all vanilla archives (regression guard, #699) |
+| ESM parser        | **Live** — `crates/plugin/src/esm/` with `parse_esm_cells` walker + ~25 record types, several with Oblivion-specific decode branches. NOT a stub (the per-game *legacy/tes4.rs* stub was removed under #390). |
+| Parse rate        | See ROADMAP.md Oblivion compat-matrix row (drifts after each sweep; do NOT hardcode a number here). Post-v10.x-family: ~10 residual NetImmerse truncations + 1 corrupt-by-design hard-fail (`#698` closed). |
+| Cell loading      | Interior renders end-to-end (Anvil Heinrich Oaken Halls). Exterior blocked on TES4 worldspace + LAND wiring (same shape FO3 was — *not* BSA v103) |
 | Reference data    | `/mnt/data/SteamLibrary/steamapps/common/Oblivion/Data/`           |
 
 ### Known Quirks (do NOT re-derive — verify still hold)
 
-- `user_version` only exists for files ≥ 10.0.1.8. Older NetImmerse files have `num_blocks` at the position `user_version` would occupy.
-- `BSStreamHeader` conditional is `version == 10.0.1.2 || user_version >= 3` (not `user_version >= 10`).
-- `NiTexturingProperty` reads `uint` count directly — **do NOT add a leading `Has Shader Textures: bool`**, nif.xml is wrong here and the Gamebryo 2.3 source is authoritative. Regressing this breaks every Oblivion clutter/book/furniture mesh (`afab3e7`).
-- Pre-Gamebryo v3.3.0.13 files (e.g. `meshes/marker_*.nif`) inline type names as sized strings instead of a global type table. Parser returns an empty `NifScene` with a debug log rather than failing.
-- Oblivion has **no per-block size table**. A single mis-aligned read poisons every subsequent block. Recovery via N23.10's `block_size`-advance path is unavailable.
-- `as_ni_node` walker must unwrap every NiNode subclass (`BsOrderedNode`, `NiBillboardNode`, `NiSwitchNode`, `NiLODNode`, etc.) so scene-graph walks descend correctly.
+- **`user_version` only exists for files ≥ v10.0.1.8.** Older NetImmerse files
+  have `num_blocks` where `user_version` would be. Confirm the
+  `version >= NifVersion::V10_0_1_8` guard in `crates/nif/src/header.rs`.
+- **BSStreamHeader presence is the nif.xml dual-band condition** (post-#170),
+  NOT the old `version == 10.0.1.2 || user_version >= 3`. The live guard is
+  `version == V10_0_1_2 || (user_version >= 3 && (version ∈ {V20_2_0_7,
+  V20_0_0_5} || (V10_1_0_0 <= version <= V20_0_0_4 && user_version <= 11)))`.
+  A v20.0.0.5 Oblivion file with `user_version >= 3` reads the header; a
+  non-Bethesda file outside the band must NOT (regression of #170).
+- **`NiTexturingProperty` reads a `uint` count directly** — do NOT add a
+  leading `Has Shader Textures: bool`. nif.xml is wrong here; the Gamebryo 2.3
+  source is authoritative. Regressing this breaks every Oblivion clutter / book
+  / furniture mesh. Test lives in `crates/nif/src/blocks/properties_tests.rs`.
+- **Oblivion has no per-block size table.** A single mis-aligned read poisons
+  every subsequent block — there is no `block_size`-advance recovery path
+  (unlike 20.2.0.7+). This is why every v10.x stride-drift bug truncated whole
+  subtrees rather than one field.
+- **Pre-Gamebryo v3.3.0.13 files** (e.g. `meshes/marker_*.nif`) inline type
+  names as sized strings instead of a global type table. Parser returns an
+  empty `NifScene` with a debug log rather than failing.
+- **NetImmerse v10.x leading group_id.** For versions in [10.0.0.0,
+  10.1.0.114), each block is preceded by a 4-byte group_id (`00 00 00 00`);
+  block content starts AFTER it. Mixing stream-relative vs file offsets is the
+  classic false-trail when chasing stride drift (see memory note
+  `nif_v10x_stride_drift_resolved`).
+- **`as_ni_node` walker must unwrap every NiNode subclass** (`BSOrderedNode`,
+  `NiBillboardNode`, `NiSwitchNode`, `NiLODNode`, …) so scene-graph walks
+  descend correctly.
 
 ## Parameters (from $ARGUMENTS)
 
@@ -41,59 +86,209 @@ See `.claude/commands/_audit-common.md` for project layout, game data locations,
 2. `mkdir -p /tmp/audit/oblivion`.
 3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
 4. Confirm `Oblivion/Data/` exists; if not, note which dimensions lose real-data validation.
+5. Read the current Oblivion row in `ROADMAP.md` (compat matrix) and
+   `docs/feature-matrix.md` so every status claim cites live numbers, not this file.
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: NIF v20.0.0.5 Parser Correctness
+Dimensions are ordered by Oblivion-specific risk: NIF version handling first
+(the v10.x tail is the unique surface), then archive, ESM, render, real-data.
+
+### Dimension 1: NIF Version Handling — v20.0.0.5 + the v10.x NetImmerse Tail
 **Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/header.rs`, `crates/nif/src/stream.rs`, `crates/nif/src/blocks/*.rs`, `docs/legacy/nif.xml`
-**Checklist**: Header `user_version` threshold (10.0.1.8, not 10.0.1.0). BSStreamHeader dual condition (`version == 10.0.1.2 || user_version >= 3`). NiTexturingProperty reads u32 count raw (no bool gate — regression guard). Inline-string block type handling for v3.3.0.13. No-block-size path does NOT rely on `block_size` for recovery. u16 vs u32 flag width per block. Oblivion-only block types dispatched: NiKeyframeController, NiSequenceStreamHelper, NiBillboardNode + 12 NiNode subclasses, NiLight hierarchy, NiUVController, NiCamera, NiTextureEffect, legacy particle stack (13 types), 11 BSShader*Property aliases. **NIF collision import (#1277 Task 1, `9c6096aa`)**: `BhkMultiSphereShape` (`crates/nif/src/import/collision.rs:301`) and `BhkConvexListShape` (`crates/nif/src/import/collision.rs:397`) now translate into `CollisionShape` (the former expands to `CollisionShape::Ball`/`Compound`, the latter to `ConvexHull`/`Compound`) rather than being silently dropped — verify Oblivion bhk shapes resolve through `resolve_shape_inner` (`extract_collision` chain) instead of falling out of the chain.
+**Entry points**: `crates/nif/src/header.rs`, `crates/nif/src/version.rs`, `crates/nif/src/stream.rs`, `crates/nif/src/blocks/`, `docs/legacy/`
+**Checklist**:
+- `user_version` threshold (`V10_0_1_8`) and the BSStreamHeader dual-band guard
+  in `header.rs` match nif.xml (see Known Quirks). The #170 regression test in
+  `crates/nif/src/header.rs` (tests module) must still assert a non-Bethesda
+  out-of-band file does NOT read the header.
+- The v10.x sub-version constants exist and are used as gate boundaries:
+  `V10_0_1_2`, `V10_1_0_0`..`V10_1_0_114`, `V10_2_0_0`, `V20_0_0_4`,
+  `V20_0_0_5` in `crates/nif/src/version.rs`.
+- **#1509 regression guard** (`crates/nif/src/blocks/controller/morph.rs`):
+  `NiGeomMorpherController` gates its trailing field on `bsver > 9` (NOT the old
+  `bsver != 0 && bsver <= 11`). `doghead.nif` is v10.2.0.0 **bsver 9** and must
+  keep the field; an off-by-band gate restarts `NiMorphData` 24 B late and
+  truncates the file. Tests: `crates/nif/src/blocks/controller/path_lookat_tests.rs`.
+- **#1506/#1507/#1508 regression guards** — the resolved stride-drift family.
+  Each was a `since`/`until` field gated on the wrong comparator dropping N
+  bytes. Confirm `NiInterpController`/`NiQuatTransform`, `NiPSysData` + emitter,
+  and `NiBlendInterpolator` + ControlledBlock all still land exactly on the next
+  block boundary in the v10.x bands. Any new truncation growth on Oblivion-Meshes
+  is a regression of this family — escalate, don't re-derive.
+- `NiTexturingProperty` reads u32 count raw, no bool gate (regression guard).
+- Inline-string block-type handling for pre-v3.3.0.13.
+- u16 vs u32 flag width per block in the v20.0.0.5 vs v10.x layouts.
+- Oblivion-only / legacy block types dispatched in `crates/nif/src/blocks/mod.rs`:
+  NiKeyframeController, NiSequenceStreamHelper, NiBillboardNode + NiNode
+  subclasses, NiLight hierarchy, NiUVController, NiCamera, NiTextureEffect, the
+  legacy particle stack, the BSShader*Property aliases.
+- **Collision import** (`crates/nif/src/import/collision.rs`): `BhkMultiSphereShape`
+  and `BhkConvexListShape` translate into `CollisionShape` (the former to
+  `Ball`/`Compound`, the latter to `ConvexHull`/`Compound`) via
+  `resolve_shape_inner` in the `extract_collision` chain — they must not fall
+  out silently. Verify against the `BhkMultiSphereShape` / `BhkConvexListShape`
+  downcast arms.
 **Output**: `/tmp/audit/oblivion/dim_1.md`
 
 ### Dimension 2: BSA v103 Archive
 **Subagent**: `general-purpose`
-**Entry points**: `crates/bsa/src/archive/`
-**Checklist**: BSA v103 header recognition (version byte) — **regression guard, decompression has been working since the 2026-04-17 sweep that confirmed 147 629 / 147 629 vanilla extractions clean**. Pre-2026-04-17 audits (and pre-#699 doc references) framed v103 as a blocker; that premise is dead. Verify the 16-byte folder-record offset is still respected (different from v104's 24 B), the bit 7-10 flag semantics still resolve via the v103 path, hash function still produces correct folder/file hashes, and full-archive sweep stays at 100 %. Only escalate to "open finding" if `meshes/*.nif` extraction starts failing on a previously-clean archive. Look for misleading diagnostics that paint v103 as broken without measurement.
+**Entry points**: `crates/bsa/src/archive/` (`mod.rs`, `open.rs`, `extract.rs`, `hash.rs`)
+**Checklist**: This is a **regression guard** — v103 decompression has worked
+end-to-end since 2026-04-17 (#699); the "v103 is broken" premise is dead, do not
+regenerate it.
+- `BSA_V_OBLIVION = 103` recognised in `open.rs`; rejection only outside {103,104,105}.
+- **Folder-record size**: v103 AND v104 are **16 bytes**; only v105 (Skyrim SE)
+  is 24. The live code is `if version == BSA_V_SKYRIM_SE { 24 } else { 16 }` in
+  `open.rs`. (The older skill text claiming "v104 = 24 B" was wrong — verify
+  against the constant, do not perpetuate it.)
+- v103 archive-flag semantics (e.g. the "Xbox archive" bit several vanilla v103
+  archives set, ignored for embedded names — `embed_file_names` gates on
+  `>= BSA_V_FO3_SKYRIM`).
+- Folder/file hash function in `hash.rs` still produces correct hashes.
+- Full-archive sweep stays at 100% extraction. Only escalate to an open finding
+  if `meshes/*.nif` extraction starts failing on a previously-clean archive.
 **Output**: `/tmp/audit/oblivion/dim_2.md`
 
-### Dimension 3: ESM Record Coverage
+### Dimension 3: ESM Record Coverage (live path, not a stub)
 **Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/` (TES4 records live alongside FNV / FO3 — the per-game legacy/tes4.rs stub was removed under `#390`)
-**Checklist**: TES4 header format differences (e.g., HEDR version 1.0 vs 0.94, group structure). What record types are Oblivion-unique (SPEL, ENCH, MGEF, BOOK, etc. — subset vs FNV)? Dialog/Quest record format: DIAL/INFO differ between Oblivion and later titles. CELL record format for Oblivion (XCLL, RCLR, etc.). Does `parse_esm_cells()` walker handle Oblivion's group layout? What would minimum "render a cell" require from the parser?
+**Entry points**: `crates/plugin/src/esm/` (`mod.rs`, `reader.rs`, `cell/`, `records/`)
+**Checklist**: TES4 records share the live ESM path with FNV/FO3 — there is no
+per-game stub (removed under #390). The parser already carries Oblivion-specific
+decode branches; the audit's job is correctness + coverage gaps, not "does it
+exist".
+- TES4 header (`HEDR` version 1.0 vs 0.94) and GRUP structure handled by the
+  walker (`crates/plugin/src/esm/records/grup_walker.rs`).
+- Oblivion-specific branches already present — verify they're correct, not
+  regressed: `flags_oblivion` + `is_oblivion` in
+  `crates/plugin/src/esm/records/actor.rs`; MGEF-by-code map (Oblivion 4-char
+  effect codes) and the CONT 4-byte-payload guard in
+  `crates/plugin/src/esm/records/tests.rs` / `container.rs`; CLMT three-entry
+  WLST in `crates/plugin/src/esm/records/climate.rs`.
+- The two ignored Oblivion real-data parity tests
+  (`clas_oblivion_knight_against_vanilla`, `race_oblivion_data_and_subs_against_vanilla`)
+  still pass against vanilla `Oblivion.esm` when un-ignored.
+- CELL walker: does `parse_esm_cells` (`crates/plugin/src/esm/cell/mod.rs`)
+  handle Oblivion's CELL group layout (XCLL lighting, RCLR, interior vs
+  exterior block grouping)?
+- DIAL/INFO format differs between Oblivion and later titles — does the
+  conversation-tree decode (M24.2) account for it, or silently mis-read?
+- What is the minimum record set the cell loader needs to place an Oblivion
+  exterior REFR? (Feeds the Blocker Chain.)
 **Output**: `/tmp/audit/oblivion/dim_3.md`
 
 ### Dimension 4: Rendering Path for Oblivion Shaders
 **Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/import/material/` (post-Session-35 split — mod / walker / shader_data), `crates/nif/src/import/walk/`, `byroredux/src/systems/particle.rs`, `crates/renderer/shaders/triangle.frag`
-**Checklist**: NiTexturingProperty → `MaterialInfo` pipeline (base slot 0, dark slot 1, normal from bump slot per `#131`, detail, glow, gloss). NiMaterialProperty color mapping (raw monitor-space per 0e8efc6). NiAlphaProperty blend factor extraction (ensure all Gamebryo AlphaFunction enum values route correctly). NiStencilProperty / NiZBufferProperty / NiVertexColorProperty / NiSpecularProperty / NiWireframeProperty / NiDitherProperty / NiShadeProperty — do we honor them or drop them silently? Vertex color interaction with material color. **#869 (part 1 + 2, `e3c54a32` + `c636b36a`)**: `NiWireframeProperty` wires to LINE pipeline variant; `NiShadeProperty.flat_shading` is consumed in the fragment shader. **#1239 Oblivion `NiPSysEmitter` version gating** (`97524667`): Oblivion's pre-Skyrim field layout is routed via nif.xml's version gate — regression would silently misparse particle emitter authoring. **Typed particle-emitter import → runtime path**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are now TYPED blocks (`crates/nif/src/blocks/particle.rs`) decoded by `extract_emitter_params` + `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs:670` / `:713`) and fed into `byroredux/src/systems/particle.rs::apply_emitter_params` (line 29) — verify an Oblivion legacy emitter that parses (per the #1239 gate) actually reaches the ECS authoring path and animates, not just parses-then-drops. **Disney BSDF gating regression guard (#1248-#1252)**: zero Oblivion materials author BGSM, so `MAT_FLAG_PBR_BSDF` must be 0 across the Oblivion.esm material universe — the Disney lobe at `triangle.frag` is unreachable for Oblivion. Audit pattern matches FNV/FO3: any Oblivion scene activating Burley / anisotropic GGX is a gate regression.
+**Entry points**: `crates/nif/src/import/material/` (`mod.rs`, `walker.rs`, `shader_data.rs`), `crates/nif/src/import/walk/`, `byroredux/src/systems/particle.rs`, `crates/renderer/shaders/triangle.frag`
+**Checklist**:
+- `NiTexturingProperty` → `MaterialInfo` pipeline (base slot 0, dark slot 1,
+  normal-from-bump per #131, detail, glow, gloss).
+- `NiMaterialProperty` color mapping is raw monitor-space (per 0e8efc6 — do NOT
+  `srgb_to_linear` legacy colors).
+- `NiAlphaProperty` blend-factor extraction routes every Gamebryo AlphaFunction
+  enum value.
+- `NiStencilProperty` / `NiZBufferProperty` / `NiVertexColorProperty` /
+  `NiSpecularProperty` / `NiWireframeProperty` / `NiDitherProperty` /
+  `NiShadeProperty` — honored or dropped silently? **#869 guards**:
+  `NiWireframeProperty` wires to the LINE pipeline variant;
+  `NiShadeProperty.flat_shading` is consumed in the fragment shader.
+- Vertex-color interaction with material color.
+- **#1239 Oblivion `NiPSysEmitter` version gating**: Oblivion's pre-Skyrim
+  emitter field layout is routed via nif.xml's version gate — a regression
+  silently misparses emitter authoring.
+- **Typed particle-emitter import → runtime path**: `NiPSysEmitter` /
+  `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are
+  TYPED blocks (`crates/nif/src/blocks/particle.rs`) decoded by
+  `extract_emitter_params` + `extract_emitter_rate`
+  (`crates/nif/src/import/walk/mod.rs`) and fed into
+  `apply_emitter_params` (`byroredux/src/systems/particle.rs`). Verify an
+  Oblivion emitter that parses (per the #1239 gate) actually reaches the ECS
+  authoring path and animates — not just parses-then-drops.
+- **Disney BSDF gating regression guard (#1248-#1252)**: zero Oblivion materials
+  author BGSM/`.mat`, so `MAT_FLAG_PBR_BSDF` (`crates/renderer/shaders/triangle.frag`)
+  must be 0 across the entire Oblivion material universe — the Disney lobe is
+  unreachable for Oblivion. Any Oblivion scene activating Burley / anisotropic
+  GGX is a gate regression.
 **Output**: `/tmp/audit/oblivion/dim_4.md`
 
-### Dimension 5: Real-Data Validation
-**Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
-**Checklist**: Current parse rate on `Oblivion - Meshes.bsa` (expect 100% / 7963+). Run `BYROREDUX_OBLIVION_DATA=... cargo run -p byroredux-nif --example nif_stats` and report block type histogram. Cross-check against the N26 coverage sweep — are any new block types appearing since then? Identify the remaining no-block-size files (if any) and whether they render meaningfully or are debug placeholders. Pick 3 representative interior meshes (e.g. Anvil Heinrich Oaken Halls chandelier, a book, a creature head) and trace them through `import_nif_scene` → verify expected mesh count + material chain.
+### Dimension 5: NIFAL Canonical Material Translation for Oblivion
+**Subagent**: `renderer-specialist`
+**Entry points**: `byroredux/src/material_translate.rs`, `crates/nif/src/import/material/walker.rs`, `crates/core/src/ecs/components/material.rs`, `byroredux/src/render/static_meshes.rs`, `docs/engine/nifal.md`
+**Checklist**: Trace an Oblivion `NiTexturingProperty`/`NiMaterialProperty`
+`MaterialInfo` through the single canonical boundary `translate_material`
+(`byroredux/src/material_translate.rs`) into the ECS `Material`.
+- Metalness/roughness arrive as plain `f32` carrying the `f32::NAN` sentinel
+  (`mesh.metalness_override`/`roughness_override` `.unwrap_or(f32::NAN)`) and are
+  resolved exactly once by `Material::resolve_pbr`
+  (`crates/core/src/ecs/components/material.rs`). Confirm no per-draw
+  `classify_pbr` reappears and that `static_meshes.rs` still reads
+  `m.roughness`/`m.metalness` directly with no render-time keyword scan.
+- `emissive_source` is tagged `EmissiveSource::Material` for Oblivion legacy
+  meshes via the `NiMaterialProperty` arm in
+  `crates/nif/src/import/material/walker.rs` (distinct from the Skyrim/FO4
+  `BSLightingShaderProperty` arm). Test:
+  `crates/nif/src/import/material/emissive_source_tests.rs`.
+- `MAT_FLAG_PBR_BSDF` stays 0 across the all-legacy Oblivion universe (shared
+  with Dim 4's Disney-gate guard; flag this once, cross-reference).
+See `/audit-nifal` for the cross-game canonical-tier audit; this is the
+Oblivion-specific slice.
 **Output**: `/tmp/audit/oblivion/dim_5.md`
 
-### Dimension 6: Blockers & Game-Specific Quirks
+### Dimension 6: Real-Data Validation
 **Subagent**: `general-purpose`
-**Entry points**: `ROADMAP.md` (Known Issues), `docs/audits/`
-**Checklist**: Real exterior blocker is TES4 worldspace + LAND wiring (same shape FO3 was in pre-cell-loader era — *not* BSA v103 decompression, which has been working end-to-end since 2026-04-17; see Dim 2 regression guard). Does the `--bsa` CLI path open + list + extract Oblivion archives end-to-end? Are there Oblivion-specific record types the cell loader would need beyond the FNV-aligned set? Are there animation blocks that parse but cannot play because scene-graph name resolution is missing? Does the pre-Gamebryo v3.3.0.13 fallback log as `warn` or `debug` (spam risk on full archive sweeps)? Any 100 %-parse-rate NIFs that would still render wrong visually (e.g., legacy particle emitters that parse but don't route to the renderer)? Don't re-derive "v103 is broken" — that finding has been dead since 2026-04-17 (#699).
+**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/examples/recovery_trace.rs`, `crates/nif/tests/parse_real_nifs.rs`, `crates/nif/tests/per_block_baselines.rs`
+**Checklist**:
+- Run `nif_stats` (and `nif_stats --tsv` for the per-type histogram) over
+  `Oblivion - Meshes.bsa`; compare clean/recovered/truncated counts against the
+  current ROADMAP Oblivion row AND the checked-in Oblivion baseline in
+  `per_block_baselines.rs`. Any `unknown` growth or `parsed` shrinkage is a
+  regression.
+- Run `recovery_trace` to enumerate the residual truncated files (~10 NetImmerse
+  v10.x after the family fix). Confirm they're the expected NetImmerse tail and
+  the single corrupt-by-design hard-fail, not new drift.
+- Cross-check the block-type histogram for any new types appearing since the last
+  sweep.
+- Pick 3 representative interior meshes (Anvil Heinrich Oaken Halls chandelier, a
+  book, a creature head) and trace them through `import_nif_scene` → verify
+  expected mesh count + material chain.
 **Output**: `/tmp/audit/oblivion/dim_6.md`
 
-### Dimension 7: NIFAL Canonical Material Translation for Oblivion
-**Subagent**: `renderer-specialist`
-**Entry points**: `byroredux/src/material_translate.rs`, `crates/core/src/ecs/components/material.rs`, `byroredux/src/render/static_meshes.rs`, `docs/engine/nifal.md`
-**Checklist**: Trace an Oblivion `NiTexturingProperty`/`NiMaterialProperty` `MaterialInfo` through the single canonical boundary `translate_material` (`byroredux/src/material_translate.rs:65`) into the ECS `Material`. Verify metalness/roughness arrive as plain `f32` carrying the `f32::NAN` sentinel (`material_translate.rs:149`–`150`, `metalness_override`/`roughness_override` unwrap) and are resolved exactly once by `material.resolve_pbr()` (`material_translate.rs:152` → `Material::resolve_pbr`, `crates/core/src/ecs/components/material.rs:588`) — confirm the deleted per-draw `Material::classify_pbr` does NOT reappear and that `static_meshes.rs:270` still reads `m.roughness`/`m.metalness` directly with no render-time keyword scan. Verify `emissive_source` is tagged `EmissiveSource::Material` for Oblivion legacy meshes (the `NiMaterialProperty.emissive_mult` provenance arm, `material.rs:354`+), distinct from the Skyrim/FO4 `BSLightingShaderProperty` arm. Confirm `MAT_FLAG_PBR_BSDF` (`crates/renderer/shaders/triangle.frag:204`) stays **0** across the all-legacy Oblivion material universe — zero Oblivion materials author BGSM/`.mat`, so the Disney lobe must never light. See also `/audit-nifal` for the cross-game canonical-tier audit; this dimension is the Oblivion-specific slice.
+### Dimension 7: Exterior Blocker Chain & Game-Specific Quirks
+**Subagent**: `general-purpose`
+**Entry points**: `ROADMAP.md` (Known Issues + compat matrix), `docs/feature-matrix.md`, `byroredux/src/cell_loader/`, `docs/audits/`
+**Checklist**:
+- The real exterior blocker is **TES4 worldspace + LAND wiring** (same shape FO3
+  was pre-cell-loader) — *not* BSA v103 decompression, which has worked
+  end-to-end since 2026-04-17 (#699). Do not regenerate the dead "v103 is
+  broken" framing.
+- Does the `--bsa` CLI path open + list + extract Oblivion archives end-to-end?
+- Are there Oblivion-specific record types the cell loader
+  (`byroredux/src/cell_loader/`) needs beyond the FNV-aligned set to place
+  exterior REFRs?
+- Animation blocks that parse but can't play because scene-graph name resolution
+  is missing?
+- Does the pre-v3.3.0.13 fallback log at `warn` or `debug` (spam risk on
+  full-archive sweeps)?
+- Any 100%-parse NIFs that would still render wrong (legacy particle emitters
+  that parse but don't route to the renderer — cross-check Dim 4)?
 **Output**: `/tmp/audit/oblivion/dim_7.md`
 
 ## Phase 3: Merge
 
 1. Read all `/tmp/audit/oblivion/dim_*.md` files.
 2. Combine into `docs/audits/AUDIT_OBLIVION_<TODAY>.md` with structure:
-   - **Executive Summary** — Current compatibility level (NIF parse, archive extract, ESM parse, render end-to-end), top blockers in priority order.
+   - **Executive Summary** — Current compatibility level (NIF parse incl. v10.x
+     tail, archive extract, ESM parse, render end-to-end), top blockers in
+     priority order. Cite ROADMAP/feature-matrix numbers, not this skill.
    - **Dimension Findings** — Grouped by severity per dimension.
-   - **Blocker Chain** — Sequential list of what must land to reach "exterior cell renders" — interiors already work end-to-end (Anvil Heinrich Oaken Halls). Real chain today is TES4 worldspace + LAND wiring → CELL exterior REFR placement → exterior bench. The pre-#699 chain rooted in "BSA v103 decompression" is a stale framing the audit must NOT regenerate.
-   - **Regression Guard List** — Issues previously fixed that this audit verified are still correct (NiTexturingProperty u32 count, BSStreamHeader conditional, `user_version` threshold).
+   - **Blocker Chain** — Sequential list to reach "exterior cell renders".
+     Interiors already work end-to-end (Anvil Heinrich Oaken Halls). Real chain:
+     TES4 worldspace + LAND wiring → CELL exterior REFR placement → exterior
+     bench. Do NOT regenerate the stale BSA-v103 framing.
+   - **Regression Guard List** — Previously-fixed items this audit verified still
+     hold: the v10.x stride-drift family (#1506/#1507/#1508/#1509),
+     `NiTexturingProperty` u32 count, BSStreamHeader dual-band (#170),
+     `user_version` threshold, BSA v103 extraction (#699), Disney-gate stays 0.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_OBLIVION_<TODAY>.md`

--- a/.claude/commands/audit-performance/SKILL.md
+++ b/.claude/commands/audit-performance/SKILL.md
@@ -1,123 +1,153 @@
 ---
-description: "Audit GPU/CPU performance — draw calls, memory, queries, allocations, hot paths"
+description: "Audit GPU/CPU performance — hot paths, allocations, draw batching, GPU memory pressure, SSBO sizing, telemetry"
 argument-hint: "--focus <dimensions> --depth shallow|deep"
 ---
 
 # Performance Audit
 
-Audit ByroRedux for GPU performance bottlenecks, CPU hot-path inefficiencies, memory allocation patterns, and rendering pipeline overhead.
+Audit ByroRedux for CPU hot-path inefficiency, per-frame allocation churn,
+draw-call/instancing waste, GPU memory pressure + eviction thrash, SSBO
+sizing, and pipeline overhead.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, methodology,
+deduplication, context rules, path-reference convention, and finding format.
+See `.claude/commands/_audit-severity.md` for the severity scale.
+**Do not re-derive memory ceilings** — `docs/engine/memory-budget.md` is the
+authoritative source for every SSBO size, LRU threshold, reserve floor,
+deferred-destroy depth, and VRAM budget cited below. Cite it; don't transcribe.
+
+Hardware target: **RTX 4070 Ti (12 GB) + Ryzen 7950X (16c/32t)**. RT VRAM
+minimum is 6 GB. A CPU bottleneck on this machine is a **bug**, not a tuning
+gap — the dimensions are ordered by per-frame impact accordingly.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,5`). Default: all 10.
-- `--depth shallow|deep`: `shallow` = check patterns only; `deep` = trace hot paths and measure impact. Default: `deep`.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,5`). Default: all 9.
+- `--depth shallow|deep`: `shallow` = pattern scan only; `deep` = trace hot paths and quantify. Default: `deep`.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: GPU Pipeline | GPU Memory | Draw Call Overhead | ECS Query Patterns | NIF Parse | CPU Allocations | TAA & GPU Skinning Cost | Material Table & SSBO Upload | World Streaming & Cell Transitions | Per-frame Translation & UI Overlay
+- **Dimension**: CPU Hot Paths | Draw & Instancing | GPU Memory Pressure | SSBO Sizing & Upload | GPU Pipeline | Skinning & BLAS | Streaming & Cells | NIF Parse | Telemetry & Origin Cost
 
-## Reference Telemetry
+## Bench-of-Record (do NOT hardcode numbers)
 
-`ScratchTelemetry` resource is refreshed per-frame; surface via `ctx.scratch` console command. Five tracked scratches: `gpu_instances`, `batches`, `indirect_draws`, `terrain_tile`, `tlas_instances`. Prospector baseline (1200 ent / 773 draws): 337 KB total, 320 B wasted. Use for diffing M40 cell transitions and R1 dedup wins.
+ROADMAP.md carries the **Bench-of-record** block (currently `R6a-stale-*`,
+flagged in ROADMAP itself as ~100+ commits stale and not gating). **Never
+copy FPS / frame-time / fence numbers into this skill** — they rot every
+session and ROADMAP marks them stale. Instead: read the current ROADMAP
+Bench-of-record + per-game compat table, run the bench described there, and
+report **observed-vs-ROADMAP deltas**. A regression is a delta, not an
+absolute. The canonical control benches named in ROADMAP are Prospector
+(FNV, glass-heavy interior), WhiterunBanneredMare (Skyrim, steady-state),
+and MedTekResearch01 (FO4, CSG-precombine-heavy).
 
-## Known Infrastructure Gap (2026-05-04)
+## Regression-Guard Posture
 
-**dhat / alloc-counter regression coverage is NOT wired.** The 2026-05-04 batch shipped 5 perf fixes (#823–#828, #830–#833) without quantitative regression guards for allocation counts. Audits proposing alloc-reduction findings MUST flag this gap explicitly: a fix that improves allocation behavior today can silently regress tomorrow. Until dhat-infra lands, "estimated" / "expected" allocation savings in fix commits are the only baseline. Treat any new alloc-hot-path finding as warranting a follow-up "wire dhat for this site" issue.
+The Session 46 perf batch (#1371–#1379) and Session 47 precision work
+(#1489–#1498) **already landed**. Treat their invariants as **regression
+guards to verify still hold**, not as findings to re-propose. A finding that
+re-proposes a landed fix is noise; a finding that the guard has eroded is real.
+Each dimension lists its guards inline — confirm the cited symbol is present
+before reporting anything in that area.
+
+**dhat alloc-bound coverage is now wired** (#1381). `dhat` is a workspace dep
+(`Cargo.toml`); the `byroredux` binary has a `dhat-heap` feature
+(`byroredux/Cargo.toml`) installing the profiling allocator, and the NIF crate
+ships quantitative bounds at `crates/nif/tests/heap_allocation_bounds.rs` +
+`crates/nif/tests/heap_allocation_bounds_geometry.rs`. So allocation findings
+on the NIF parse path are now *testable* — propose a bound, don't estimate.
+The **gap** that remains: per-frame render/ECS hot paths have NO dhat coverage
+(the profiler is a process singleton; the live engine loop is smoke-test
+territory). Allocation findings on render/ECS hot paths must still flag
+"no quantitative guard exists for this site."
 
 ## Phase 1: Setup
 
 1. Parse `$ARGUMENTS` for `--focus`, `--depth`
 2. `mkdir -p /tmp/audit/performance`
-3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/performance/issues.json`
-4. Scan `docs/audits/` for prior performance reports
+3. Dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/performance/issues.json`
+4. Read the current ROADMAP.md Bench-of-record block + compat table
+5. Scan `docs/audits/` for prior performance reports
 
 ## Phase 2: Launch Dimension Agents
 
-### Dimension 1: GPU Pipeline Efficiency
-**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (draw_frame), `crates/renderer/shaders/triangle.frag`, `crates/renderer/src/vulkan/volumetrics.rs` (M55 froxel grid), `crates/renderer/src/vulkan/bloom.rs` (M58 mip pyramid)
-**Checklist**: Unnecessary pipeline switches, redundant descriptor set binds, per-draw overhead (cmd_set_depth_bias on every draw?), shader branching cost (light loop divergence, RT ray query divergence), TLAS rebuild vs refit frequency, AS barrier placement, SVGF dispatch overhead per frame, TAA dispatch cost (fullscreen compute, RGBA16F sample bandwidth), caustic splat dispatch cost (fullscreen compute + atomic contention), composite pass fullscreen quad cost, G-buffer bandwidth (6 render targets per fragment), instanced draw batching (M31) effectiveness, volumetrics inject + integrate dispatch cost (`volumetrics.rs`: froxel grid `FROXEL_WIDTH`×`FROXEL_HEIGHT`×`FROXEL_DEPTH` = 160×90×128, single-ray TLAS shadow per froxel — pure O(froxels), must not scale with mesh count), bloom pyramid dispatch cost (`bloom.rs`: `BLOOM_MIP_COUNT` = 5 down-mips + 4 up-mips, 4-tap bilinear box — pure O(pixels)), Disney BSDF lobe ALU cost in `triangle.frag` (Trowbridge-Reitz + Burley diffuse + sheen, adapted GLSL-PathTracer/Burley-2012 — verify the lobe isn't evaluated for fragments that never reach it), and the `NUM_RESERVOIRS = 16` (triangle.frag:2664, bumped from 8) WRS shadow-ray reservoir loop — doubled streaming-RIS divergence cost vs the prior 8-reservoir loop.
+### Dimension 1: CPU Per-Frame Allocations & Hot Paths
+The highest-impact surface: a 16-core Ryzen should never be the bottleneck.
+**Entry points**: `byroredux/src/systems/animation.rs` (`animation_system`, `transform_propagation_system`), `byroredux/src/systems/bounds.rs` (world-bound propagation), `byroredux/src/systems/billboard.rs`, `byroredux/src/systems/particle.rs` (`apply_emitter_params`), `byroredux/src/render/mod.rs` (`build_render_data`), `crates/core/src/ecs/packed.rs` (dirty-set drain), `crates/core/src/ecs/resources.rs` (`SkinSlotPool` bone pool)
+**Checklist**: Per-frame `Vec`/`HashMap`/`String` allocations that should reuse a persistent scratch; `collect()` into a fresh Vec where `clear()+extend` would do; capacity churn from `mem::take`; per-entity allocation inside a per-frame loop.
+**Session 46 guards (verify intact, do NOT re-propose)**:
+- `PackedStorage::drain_dirty_into(&mut self, out: &mut Vec<EntityId>)` (#1371, `crates/core/src/ecs/packed.rs`) drains into a caller-supplied buffer via `Vec::append`, preserving `self.dirty` capacity. `take_dirty` (the `mem::take` path) zero-capacities and forces 0→N regrowth every frame — its use in `transform_propagation_system` / world-bound propagation is the regression pattern. Guard test: `drain_dirty_into_preserves_storage_capacity`.
+- `make_animation_system()` (#1372) captures two persistent scratch Vecs (`entities_scratch`, `playback_scratch`) reused via clear+extend; `make_billboard_system()` (#1374) captures `last_cam` and skips the whole `get_mut` loop when the camera hasn't moved (re-arming `GlobalTransform`'s `TRACK_CHANGES` dirty set every frame was defeating incremental bounds). Re-introducing per-frame `collect()` / unconditional billboard writes is the regression.
+- `build_debug_ui_snapshot` deep-clone (2× BTreeMap + Vec<String>) is gated on `debug_ui … visible` (#1376) — boot-default hidden = ~0 cost. A path that clones unconditionally regresses normal play.
+- Bone pool `next_slot` contracts after the idle-slot sweep (#1379, `SkinSlotPool` in `crates/core/src/ecs/resources.rs`): `free_list` is sorted and tail-popped while the largest free slot == `next_slot-1`, so `max_used_slot()` (the bone_world copy size + skin dispatch count) shrinks when a high-NPC scene unloads to a low-NPC one. A sweep that never contracts the issued range regresses steady-state cost after cell unload.
 **Output**: `/tmp/audit/performance/dim_1.md`
 
-### Dimension 2: GPU Memory & Allocation Patterns
-**Entry points**: `crates/renderer/src/vulkan/buffer.rs`, `crates/renderer/src/vulkan/allocator.rs`, `crates/renderer/src/vulkan/scene_buffer/`, `crates/renderer/src/vulkan/acceleration/`
-**Checklist**: Host-visible vs device-local usage, staging buffer lifecycle, BLAS scratch buffer reuse (high-water mark — does it grow unbounded?), per-frame SSBO/UBO mapped writes (flush needed?), texture upload staging reuse, gpu-allocator fragmentation, TLAS instance buffer sizing (2x padding policy), G-buffer memory footprint at high resolutions, SVGF history buffer double-allocation cost.
+### Dimension 2: Draw-Call & Instancing Efficiency
+**Entry points**: `byroredux/src/render/mod.rs` (`build_render_data` @272, `draw_sort_key` @187), `byroredux/src/render/static_meshes.rs` (draw enumeration), `crates/renderer/src/vulkan/context/draw.rs` (the per-instance `GpuInstance` build loop ~1792)
+**Checklist**: Sort-key effectiveness — `draw_sort_key` returns a 10-tuple `(u8,u8,u8,u8,u32×6)` ordering by pipeline/material/texture before depth; verify it actually minimizes pipeline + descriptor-set rebinds in the draw loop. Draw-call-count vs entity-count ratio (the compat table reports both per cell). Instanced batching — same mesh + multiple transforms should collapse, not emit N draws. Push-constant / per-draw state churn (`cmd_set_depth_bias` on every draw?). The parallel-sort gate: `draw_commands` switches to `par_sort_unstable_by_key` only at `>= 2000` commands (`render/mod.rs` ~398); verify the threshold matches the typical Bethesda cell range (400–1500) — a too-low gate pays rayon spin-up on small cells, too-high starves big exterior grids. **GT-presence hoist guard (#1377)**: the static-mesh loop does `if tq.get(entity).is_none() { continue; }` before the vis/wb sibling probes — dropping the hoist re-pays two SparseSet gets per GT-less entity.
 **Output**: `/tmp/audit/performance/dim_2.md`
 
-### Dimension 3: Draw Call & Batching Overhead
-**Entry points**: `byroredux/src/render/mod.rs` (build_render_data), `byroredux/src/render/static_meshes.rs` (draw enumeration), `crates/renderer/src/vulkan/context/draw.rs` (draw loop)
-**Checklist**: Sort key efficiency, texture bind frequency, pipeline switch frequency, push constant overhead per draw, potential for instanced drawing (same mesh multiple transforms), draw call count vs entity count ratio.
+### Dimension 3: GPU Memory Pressure & Eviction Thrash
+**Entry points**: `crates/renderer/src/vulkan/acceleration/predicates.rs` (`blas_budget_bytes` @551), `crates/renderer/src/vulkan/acceleration/blas_static.rs` (LRU eviction), `crates/renderer/src/texture_registry.rs`, `crates/renderer/src/mesh.rs` (vertex/index pool caps), `byroredux/src/asset_provider.rs` (BGSM/BGEM cache), `crates/renderer/src/deferred_destroy.rs`
+**Checklist** (ceilings: `docs/engine/memory-budget.md`): BLAS budget is **dynamic** — `device_local_bytes / 3` floored at `MIN_BLAS_BUDGET_BYTES` (256 MB) via `blas_budget_bytes`; eviction runs pre-batch + mid-batch at 90% budget, check interval `BATCH_EVICTION_CHECK_INTERVAL` = 64 builds. **Do NOT cite a static "1 GB" figure — that's stale doc.** Verify LRU (smallest last-used tick = victim) evicts smoothly during streaming with no rebuild thrash. Scratch high-water: `shrink_blas_scratch_to_fit` / `shrink_tlas_to_fit` reclaim at cell-unload with `BLAS_REBUILD_SLACK_BYTES`/`TLAS_*_SLACK_BYTES` headroom — verify they don't shrink below the reserve floors (`MIN_TLAS_INSTANCE_RESERVE` / `WORKING_SET_FLOOR` = 8192). `MeshRegistry` soft/hard caps (`VERTEX_POOL_*`, `INDEX_POOL_*`) emit warn/error via `check_pool_growth()` per upload — confirm caps fire, not silent overrun. BGSM/BGEM cache uses **half-eviction** (#1430, drop oldest N/2 via insertion-order `VecDeque`), NOT full flush — a full-flush path reintroduces the cold-restart thundering herd. `NifImportRegistry` 2048-entry LRU (`BYRO_NIF_CACHE_MAX`) bounds scene count. Deferred-destroy countdown = `MAX_FRAMES_IN_FLIGHT` (2); freeing earlier writes in-flight GPU memory (CRITICAL).
 **Output**: `/tmp/audit/performance/dim_3.md`
 
-### Dimension 4: ECS Query Patterns
-**Entry points**: `byroredux/src/systems/{animation, audio, billboard, bounds, camera, character, debug, light_anim, metrics, particle, water, weather}.rs` (post-Session-34 split; `systems.rs` is a thin module index), `crates/core/src/ecs/world.rs`, `crates/core/src/ecs/query.rs`, `crates/core/src/ecs/lock_tracker.rs`
-**Checklist**: Query lock duration (held across I/O or GPU ops?), redundant queries in same system, name index rebuild frequency, animation_system per-frame HashMap builds, transform_propagation_system BFS efficiency. `character.rs` (KCC, M28.5) and `light_anim.rs` (per-frame light animation) are additional per-frame query surfaces — verify they don't widen lock scope or re-query the same component multiple times per tick.
-**2026-05-04 baseline (must not regress)**:
-- `lock_tracker::held_others` Vec collection is `cfg(debug_assertions)`-gated (#823 ECS-PERF-01) — release builds were paying ~100 small allocs/frame for a no-op. Re-enabling for release is a regression
-- `NameIndex.map` is refilled in place (HashMap::clear + insert), NOT replaced via `HashMap::new() + std::mem::swap` (#824 ECS-PERF-02) — the swap path costs ~3 ms cell-stream-in spike
-- `transform_propagation_system` caches the root entity set keyed on `(Transform::len, Parent storage len OR 0 when Parent absent, world.next_entity_id())` (#825 ECS-PERF-03; see `crates/core/src/ecs/systems.rs` cache state + invalidation logic — third field is an `EntityId` value, not a count, and the Parent-len has `unwrap_or(0)` for scenes with no parent storage) — saves ~250 µs/frame at Megaton scale
-- `animation_system` hoists `events` / `seen_labels` scratches out of the per-entity loop and uses `clone` instead of `mem::take` so capacity persists across iterations (#828 ECS-PERF-06)
-- `World::despawn` poisoned-lock panic uses a `type_names` side-table to name the offending component (#466 E-03) — regression test must continue to pin the panic message format
+### Dimension 4: SSBO Sizing & Per-Frame Upload
+**Entry points**: `crates/renderer/src/vulkan/scene_buffer/constants.rs` (all `MAX_*`), `crates/renderer/src/vulkan/scene_buffer/upload.rs` (`upload_instances` @471, lights/camera/bones/materials/indirect), `crates/renderer/src/vulkan/material.rs` (MaterialBuffer dedup), `byroredux/src/material_translate.rs` (`translate_material` @73), `crates/core/src/ecs/components/material.rs` (`resolve_pbr` @638)
+**Checklist** (sizes: `docs/engine/memory-budget.md`): Scene SSBOs are resident, double-buffered (≈140 MB total). `MAX_INSTANCES` = `0x40000` (262 144); `MAX_INDIRECT_DRAWS` is aliased to it; `MAX_MATERIALS` = 16 384. Per-frame upload size must be **O(live data)** not O(capacity) — a full-capacity memcpy of a near-empty buffer is the waste. Host-visible mapped writes: flush correctness + no redundant re-upload of unchanged data. Material dedup ratio — N placements of one material → 1 `GpuMaterial`; report dedup hit-rate per cell; `MaterialTable::intern` must be O(1) amortized; upload size O(unique materials) not O(draws).
+**R1 + NIFAL guards (verify, do NOT re-propose)**:
+- `GpuInstance` is 112 B (down from ~400 B legacy) carrying per-DRAW data only; per-material fields read through `materials[material_id]` in the shader. Guards: `gpu_instance_is_112_bytes_std430_compatible`, `gpu_instance_field_offsets_match_shader_contract`, `gpu_instance_does_not_re_expand_with_per_material_fields` in `crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs`. A drift here is HIGH (shader-contract lockstep).
+- PBR resolved ONCE at import: `Material::metalness`/`roughness` are plain `f32` (not `Option` + per-draw classify), populated by `Material::resolve_pbr` after `translate_material`. The draw loop must NOT re-enter `classify_pbr_keyword` (`crates/core/src/ecs/components/material.rs` @449) per draw. Regression pattern: per-draw keyword scan, or reading metalness/roughness as `Option`. See `/audit-nifal` for the single-boundary contract.
 **Output**: `/tmp/audit/performance/dim_4.md`
 
-### Dimension 5: NIF Parse Performance
-**Entry points**: `crates/nif/src/lib.rs` (parse_nif), `crates/nif/src/import/`, `crates/nif/src/blocks/`, `crates/nif/src/blocks/particle.rs` (typed `NiPSysEmitter`/`NiPSysEmitterCtlr`/`NiPSysEmitterCtlrData`/`NiPSysGrowFadeModifier`), `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` @670, `extract_emitter_rate` @713), `crates/nif/src/stream.rs` (allocate_vec, read_pod_vec), `byroredux/src/streaming.rs` (pre_parse_cell with rayon)
-**Checklist**: Per-block allocation count, string cloning vs borrowing, Vec preallocation, SVD decomposition frequency (nalgebra overhead), block_size skip vs full parse for unused blocks, typed-particle-block parse cost — the new `NiPSysEmitter*` blocks parse during import; verify `extract_emitter_params`/`extract_emitter_rate` are a one-time import-side walk (not re-walked per frame; the per-frame side lives in Dim 6 / Dim 10). NIFAL note: the typed particle blocks feed the canonical translation tier — see also `/audit-nifal` for the no-fabrication / single-boundary contract on emitter param translation.
-**2026-05-04 baseline (must not regress)**:
-- `pre_parse_cell` parallelises the model loop with rayon's `into_par_iter` (#830 NIF-PERF-06, `byroredux/src/streaming.rs::pre_parse_cell`) — drops cell-stream latency ~6-7× on FNV/SE exterior grids. Serial fallback is a regression
-- `stream.allocate_vec::<T>(n)?;` is `#[must_use]` — bound-check-only call sites that discard the empty Vec are a leak/no-op pattern that #831 NIF-PERF-03 fixed at 9 sites; the `must_use` attribute prevents recurrence
-- 6 NIF bulk-array readers go through `read_pod_vec<T>` to collapse double allocation (#833 NIF-PERF-02). Direct allocate-then-loop-and-fill is the regression pattern. The helper has a top-of-module compile-error gate for big-endian hosts; bytemuck path was rejected because bytemuck is NOT a workspace dep despite some audits claiming it
-- Per-block parse-loop counters use `entry().get_mut() / insert` split, NOT `entry().or_insert(name.to_string())` (#832 NIF-PERF-01) — the to_string path leaked ~150 KB/cell of throwaway short-string allocations on Oblivion
+### Dimension 5: GPU Pipeline & Pass Efficiency
+**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (`draw_frame`), `crates/renderer/shaders/triangle.frag`, `crates/renderer/src/vulkan/volumetrics.rs` (M55), `crates/renderer/src/vulkan/bloom.rs` (M58), `crates/renderer/src/vulkan/svgf.rs`, `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/src/vulkan/composite.rs`, `crates/renderer/src/vulkan/ssao.rs`
+**Checklist**: Per-pass dispatches must be O(pixels) / O(froxels), never O(meshes). Volumetrics froxel grid (`volumetrics.rs`: 160×90×128, inject+integrate, single-ray TLAS shadow per froxel) must not scale with mesh count. Bloom pyramid (`bloom.rs`: 5 down + 4 up mips, 4-tap bilinear box) pure O(pixels). TLAS rebuild-vs-refit frequency + AS barrier placement (missing build→read barrier is HIGH). G-buffer bandwidth (7 attachments × 2 FIF). Disney BSDF lobe ALU in `triangle.frag` — verify lobes aren't evaluated for fragments that never reach them. Streaming-RIS shadow reservoir loop count — verify `NUM_RESERVOIRS` in `triangle.frag` against its `GpuLight` cost; a bumped count doubles divergence. `inv_vp` is computed once on the CPU and passed via UBO (cluster cull + SSAO read it) — a shader-side per-invocation `inverse()` (~100 ALU) is the regression. **Speculative-Vulkan caveat**: render-pass / barrier / pipeline-state findings whose failure mode is invisible to `cargo test` need RenderDoc evidence or a revert plan, not speculation — flag confidence explicitly.
 **Output**: `/tmp/audit/performance/dim_5.md`
 
-### Dimension 6: CPU Allocation Hot Paths
-**Entry points**: `byroredux/src/systems/animation.rs` (animation_system, transform_propagation_system; post-Session-34 split), `byroredux/src/systems/particle.rs` (apply_emitter_params — per-frame emitter param apply), `byroredux/src/render/mod.rs` (build_render_data)
-**Checklist**: Per-frame Vec allocations (should use pre-allocated buffers?), String allocations in name lookups (already fixed with FixedString?), HashMap rebuilds, temporary Vec<DrawCommand> growth, scratch reuse vs realloc — diff against `ScratchTelemetry` baseline (337 KB / 320 B wasted on Prospector). Per-frame emitter apply — `apply_emitter_params` runs every frame over emitter entities; verify it does not allocate per-entity (see Dim 10 for the full translation/overlay budget). Allocation findings should explicitly call out the dhat-infra gap (see Known Infrastructure Gap above) and note whether the proposed fix is testable today.
+### Dimension 6: Skinning & BLAS Cost (M29.x)
+**Entry points**: `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/shaders/skin_palette.comp`, `crates/renderer/shaders/skin_vertices.comp`, `crates/renderer/src/vulkan/acceleration/blas_skinned.rs` (refit), `crates/core/src/ecs/resources.rs` (`SkinSlotPool` @654: `pose_dirty` HashSet @688, `try_mark_pose_dirty` @913, `clear_pose_dirty` @929), `byroredux/src/render/skinned.rs` (per-frame mark/clear call sites)
+**Checklist + guards (verify, do NOT re-propose)**:
+- Bone-palette multiply runs as a dedicated compute pass (`SkinPaletteComputePipeline`, M29.5), not inline per skinned-vertex. `bind_inverses` is a **persistent** SSBO with a per-entity slot pool (M29.6) — uploaded ONCE at first-sight; per-frame upload size must be O(first-sight entities), not O(all skinned).
+- **Dispatch-dirty gate (#1195)**: skin dispatch is skipped when the bone-pose hash (FNV-1a over the bone-world slice) matches last frame. The dirty set is `pose_dirty: HashSet<EntityId>` on `SkinSlotPool` in `crates/core/src/ecs/resources.rs` (NOT the renderer layer); marked/drained via `try_mark_pose_dirty`/`clear_pose_dirty`; call sites in `byroredux/src/render/skinned.rs` (`clear_pose_dirty` before the dispatch loop, `try_mark_pose_dirty` inside). Regression: a path that bumps `dispatches_total` without consulting `pose_dirty.contains(entity)`. First-sight invariant: `SkinSlot.has_populated_output` is false until the first dispatch flips it — the gate MUST NOT skip before that flip.
+- **BLAS refit gate (#1196)**: `refit_skinned_blas` skips on `has_populated_output && !is_dirty && accel.has_skinned_blas(entity_id)` — all three live or first-sight/skip-safety breaks. Refit must dominate; full rebuild only on bone-count change or after `SKINNED_BLAS_REFIT_THRESHOLD` (600 frames). `SKINNED_BLAS_FLAGS` is deliberately `FAST_BUILD` not `FAST_TRACE` (memory-budget.md: +15.8 FPS on Prospector) — flipping it back is a regression.
+- **Descriptor-rewrite skip (#1197)**: `vkUpdateDescriptorSets` for the skin dispatch is skipped when the (input, palette) pair matches `SkinSlot.descriptor_bindings[frame]`; steady-state target is 0 writes after warm-up.
+- **Instrumentation**: per-pass GPU timer + `dispatches_skipped` on `SkinCoverageFrame` (#1194) — reachable via `bench-stats --break-down skin` / `skin.coverage` (byro-dbg). Dispatch-count findings can be **quantified, not estimated**.
 **Output**: `/tmp/audit/performance/dim_6.md`
 
-### Dimension 7: TAA & GPU Skinning Cost (M37.5 + M29.5 + M29.6)
-**Entry points**: `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/src/vulkan/acceleration/` (BLAS refit path), `crates/renderer/shaders/taa.comp`, `crates/renderer/shaders/skin_vertices.comp`, `crates/core/src/ecs/resources.rs` (`SkinSlotPool` @650 — owns `pose_dirty: HashSet<EntityId>` @684 + `try_mark_pose_dirty` @885 / `clear_pose_dirty` @905), `byroredux/src/render/skinned.rs` (per-frame mark/clear call sites — `clear_pose_dirty` @152, `try_mark_pose_dirty` @180)
-**Checklist**: TAA dispatch cost relative to scene cost (compute should be O(pixels) only, not O(pixels × meshes)). History image allocation: 2× RGBA16F at swapchain res — non-trivial at 4K (~64 MB). Skin compute dispatch frequency: per-skinned-mesh per-frame is the design; verify no dispatch for static meshes (pre-skin gating). BLAS refit cost vs full rebuild — refit must dominate; full rebuild only on bone count change. Per-skinned-mesh output buffer: lazily allocated, never re-uploaded with stale data. Bone palette upload: single buffer per frame, sized to MAX_TOTAL_BONES — no per-mesh upload churn. M29.3 raster path (when shipped): vertex shader reads pre-skinned vertex SSBO instead of inline matrix sum (~50 ALU ops saved per vertex).
-**M29.5 + M29.6 baselines (must not regress)**:
-- **M29.5 GPU bone-palette compute pass** (`4ac5ee8f`): the bone-palette matrix multiply (`palette[i] = bone_world[i] * bind_inverses[i]`) runs as a dedicated compute pass (`SkinPaletteComputePipeline` in `skin_compute.rs`), not inline per skinned-vertex dispatch. Regression pattern: a future change that re-inlines the multiply into `skin_vertices.comp`
-- **M29.6 persistent `bind_inverses` SSBO + per-entity slot pool** (`5be66790` + hotfix bundle #1191/#1192/#1193): `bind_inverses` is a **persistent** SSBO with a per-entity slot pool — each entity's bind-inverse matrices are uploaded ONCE at first-sight and never re-uploaded. Verify the per-frame upload size is `O(first-sight entities this frame)` × MBPM × 64 B, NOT `O(all skinned entities)` × that
-- **#1194 PERF-DIM7-INSTR landed** (`e5774b19`): per-pass GPU timer + `dispatches_skipped: u32` counter on `SkinCoverageFrame`. The timer is reachable through `bench-stats --break-down skin` and `skin.coverage` (byro-dbg). Audit findings on dispatch-count regressions can now be quantified, not estimated
-- **#1195 dispatch-dirty gate** (`57c34c7f`): skin compute dispatch is skipped when the entity's bone pose hash matches the previous frame (FNV-1a over the bone-world slice; ~0.5 µs/entity). The dirty set is `pose_dirty: HashSet<EntityId>` on `SkinSlotPool` — and that struct lives in `crates/core/src/ecs/resources.rs` (struct @650, field @684), NOT the renderer/skin_compute layer. It is populated/drained via `try_mark_pose_dirty` (@885) / `clear_pose_dirty` (@905); the per-frame mark+clear call sites are in `byroredux/src/render/skinned.rs` (`clear_pose_dirty` @152 must run before the dispatch loop, `try_mark_pose_dirty` @180 inside it). Regression pattern: a code path that increments `dispatches_total` without consulting `pose_dirty.contains(entity)`. First-sight invariant: `SkinSlot.has_populated_output = false` until the first successful dispatch flips it true; gate MUST NOT skip until that flip
-- **#1196 BLAS refit gate** (same commit `57c34c7f`): paired with #1195 — `refit_skinned_blas` skips when `slot.has_populated_output && !is_dirty && accel.has_skinned_blas(entity_id)`. Verify the three-way conjunction is all live; dropping any one breaks first-sight correctness or skip safety
-- **#1197 descriptor-set rewrite skip** (`946e95f9`): `vkUpdateDescriptorSets` for the skin compute dispatch is skipped when the live (input, palette) buffer pair matches the cached `SkinSlot.descriptor_bindings[frame]`. Per-frame counter `descriptor_writes_this_frame: Cell<u32>` surfaced through `tex.skin`. Steady-state target is 0 writes after the MAX_FRAMES_IN_FLIGHT-frame warm-up
+### Dimension 7: World Streaming & Cell Transitions (M40)
+**Entry points**: `byroredux/src/streaming.rs` (+ `streaming_tests.rs`), `byroredux/src/streaming_helpers.rs` (`drain_streaming_state` + `consume_streaming_payload`), `byroredux/src/cell_loader/transition.rs` (boundary cross), `byroredux/src/cell_loader/precombined.rs` (FO4 XCRI/XPRI), `byroredux/src/cell_loader/nif_import_registry.rs`, `byroredux/src/npc_spawn.rs`, `crates/sfmaterial/src/reader.rs` (Starfield CDB)
+**Checklist + guards**: Cell-transition stall budget (frame-time spike at boundary cross). `pre_parse_cell` is a two-phase pipeline: serial header extract feeds a rayon-parallel body parse (#877) — collapsing the phases regresses cell-stream latency ~6–7× on FNV/SE exterior grids. Small-model serial fast-path (#1262) skips rayon overhead below a size threshold inside `pre_parse_cell` — verify intact. NIF import cache hit-rate during streaming (cached across cells, not per-cell churn). BLAS LRU evicts smoothly under the dynamic budget (Dim 3) with no thrash. Shutdown drain joins the worker without leak. CDB parsed/indexed **once** per archive load (O(1) lookup), never per-cell or per-material. Multi-cell exterior grid is M40 follow-up; the single-cell baseline must not regress.
 **Output**: `/tmp/audit/performance/dim_7.md`
 
-### Dimension 8: Material Table & SSBO Upload (R1)
-**Entry points**: `crates/renderer/src/vulkan/material.rs`, `crates/renderer/src/vulkan/scene_buffer/` (MaterialBuffer SSBO), `byroredux/src/render/static_meshes.rs` (material intern call sites), `byroredux/src/material_translate.rs` (`translate_material` @65 — the single ImportedMesh→Material boundary), `crates/core/src/ecs/components/material.rs` (`Material::resolve_pbr` @588)
-**Checklist**: Dedup ratio — N placements of the same material should produce 1 GpuMaterial entry; report dedup hit rate per cell. Per-frame upload size — should be O(unique materials), not O(draws). Hash-table churn — `MaterialTable::intern` should be O(1) amortized per lookup. SSBO resize policy — does the buffer over-allocate and reuse, or realloc-shrink each frame? GpuInstance struct size win — verify the post-R1 size (target 112 B vs ~400 B legacy) is realized in the `gpu_instance_is_112_bytes_std430_compatible` + `gpu_instance_field_offsets_match_shader_contract` + `gpu_instance_does_not_re_expand_with_per_material_fields` tests in `scene_buffer/gpu_instance_layout_tests.rs`. Memory bandwidth — confirm material table upload doesn't replace dedup wins with bandwidth losses on large scenes.
-**NIFAL canonical-translation regression pin (must not regress)**: PBR is now resolved ONCE at import via the NIFAL tier — `Material::metalness` / `Material::roughness` are plain `f32` (not `Option` + per-draw `classify_pbr`), populated by `Material::resolve_pbr` after `translate_material`. The draw loop must NOT re-run keyword classification per draw: `byroredux/src/render/static_meshes.rs:270` documents "no per-draw keyword scan / classify_pbr fallback." Regression pattern: any code path that re-enters `classify_pbr_keyword` (crates/core/src/ecs/components/material.rs:432) from inside the per-draw enumeration, or that reads `metalness`/`roughness` as `Option`. See also `/audit-nifal` for the single-boundary / no-render-time-fallback contract this pin guards.
+### Dimension 8: NIF Parse Performance
+**Entry points**: `crates/nif/src/stream.rs` (`allocate_vec`, `read_pod_vec`), `crates/nif/src/import/`, `crates/nif/src/blocks/`, `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params`, `extract_emitter_rate`), `byroredux/src/streaming.rs` (`pre_parse_cell`)
+**Checklist + guards (now dhat-testable — propose bounds)**:
+- Bulk-array readers go through `read_pod_vec<T>` to collapse double-allocation (#833); direct allocate-then-loop-fill is the regression. The helper has a big-endian compile-error gate (bytemuck is NOT a workspace dep, despite some audits claiming it).
+- `stream.allocate_vec::<T>(n)?` is `#[must_use]` (#831); bound-check call sites that discard the empty Vec are the no-op pattern it fixed.
+- Per-block parse counters use `entry().get_mut()/insert` split, NOT `or_insert(name.to_string())` (#832) — the to_string path leaked ~150 KB/cell of throwaway short strings on Oblivion.
+- Verify typed particle blocks (`NiPSysEmitter*`) parse during import only — `extract_emitter_params`/`extract_emitter_rate` are a one-time import-side walk, not re-walked per frame (the per-frame side lives in Dim 1). These feed the NIFAL canonical tier — see `/audit-nifal`.
+- Allocation findings here CAN be bounded by a dhat test (see Regression-Guard Posture); the existing bounds cover the node + geometry + particle parse paths (`crates/nif/tests/heap_allocation_bounds.rs`, `heap_allocation_bounds_geometry.rs`). Propose extending them for new alloc sites rather than estimating.
 **Output**: `/tmp/audit/performance/dim_8.md`
 
-### Dimension 9: World Streaming & Cell Transitions (M40)
-**Entry points**: `byroredux/src/streaming.rs` (+ `streaming_tests.rs`), `byroredux/src/cell_loader/{load,unload,transition,exterior,references,spawn,partial,refr,precombined,terrain,water,index,euler,nif_import_registry,load_order}.rs` (post-Session-34 split — `cell_loader.rs` is a thin re-export, NOT the impl; `transition.rs` carries the boundary-crossing path and `precombined.rs` the FO4 XCRI/XPRI precombined-mesh path), `byroredux/src/npc_spawn.rs`, `byroredux/src/streaming_helpers.rs` (post-#1267 split — `drain_streaming_state` + `consume_streaming_payload` free-fn pair lives here), `crates/sfmaterial/src/` (Starfield `materialsbeta.cdb` reader — feeds material translation during SF cell streaming)
-**Checklist**: Cell-transition stall budget (frame-time spike at boundary crossing). Async pre-parse worker thread doing real work off-main (verify with profiler). NIF import cache hit rate during streaming (cached across cells, not per-cell churn). BLAS LRU eviction at the dynamic VRAM-derived budget (`device_local_bytes / 3`, floored at 256 MB per `acceleration/predicates.rs::blas_budget_bytes`) triggers smoothly during streaming, no thrash — NOT the stale-doc "1 GB" figure. Texture upload budget per frame during streaming — staging buffer reuse, not realloc. Shutdown drain joins worker without leaks. Single-cell-at-a-time today (Phase 1a/1b) — multi-cell exterior grid is M40 follow-up; baseline must not regress. Starfield CDB parse cost — the `sfmaterial` crate parses `materialsbeta.cdb` to feed material translation during SF (now walkable Cydonia) cell streaming; verify the CDB is parsed/indexed once (not re-parsed per cell or per material lookup).
-**2026-05-23 baselines (must not regress)**:
-- **#877 `pre_parse_cell` serial extract → parallel parse split** (`ba646f8b`): the streaming worker is a two-phase pipeline. Serial header extract (~ms) feeds a rayon-parallel body parse (~ms). Collapsing the phases is a regression pattern
-- **#1262 small-model rayon serial fast-path** (`6368b077`): models below a size threshold skip the rayon overhead. The threshold lives in `pre_parse_cell`; verify it's intact
-- **#1263/#1265 BSGeometry / NiTriShape bulk-read fast paths** (`dd02ad3f`): see NIF audit Dim 6 — these directly affect cell-streaming throughput on Starfield + FNV exterior grids
+### Dimension 9: Telemetry & Camera-Relative Origin Cost
+**Entry points**: `crates/renderer/src/vulkan/gpu_timers.rs` (`GpuPerFrameTimers`, `GpuTimerSnapshot`), `crates/core/src/ecs/resources.rs` (`ScratchTelemetry` @392), `byroredux/src/render/camera.rs` (`assemble_camera`, render-origin snap), `crates/renderer/src/vulkan/context/draw.rs` (per-instance model rebase ~1805, `origin_corrected_prev_view_proj`)
+**Checklist**:
+- **GPU-side timing**: `gpu_timers.rs` exposes per-pass `cmd_*_start/end` timestamp pairs (main render, skin dispatch, BLAS refit, TLAS build, TAA, SVGF, SSAO, bloom, composite, cluster cull, caustic splat, volumetrics) read back via `read_and_reset` into a `GpuTimerSnapshot`. Findings that claim a pass is "expensive" should cite these timers (reachable via `bench-stats`), not guess. Verify timers don't introduce a per-frame stall (timestamp query readback must use the prior frame's results, not block on the current).
+- **CPU-side scratch telemetry**: `ScratchTelemetry` (refreshed per-frame, surfaced via `ctx.scratch`) tracks `gpu_instances` / `batches` / `indirect_draws` / `terrain_tile` / `tlas_instances` capacity-vs-used + wasted bytes. Diff against it for over-reserved scratch.
+- **Camera-relative origin cost (#1492–#1496, #markarth-precision)**: the render origin is snapped to the 4096-unit cell grid (`RENDER_ORIGIN_SNAP`), so it only moves on a cell-boundary crossing. CPU cost: `assemble_camera` builds an extra relative view-proj (one `look_at_rh` per frame), and the per-instance build loop in `draw_frame` subtracts the origin from each model translation column (`m[12..14] - render_origin`, 3 subtractions inside the already-O(visible-instances) loop). This is **negligible added CPU** — verify it stays inside the existing loop and is not refactored into a second full pass over instances. On a grid crossing, `origin_corrected_prev_view_proj` right-multiplies the previous VP by `translation(O₂−O₁)` so TAA/SVGF history is NOT reset (#1489) — a path that drops history on every crossing is a HIGH perf+quality regression (full-screen flash per cell edge).
 **Output**: `/tmp/audit/performance/dim_9.md`
-
-### Dimension 10: Per-frame Translation & UI Overlay Cost
-**Entry points**: `byroredux/src/systems/particle.rs` (`apply_emitter_params` @29 — per-frame), `crates/debug-ui/src/lib.rs` (egui overlay, runs every frame before `draw_frame`), `crates/sfmaterial/src/reader.rs` (`ComponentDatabaseFile::parse` — Starfield CDB)
-**Checklist**: NIFAL particle emitter per-frame apply — `apply_emitter_params` reads the import-side emitter params (Dim 5) and applies them per-frame; verify it's O(emitter entities), uses pre-allocated scratch, and does NOT re-derive params from the NIF each frame (translation belongs at import). egui debug-UI overlay cost — the `debug-ui` crate runs an egui context EVERY frame (build + tessellate + texture upload + a Vulkan pass over the composite output); confirm it is gated behind the F-key toggle so a disabled overlay costs ~0 (no tessellation / no descriptor churn when hidden), and that texture uploads are incremental (only new/changed egui textures, not a full re-upload per frame). sfmaterial CDB parse cost — `ComponentDatabaseFile::parse` must run once per archive load, indexed for O(1) lookup, never per-frame or per-material (cross-ref Dim 9 streaming). NIFAL note: emitter param translation is part of the canonical tier — see also `/audit-nifal`.
-**Output**: `/tmp/audit/performance/dim_10.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/performance/dim_*.md` files
-2. Combine into `docs/audits/AUDIT_PERFORMANCE_<TODAY>.md` with structure:
-   - **Executive Summary** — Total findings by severity, estimated FPS impact
-   - **Hot Path Analysis** — Table of per-frame operations with estimated cost
-   - **Findings** — Grouped by severity (CRITICAL first), deduplicated
-   - **Prioritized Fix Order** — Quick wins first (cache reuse, preallocation), then architectural changes
+1. Read all `/tmp/audit/performance/dim_*.md`
+2. Combine into `docs/audits/AUDIT_PERFORMANCE_<TODAY>.md`:
+   - **Executive Summary** — findings by severity; observed-vs-ROADMAP bench delta (not absolute FPS)
+   - **Hot Path Analysis** — per-frame CPU + per-pass GPU cost table, sourced from `gpu_timers` / `ScratchTelemetry` where available
+   - **Findings** — grouped by severity (CRITICAL first), deduplicated, eroded-guards called out separately from new issues
+   - **Prioritized Fix Order** — quick wins (scratch reuse, preallocation, gate restoration) before architectural changes
 3. Remove cross-dimension duplicates
 
 ## Phase 4: Cleanup

--- a/.claude/commands/audit-publish/SKILL.md
+++ b/.claude/commands/audit-publish/SKILL.md
@@ -5,121 +5,201 @@ argument-hint: "<path-to-audit-report>"
 
 # Audit → GitHub Issues Publisher
 
+Turn a finished audit report (`docs/audits/AUDIT_<TYPE>_<DATE>.md`) into one GitHub
+issue per actionable finding, with dedup, label reconciliation, and a completeness
+gate so nothing silently slips through.
+
+Shared protocol (read, do not restate): `.claude/commands/_audit-common.md` —
+the **Base Per-Finding Format** (the exact field set this skill parses) and the
+**Deduplication (MANDATORY)** flow. Severity scale: `.claude/commands/_audit-severity.md`.
+
+This skill is the *only* place issues are created. Audit skills stop at writing the
+report; they never call `gh issue create`.
+
 ## Process
 
-1. **Load the report** at `$ARGUMENTS` (e.g. `docs/audits/AUDIT_RENDERER_2026-04-04.md`)
+### 1. Load + parse the report
 
-2. **Parse findings** — extract each finding block (ID, severity, location, description, status)
+Read `$ARGUMENTS` (e.g. `docs/audits/AUDIT_RENDERER_2026-04-04.md`). Each finding block
+follows _audit-common's Base Per-Finding Format: `### <ID>: <Title>` then `Severity`,
+`Dimension`, `Location`, `Status`, `Description`, `Evidence`, `Impact`, `Related`,
+`Suggested Fix`. Extract those fields per finding; ID + Severity + Location + Status
+are required, the rest carry into the issue body.
 
-   **Path-validation gate (run first)**: before validating any finding, run the shared
-   path gate so a report written against pre-split paths fails fast rather than producing
-   issues that point at files that no longer exist:
-   ```bash
-   .claude/commands/_audit-validate.sh        # exit 1 on any STALE backticked path
-   ```
-   This is the same `#1114` / TD7-050 gate the audit skills are checked against. The
-   Session 34/35 file→dir splits are exactly what it catches — a finding whose
-   `Location:` points at a flat module that is now a directory (e.g. the old
-   *archive.rs* → `crates/bsa/src/archive/`, *render.rs* → `byroredux/src/render/`,
-   *import/walk.rs* → `crates/nif/src/import/walk/`,
-   *blocks/collision.rs* → `crates/nif/src/blocks/collision/`,
-   *blocks/tri_shape.rs* → `crates/nif/src/blocks/tri_shape/`) must be
-   re-mapped (step 4), not filed verbatim. Note `byroredux/src/systems.rs` and
-   `byroredux/src/cell_loader.rs` still exist as thin re-export shims **next to** their
-   `systems/` and `cell_loader/` dirs — a `Location` there should be re-pointed to the
-   owning submodule (e.g. `byroredux/src/systems/particle.rs`).
+### 2. Path-validation gate (run first, before judging any finding)
 
-3. **Filter** — only process findings with status **NEW**. Skip Existing/Regression (already tracked).
+```bash
+.claude/commands/_audit-validate.sh        # exit 1 on any STALE backticked path
+```
 
-4. **Validate each finding** against current code:
-   - Read the referenced file at the specified lines
-   - **Re-map before judging**: if the `Location:` file no longer exists but the code does
-     (a module split, not a fix), resolve it to its current submodule and update the
-     finding's path/line — do NOT mark it STALE/UNVERIFIABLE for a path move alone. Line
-     numbers drift after a split; trust the symbol (`grep -rn <fn/struct>`), not the line.
-     Examples seen in the wild: material logic now lives at
-     `byroredux/src/material_translate.rs` (`translate_material`) +
-     `crates/core/src/ecs/components/material.rs` (`Material::resolve_pbr`), not in the old
-     import/material call sites; the per-frame particle system is
-     `byroredux/src/systems/particle.rs` (`apply_emitter_params`), not a flat `systems.rs`.
-   - Mark as: **CONFIRMED** (issue exists), **STALE** (already fixed), **UNVERIFIABLE** (can't confirm)
-   - Skip STALE findings
+This is the `#1114` / TD7-050 gate. It fails fast when a report was written against
+pre-split paths — a `Location:` pointing at a file that is now a directory. Common
+splits to expect (old single file → current dir; the old paths are
+deliberately un-backticked since they no longer exist): *archive.rs* →
+`crates/bsa/src/archive/`, *render.rs* → `byroredux/src/render/`,
+*import/walk.rs* → `crates/nif/src/import/walk/`, *blocks/collision.rs* →
+`crates/nif/src/blocks/collision/`, *blocks/tri_shape.rs* →
+`crates/nif/src/blocks/tri_shape/`.
+`byroredux/src/systems.rs` and `byroredux/src/cell_loader.rs` survive as thin re-export
+shims **beside** their `systems/` and `cell_loader/` dirs — re-point a `Location` there
+to the owning submodule (e.g. `byroredux/src/systems/particle.rs`).
 
-5. **Deduplication check**:
-   ```bash
-   gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state
-   ```
-   Skip findings that match an existing OPEN issue title/description.
+### 3. Filter by status
 
-6. **Completeness checks** — for each CONFIRMED finding, generate checkboxes:
+Process only findings with status **NEW**. `Existing: #NNN` and `Regression of #NNN`
+are already tracked upstream — record them in the summary, do not re-file.
 
-   ```markdown
-   ## Completeness Checks
-   - [ ] **UNSAFE**: If fix involves unsafe, safety comment explains the invariant
-   - [ ] **SIBLING**: Same pattern checked in related files (other shader types, other block parsers)
-   - [ ] **DROP**: If Vulkan objects change, verify Drop impl still correct
-   - [ ] **LOCK_ORDER**: If RwLock scope changes, verify TypeId ordering
-   - [ ] **FFI**: If cxx bridge touched, verify pointer lifetimes
-   - [ ] **CANONICAL-BOUNDARY**: If fix touches `byroredux/src/material_translate.rs::translate_material`, `Material::resolve_pbr` (`crates/core/src/ecs/components/material.rs`), or the import-walk emitter params (`crates/nif/src/import/walk/mod.rs::extract_emitter_params`/`extract_emitter_rate`), verify per-game logic stays at the NIFAL parser→`Material` boundary — never pushed into the shaders/renderer and never re-derived at render time. See also `/audit-nifal`.
-   - [ ] **TESTS**: Regression test added for this specific fix
-   ```
+### 4. Validate each NEW finding against current code
 
-7. **Create GitHub issues** for each CONFIRMED + NEW finding:
-   ```bash
-   gh issue create --repo matiaszanolli/ByroRedux \
-     --title "<ID>: <title>" \
-     --body "<finding details + completeness checks>" \
-     --label "<severity>,<domain>,bug"
-   ```
+- Read the referenced file at the symbol (not the line — line numbers drift; trust
+  `grep -rn <fn/struct>`).
+- **Re-map before judging.** If the `Location:` file no longer exists but the code does
+  (a split, not a fix), resolve to the current submodule and update the finding's path
+  before filing. Do NOT mark a path move as STALE. Examples: material logic lives at
+  `byroredux/src/material_translate.rs` (`translate_material`) +
+  `crates/core/src/ecs/components/material.rs` (`Material::resolve_pbr`); the per-frame
+  particle system is `byroredux/src/systems/particle.rs` (`apply_emitter_params`), fed by
+  `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` / `extract_emitter_rate`).
+- Classify: **CONFIRMED** (bug still present) → file it; **STALE** (already fixed) → skip,
+  record in summary; **UNVERIFIABLE** (cannot confirm against code) → skip, record in summary.
 
-   **Domain vocabulary**: the canonical `<domain>` list lives at `.claude/commands/_audit-common.md`
-   (the "Domain Labels" section). It currently enumerates
-   `ecs, renderer, vulkan, pipeline, memory, sync, platform, cxx, nif, bsa, esm, animation, legacy-compat, performance, safety, tech-debt`.
-   With 19 crates now under `crates/` (including `crates/audio/`, `crates/spt/`,
-   `crates/sfmaterial/`, `crates/debug-ui/`), a finding in one of those subsystems has no
-   matching label yet. Use the closest existing domain (e.g. `renderer` for `debug-ui`'s
-   egui pass, `nif`/`bsa` for `sfmaterial` CDB parsing) and flag the gap; if the new
-   `audio`/`spt`/`sfmaterial`/`debug-ui` labels get added to the canonical list in
-   `_audit-common.md`, prefer them. (NIFAL canonical-translation findings map to the
-   subsystem they live in — `nif`/`renderer` — and should cross-link `/audit-nifal`.)
+### 5. Deduplicate against open issues
 
-   **Audit-type label table**: the report family (parsed from the `AUDIT_<TYPE>_<DATE>.md`
-   filename) selects the type label and any extra family label. Default is `bug`; the rest:
+Follow _audit-common's **Deduplication** flow:
 
-   | Report (`AUDIT_<TYPE>_*.md`) | Default `<domain>` | Type label | Extra label |
-   |------------------------------|--------------------|------------|-------------|
-   | `AUDIT_TECH_DEBT_*`          | (per finding)      | `maintenance` | `tech-debt` |
-   | `AUDIT_RENDERER_*`           | `renderer`         | `bug`      | —           |
-   | `AUDIT_STARFIELD_*` / `AUDIT_FNV_*` / `AUDIT_FO3_*` / `AUDIT_FO4_*` | `nif` (+ per finding) | `bug` | `legacy-compat` |
-   | `AUDIT_AUDIO_*`              | `audio` (fallback `renderer`) | `bug` | — |
-   | `AUDIT_CONCURRENCY_*`        | `sync`             | `bug`      | —           |
-   | `AUDIT_ECS_*`                | `ecs`              | `bug`      | —           |
-   | `AUDIT_LEGACY_COMPAT_*`      | `legacy-compat`    | `bug`      | —           |
-   | `AUDIT_INCREMENTAL_*`        | (per finding)      | `bug`      | —           |
-   | `AUDIT_NIFAL_*`              | `nif`              | `bug`      | —           |
+```bash
+mkdir -p /tmp/audit
+gh issue list --repo matiaszanolli/ByroRedux --limit 400 --json number,title,state,labels \
+  > /tmp/audit/issues.json
+```
 
-   Per-finding domain always wins over the table default. For `AUDIT_TECH_DEBT_*.md` the
-   final set is `<severity>,<domain>,tech-debt,maintenance` (tech debt isn't a bug). Any
-   future family follows the same shape (e.g. a hypothetical `AUDIT_DOCS_*.md` → `docs`
-   label + `documentation` type).
+Match each CONFIRMED finding's keywords against existing **open** issue titles/bodies.
+On a match, skip and record `Existing #NNN` in the summary. If a *closed* issue matches
+and the bug is back, file it but title/note it as a regression of `#NNN`.
 
-8. **Save to local tracking**:
-   ```bash
-   mkdir -p .claude/issues/<NUMBER>
-   ```
-   Write `ISSUE.md` with the finding details.
+### 6. Reconcile labels against the live repo (do this once, before any create)
 
-   **Immutable-snapshot convention** (TD10-001 / #1156): `.claude/issues/<N>/ISSUE.md` is a snapshot of the issue **as filed**, not a live mirror. GitHub is the authoritative source for current state — query via `gh issue view <N> --json state` when you need the live state. Do NOT write a `State:` or `Status:` field; if writing the body via `gh issue view --json body`, the state in the resulting JSON reflects fetch time, not now. Audits that need live state should query GitHub, not read the local file. This convention applies symmetrically to `INVESTIGATION.md` and any sibling files created by `/fix-issue`.
+The set of labels that exist in the repo is authoritative — `gh issue create` rejects an
+unknown label. Pull the live set first:
 
-9. **Summary** — print a table:
-   | Finding | Action | Reason |
-   |---------|--------|--------|
-   | REN-001 | Created #42 | NEW, CONFIRMED |
-   | REN-002 | Skipped | Existing #38 |
-   | REN-003 | Skipped | STALE |
-   | NIF-004 | Created #43 | NEW, CONFIRMED |
+```bash
+gh label list --repo matiaszanolli/ByroRedux --limit 200 --json name --jq '.[].name' \
+  > /tmp/audit/labels.txt
+```
 
-10. **Suggest next step**: For each created issue, note:
-    ```
-    Fix with: /fix-issue <number>
-    ```
+Every label this skill applies MUST appear in that file. The mapping below reflects how
+the repo is *actually* labeled (verified against label-usage counts across all issues) —
+**not** the broader vocabulary in _audit-common's "Domain Labels" list, several of which
+have no label in this repo.
+
+**Severity** (always exactly one, all exist): `critical` · `high` · `medium` · `low`.
+
+**Domain** (zero or more; only these exist as labels):
+`ecs` · `renderer` · `vulkan` · `pipeline` · `memory` · `sync` · `cxx` · `nif` ·
+`nif-parser` · `import-pipeline` · `animation` · `legacy-compat` · `performance` ·
+`safety` · `tech-debt` · `info`.
+
+**Type** (one): `bug` · `enhancement` · `documentation`. There is **no** `maintenance`
+label — tech-debt findings use the `tech-debt` domain label plus `bug` (or `documentation`
+for doc-rot), never `maintenance`.
+
+**Domain mapping for subsystems with no own label** — map to the closest existing label
+and note the gap in the summary; never invent a label:
+
+| Finding subsystem | Apply (exists) | NOT (does not exist) |
+|-------------------|----------------|----------------------|
+| NIF parser / block dispatch | `nif-parser` (primary) `nif` (format tag) | — |
+| BSA / BA2 / CSG archive readers | `import-pipeline` (or `nif-parser`) | `bsa` |
+| ESM / cell / plugin loading | `import-pipeline` + `legacy-compat` | `esm` |
+| Audio (M44) | `legacy-compat` / `tech-debt` per finding | `audio` |
+| SpeedTree / sfmaterial / debug-ui / facegen / physics / platform | closest of `renderer` / `import-pipeline` / `legacy-compat` | `spt` `sfmaterial` `debug-ui` `platform` |
+| NIFAL canonical-translation | the subsystem it lives in (`nif-parser` / `renderer`) + cross-link `/audit-nifal` | — |
+
+If a finding genuinely has no reasonable existing label, file it with severity + `bug`
+only and flag the missing-label gap in the summary. Do **not** `gh label create` ad hoc —
+new labels are a deliberate repo decision, not a per-publish side effect.
+
+**Report-family defaults** — the `AUDIT_<TYPE>_<DATE>.md` filename selects a default
+domain/type; a per-finding `Dimension`/domain always overrides it:
+
+| Report (`AUDIT_<TYPE>_*.md`) | Default domain | Type | Extra |
+|------------------------------|----------------|------|-------|
+| `AUDIT_RENDERER_*` | `renderer` | `bug` | — |
+| `AUDIT_ECS_*` | `ecs` | `bug` | — |
+| `AUDIT_CONCURRENCY_*` | `sync` | `bug` | — |
+| `AUDIT_NIF_*` / `AUDIT_NIFAL_*` | `nif-parser` | `bug` | — |
+| `AUDIT_FNV_*` / `AUDIT_FO3_*` / `AUDIT_FO4_*` / `AUDIT_SKYRIM_*` / `AUDIT_OBLIVION_*` / `AUDIT_STARFIELD_*` | `nif-parser` (+ per finding) | `bug` | `legacy-compat` |
+| `AUDIT_LEGACY_COMPAT_*` | `legacy-compat` | `bug` | — |
+| `AUDIT_AUDIO_*` | (per finding; `legacy-compat`) | `bug` | — |
+| `AUDIT_TECH_DEBT_*` | (per finding) | `bug` | `tech-debt` |
+| `AUDIT_INCREMENTAL_*` | (per finding) | `bug` | — |
+
+For `AUDIT_TECH_DEBT_*` the final set is `<severity>,<domain?>,tech-debt,bug` (doc-rot
+findings swap `bug` → `documentation`). For everything else: `<severity>,<domain>,bug`.
+
+### 7. Build the completeness checklist (per CONFIRMED finding)
+
+Append to each issue body. Drop rows that can't apply (e.g. omit FFI if the fix is
+NIF-only):
+
+```markdown
+## Completeness Checks
+- [ ] **UNSAFE**: If the fix adds `unsafe`, a safety comment states the upheld invariant
+- [ ] **SIBLING**: Same pattern checked in related files (other shader types, other block parsers)
+- [ ] **DROP**: If Vulkan objects change, the Drop impl is still reverse-order correct
+- [ ] **LOCK_ORDER**: If a RwLock scope changes, TypeId-sorted acquisition is preserved
+- [ ] **FFI**: If the cxx bridge is touched, pointer lifetimes across the boundary are sound
+- [ ] **CANONICAL-BOUNDARY**: If the fix touches `byroredux/src/material_translate.rs` (`translate_material`), `Material::resolve_pbr` (`crates/core/src/ecs/components/material.rs`), or the emitter params in `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` / `extract_emitter_rate`), per-game logic stays at the NIFAL parser→`Material` boundary — never pushed into shaders/renderer, never re-derived at render time. See `/audit-nifal`.
+- [ ] **TESTS**: A regression test pins this specific fix
+```
+
+### 8. Create the issue
+
+```bash
+gh issue create --repo matiaszanolli/ByroRedux \
+  --title "<ID>: <title>" \
+  --body  "<description + evidence + impact + suggested fix + completeness checks>" \
+  --label "<severity>,<domain>,<type>"
+```
+
+`--label` takes a comma-separated list. Every token must be in `/tmp/audit/labels.txt`
+(step 6). If `gh` rejects a label, the reconciliation missed one — fix the mapping, do not
+drop the finding silently.
+
+### 9. Snapshot to local tracking
+
+```bash
+mkdir -p .claude/issues/<NUMBER>
+```
+
+Write `.claude/issues/<NUMBER>/ISSUE.md` with the finding details.
+
+**Immutable-snapshot convention** (TD10-001 / #1156): this file is the issue *as filed*,
+not a live mirror. GitHub is authoritative for current state — query
+`gh issue view <N> --json state` when live state is needed. Do **not** write a
+`State:`/`Status:` field. The convention applies symmetrically to `INVESTIGATION.md` and
+any sibling created by `/fix-issue`.
+
+### 10. Completeness summary (the gate)
+
+Every NEW finding must reach a terminal action — created, skipped-as-duplicate, or
+skipped-with-reason. Print the table and assert the count matches: NEW findings parsed ==
+(Created + Skipped). A NEW finding that is neither created nor consciously skipped is a
+publish bug.
+
+| Finding | Action | Reason |
+|---------|--------|--------|
+| REN-001 | Created #42 | NEW, CONFIRMED |
+| REN-002 | Skipped | Existing #38 |
+| REN-003 | Skipped | STALE (fixed in `composite.rs`) |
+| BSA-004 | Created #43 | NEW, CONFIRMED — labeled `import-pipeline` (no `bsa` label) |
+
+Flag any subsystem-without-a-label mappings (step 6) here so the gap is visible.
+
+### 11. Suggest next step
+
+For each created issue:
+
+```
+Fix with: /fix-issue <number>
+```

--- a/.claude/commands/audit-regression/SKILL.md
+++ b/.claude/commands/audit-regression/SKILL.md
@@ -1,94 +1,143 @@
 ---
 description: "Verify closed bug fixes haven't regressed — dynamically discovers and checks"
-argument-hint: "--issues <N,N,N> --limit <N>"
+argument-hint: "--issues <N,N,N> --limit <N> --label <label>"
 ---
 
 # Regression Verification Audit
 
-Verify that ALL previously fixed issues have not regressed. Dynamically discovers closed bug issues and verifies their fixes are still in place.
+Confirm that previously-fixed bugs are still fixed. This audit **dynamically
+discovers** closed bug issues from GitHub, locates each fix and its guard test,
+and reports any fix that has gone missing as a **Regression of #NNN**.
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, severity, dedup,
+context rules, and the per-finding format. See `.claude/commands/_audit-severity.md`
+for the severity scale. This file only adds the regression-specific flow.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--issues <N,N,N>`: Only verify specific issue numbers (e.g., `--issues 1,2,9`)
-- `--limit <N>`: Maximum number of closed issues to verify (default: 50)
-- `--label <label>`: Filter issues by label (default: `bug`)
+- `--issues <N,N,N>`: Verify only these issue numbers (e.g., `--issues 9,16,1516`).
+- `--limit <N>`: Max closed issues to verify (default: 50).
+- `--label <label>`: Issue label filter (default: `bug`).
 
-## Step 1: Discover Fixed Issues
-
-Fetch closed bug issues from GitHub:
+## Step 1 — Discover fixed issues
 
 ```bash
-gh issue list --repo matiaszanolli/ByroRedux --state closed --label bug --limit 50 --json number,title,body,closedAt,labels
+gh issue list --repo matiaszanolli/ByroRedux --state closed --label bug \
+  --limit 50 --json number,title,body,closedAt,labels
 ```
 
-If `--issues` is provided, fetch only those specific issues instead.
+With `--issues`, fetch those numbers directly (`gh issue view <N> --repo
+matiaszanolli/ByroRedux --json number,title,body,closedAt,labels`) instead.
 
-> **Default-window caveat.** The repo now has 1200+ closed issues (past #1295). The default `--limit 50` window only covers the most-recently-closed bugs, so older high-value fixes — and the recent NIFAL / Disney-BSDF / water-caustics closure wave (e.g. #1210, #1248–#1257) — get **no coverage** unless you raise `--limit` or pass them explicitly via `--issues`. When auditing the translation/shader tier, either bump `--limit` or add those issue numbers to `--issues`. The unconditional **NIFAL canonical-translation fragile-area checks in Step 3** are the safety net for refactor-landed (never-an-issue) regressions.
+For each issue, pull out:
+- **Number + title** — the regression handle.
+- **File references** — backtick-quoted paths in the body (`crates/nif/...`).
+- **Acceptance criteria / fix description** — what the fix is supposed to do.
+- **Related `#NNNN`** — phased fixes split across several issues (e.g. #1210 →
+  #1255 → #1257) regress as a set; verify the whole chain, not just the head.
 
-For each closed issue, extract:
-- **Issue number and title**
-- **File references** from the body (look for backtick-quoted paths like `crates/nif/...`)
-- **Fix description** from the body (look for "Acceptance Criteria", fix commits)
-- **Related issues** (look for `#NNNN` references)
+> **Discovery window caveat.** The repo has 1500+ closed issues. The default
+> `--limit 50` only covers the most-recently-closed bugs, so older high-value
+> fixes get **no coverage** unless you raise `--limit` or pass them via
+> `--issues`. The unconditional **Step 4** fragile-area checks are the safety
+> net for fixes that landed as proactive refactors and were never an issue at
+> all — run them every time regardless of which issues Step 1 surfaced.
 
-## Step 2: Verify Each Fix
+## Step 2 — Locate each fix and its guard
 
-### Step 2a: Locate the Fix
-1. Search for the issue number in commit messages: `git log --oneline --grep="#<NUMBER>"`
-2. If found, check the diff: `git show <commit> --stat`
-3. Read the referenced file(s) to confirm the fix is present
+For each issue, work the fix → guard-test chain:
 
-### Step 2b: Check for Regression Tests
-1. Search for test files referencing the issue: `grep -r "<NUMBER>" crates/ --include="*.rs" -l`
-2. Look for test names: `grep -r "test.*<keyword>" crates/ --include="*.rs"`
-3. Record what tests exist
+1. **Find the fix commit.** `git log --oneline --grep="#<N>"` (commits use
+   `Fix #<N>: …` and `fix/<N>-…` branch merges). `git show <commit> --stat`
+   shows which files moved.
+2. **Confirm the fix is present** in the live tree. Read the referenced file(s)
+   at the symbol named in the issue/commit (prefer `grep -n "fn <name>"` over a
+   line number — the post-Session-34/35 module splits invalidate old line refs).
+3. **Find the guard test.** Tests live as `*_tests.rs` siblings next to the
+   module they cover (e.g. `crates/nif/src/blocks/interpolator_tests.rs`), or as
+   `#[cfg(test)] mod tests` inline. To locate one:
+   - `grep -rn "<N>" crates/ byroredux/ --include='*.rs'` — many tests cite the
+     issue number in a name or comment (`fn fix_1516_…`, `// #1516`).
+   - Failing that, grep the fixed symbol or a keyword from the title across
+     `*_tests.rs` siblings of the fix file.
+4. **Run the guard** to prove it still passes. Crate packages are named
+   `byroredux-<crate>` (e.g. `cargo test -p byroredux-nif <test_name>`,
+   `cargo test -p byroredux-renderer`, `cargo test -p byroredux-core`).
 
-### Step 2c: Assign Status
-- **PASS**: Fix code confirmed present + regression tests exist
-- **PARTIAL**: Fix code confirmed present but NO regression tests
-- **FAIL**: Fix code is missing or broken (REGRESSION DETECTED)
-- **UNVERIFIABLE**: Cannot determine fix location from issue body
+## Step 3 — Assign a status
 
-## Step 3: Special Checks
+- **PASS** — fix code confirmed present **and** a guard test exists (ideally run green).
+- **PARTIAL** — fix code present but **no** guard test. Flag as a hardening gap.
+- **FAIL** — fix code missing or its guard now fails. **This is the regression.**
+  Report it with `Status: Regression of #<N>` per the `_audit-common` finding format.
+- **UNVERIFIABLE** — the issue body names no file/symbol and no fix commit is
+  findable. Note it and move on; don't guess.
 
-For ByroRedux-specific fragile areas:
-- **Depth bias** (#16 and decal fixes): Verify bias values still applied for decal meshes (`RenderLayer::depth_bias()` in `crates/core/src/ecs/components/render_layer.rs`, consumed in `crates/renderer/src/vulkan/context/draw.rs`)
-- **TLAS descriptor** (validation fixes): Verify `write_tlas` called at init for all frames (`crates/renderer/src/vulkan/scene_buffer/descriptors.rs`)
-- **NiBoolInterpolator** (parse fix): Verify `read_byte_bool` not `read_bool` (`crates/nif/src/stream.rs` + `crates/nif/src/blocks/interpolator.rs`)
-- **Name collision** (#9): Verify `root_entity` scoping still in `AnimationPlayer` (`crates/core/src/animation/player.rs`)
-- **XCLL parsing** (cell lighting): Verify byte offsets for directional rotation (`crates/plugin/src/esm/cell/walkers.rs`; canonical size sets pinned per-game era)
+## Step 4 — Unconditional fragile-area checks
 
-### NIFAL canonical-translation fragile areas
+These guard fixes/contracts whose breakage is **invisible to GitHub-issue
+discovery** — most landed as refactors, not closed bugs — so check them every
+run regardless of Step 1's window. A FAIL here is still reported as a regression
+(reference the relevant issue if one exists, else describe the contract).
 
-These guard the NIF→canonical translation tier (spec: `docs/engine/nifal.md`). Regressions here are **invisible to GitHub-issue discovery** — most landed as proactive refactors, not closed bugs — so they must be checked unconditionally. **See also `/audit-nifal`** for the dimension-level checklist of this layer.
+**NIFAL canonical-translation tier** (spec: `docs/engine/nifal.md`; see also
+`/audit-nifal` for the dimension-level checklist):
 
-- **Single material boundary** (NIFAL): Verify `byroredux/src/material_translate.rs::translate_material` is still the *only* `ImportedMesh → Material` site (per-game material classification lives here, never in the shader), and that `Material.metalness` / `Material.roughness` (`crates/core/src/ecs/components/material.rs`) stay plain resolved `f32` — no reintroduced `Option<f32>` or render-time `classify_pbr`. The resolve-once contract is `*_override.unwrap_or(f32::NAN)` at the boundary + `Material::resolve_pbr` (calls `classify_pbr_keyword`) filling only the NaN slots.
-- **Typed particle emitter dispatch** (NIFAL): Verify `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` still parse as **typed** blocks (`crates/nif/src/blocks/particle.rs`, dispatched in `crates/nif/src/blocks/mod.rs`), feed `extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs` → `ImportedEmitterParams` in `crates/nif/src/import/types.rs`), and that `byroredux/src/systems/particle.rs::apply_emitter_params` consumes them — not a silent regression to opaque `NiPSysBlock`. The regression signature is a zero-sized emitter or a clobbered preset color.
-- **Collision shape coverage** (NIFAL): Verify `BhkMultiSphereShape` + `BhkConvexListShape` still translate to a `CollisionShape` in `crates/nif/src/import/collision.rs` (they were previously dropped); a regression silently drops the shape back to `None`.
-- **Disney BSDF + GPU struct contracts** (recent shader wave): Verify `crates/renderer/shaders/triangle.frag` still carries the Disney/Burley lobe + the GLSL-PathTracer MIT attribution block (top-of-file, Burley 2012 SIGGRAPH cite), `NUM_RESERVOIRS = 16` is intact, and the `GpuCamera` size contract holds (304 B — guard test `gpu_camera_is_288_bytes` in `crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs`; note the function name is stale, the asserted value is 304). `GpuInstance` must also stay 112 B (`gpu_instance_is_112_bytes_std430_compatible`).
+- **Single material boundary.** `byroredux/src/material_translate.rs` (`fn
+  translate_material`) must remain the *only* `ImportedMesh → Material` site —
+  per-game material classification lives here, never in a shader. `Material`
+  (`crates/core/src/ecs/components/material.rs`) `metalness` / `roughness` must
+  stay plain resolved `f32` fields — no reintroduced `Option<f32>` and no
+  render-time classifier. The resolve-once contract is the boundary filling
+  overrides + `Material::resolve_pbr` (which calls `classify_pbr_keyword`)
+  filling only the unresolved slots.
+- **Typed particle emitters.** `NiPSysEmitter` / `NiPSysEmitterCtlr` /
+  `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` must still parse as **typed**
+  blocks (`crates/nif/src/blocks/particle.rs`, dispatched in
+  `crates/nif/src/blocks/mod.rs`), feed `extract_emitter_params` /
+  `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs` →
+  `ImportedEmitterParams` in `crates/nif/src/import/types.rs`), and be consumed
+  by `apply_emitter_params` (`byroredux/src/systems/particle.rs`). A regression
+  to opaque `NiPSysBlock` shows up as zero-sized emitters or clobbered colors.
+- **Collision shape coverage.** `BhkMultiSphereShape` + `BhkConvexListShape`
+  must still translate to a `CollisionShape` in
+  `crates/nif/src/import/collision.rs` (they were previously dropped to `None`).
+
+**Disney BSDF + GPU struct contracts** (recent shader wave):
+
+- `crates/renderer/shaders/triangle.frag` keeps the Disney/Burley lobe + the
+  GLSL-PathTracer MIT attribution block (top-of-file, Burley 2012 cite), and
+  `NUM_RESERVOIRS = 16` is intact.
+- `#[repr(C)]` GPU structs hold their size pins in
+  `crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs`:
+  `GpuInstance` = 112 B (`gpu_instance_is_112_bytes_std430_compatible`) and
+  `GpuCamera` = 336 B (`gpu_camera_is_336_bytes`). Run them:
+  `cargo test -p byroredux-renderer gpu_`.
 
 ## Output
 
-Write to: **`docs/audits/AUDIT_REGRESSION_<TODAY>.md`**
+Write to: **`docs/audits/AUDIT_REGRESSION_<TODAY>.md`** (YYYY-MM-DD).
 
-### Per-Issue Format
+### Per-issue entry
+
 ```
 ## #<ISSUE>: <Title>
 - **Status**: PASS | PARTIAL | FAIL | UNVERIFIABLE
 - **Closed**: <date>
 - **Fix commit**: <hash> (or "not found")
-- **File checked**: `<path>:<line>`
+- **Fix site**: `<path>` (`<symbol>`)
 - **Fix present**: Yes / No / Unknown
-- **Tests exist**: Yes / No
+- **Guard test**: `<test name>` in `<path>` — passes / fails / none
 - **Notes**: <concerns>
 ```
 
-### Summary Table
+### Summary table
+
 ```
-| Issue | Title | Status | Fix Present | Tests |
+| Issue | Title | Status | Fix Present | Guard |
 |-------|-------|--------|-------------|-------|
 ```
 
-For any **FAIL** status, suggest: `/audit-publish docs/audits/AUDIT_REGRESSION_<TODAY>.md`
+For any **FAIL**, surface it as a `Regression of #NNN` finding (base format in
+`_audit-common.md`) and suggest:
+`/audit-publish docs/audits/AUDIT_REGRESSION_<TODAY>.md`

--- a/.claude/commands/audit-renderer/SKILL.md
+++ b/.claude/commands/audit-renderer/SKILL.md
@@ -5,425 +5,325 @@ argument-hint: "--focus <dimensions> --depth shallow|deep"
 
 # Renderer Audit
 
-Audit the Vulkan renderer for correctness across the full pipeline: rasterization, ray tracing (BLAS/TLAS, ray queries, shadows, reflections, GI), deferred indirect lighting (G-buffer, SVGF), compositing, synchronization, GPU memory, and resource lifecycle.
+Audit the Vulkan renderer for correctness across the full pipeline: ray tracing
+(BLAS/TLAS, ray queries, shadows, reflections, GI, glass refraction), SSBO/UBO
+indexing, GPU-struct layout, synchronization, GPU memory, deferred indirect
+lighting (G-buffer, SVGF), denoiser/composite, and the per-feature passes
+(TAA, skinning, caustics, water, volumetrics, bloom, material table).
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, the **Key Reference
+Docs** table, methodology, dedup, context rules, and the finding format.
+See `.claude/commands/_audit-severity.md` for the severity scale — the
+RT/SSBO/GPU-struct/denoiser rows there set the floors used below.
+
+**Do NOT restate the GPU-struct byte layouts, descriptor bindings, G-buffer
+formats, or submission order here** — `docs/engine/shader-pipeline.md` is the
+authoritative, code-verified reference. `docs/engine/memory-budget.md` is
+authoritative for VRAM/RAM ceilings, LRU thresholds, and deferred-destroy depth.
+Audit *against* those docs; if the code diverges from the doc, that divergence is
+itself a finding (or the doc is stale — note which).
+
+## Verification discipline (No-Guessing)
+
+- **Symbols, not line numbers.** Anchor every finding on a symbol
+  (`fn`/`struct`/`const`/test name), not `file:NN` — line anchors rot on every
+  refactor. Confirm by `grep`; if a claim is unconfirmable, drop it.
+- **Backticked `.ext` paths must resolve now** (the `_audit-validate.sh` gate).
+  note that `byroredux/src/render/` is a **directory**, not a `render.rs` file
+  (it split out post-#1115); `scene.rs` / `systems.rs` / `cell_loader.rs` are
+  likewise thin dispatchers over sibling dirs.
+- **Recast resolved issues as regression guards** — phrase as "verify X still
+  holds / hasn't drifted", not "X is broken".
+- **No speculative Vulkan changes.** Per the user's standing guidance, do NOT
+  propose render-pass / pipeline / barrier edits whose failure modes are
+  invisible to `cargo test`. Frame such findings as **"needs RenderDoc
+  verification"** and stop at the observation.
+- **Bench numbers rot.** Do not hard-code FPS/ms; cite ROADMAP.md
+  *Bench-of-record* (currently flagged stale — R6a-stale-15 gates any FPS claim).
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,7`). Default: all 23.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,7`). Default: all.
 - `--depth shallow|deep`: `shallow` = check patterns only; `deep` = trace data flow and validate invariants. Default: `deep`.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: Vulkan Sync | GPU Memory | Pipeline State | Render Pass | Command Recording | Shader Correctness | Resource Lifecycle | Acceleration Structures | RT Ray Queries | Denoiser & Composite | TAA | GPU Skinning | Caustics | Material Table (R1) | Sky/Weather/Exterior Lighting | Tangent-Space & Normal Maps (M-NORMALS) | Water (M38) | Volumetrics (M55) | Bloom (M58) | M-LIGHT v1 Soft Shadows | Disney BSDF / PBR Gating | NIFAL Material Translation | Debug Overlay & GPU Telemetry
+- **Dimension**: AS Correctness | SSBO/Indexing | GPU-Struct Layout | Sync/Barriers | Memory/Lifecycle | Ray Queries | Denoiser/Composite | TAA | Skinning | Camera-Relative Precision | NIFAL Material | Material Table | Caustics | Water | Volumetrics | Bloom | Disney BSDF | Soft Shadows | Sky/Weather | Tangent-Space | Pipeline/RenderPass | Debug/Telemetry | Cornell Harness
 
 ## Phase 1: Setup
 
-1. Parse `$ARGUMENTS` for `--focus`, `--depth`
-2. `mkdir -p /tmp/audit/renderer`
-3. Fetch dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/renderer/issues.json`
-4. Scan `docs/audits/` for prior renderer reports
+1. Parse `$ARGUMENTS` for `--focus`, `--depth`.
+2. `mkdir -p /tmp/audit/renderer`.
+3. Dedup baseline: `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/renderer/issues.json`.
+4. Scan `docs/audits/` for prior renderer reports.
+5. Read `docs/engine/shader-pipeline.md` + `docs/engine/memory-budget.md` first — they pin almost everything below.
 
 ## Phase 2: Launch Dimension Agents
 
-### Dimension 1: Vulkan Synchronization
-**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (draw_frame), `crates/renderer/src/vulkan/sync.rs`, `crates/renderer/src/vulkan/context/resize.rs`
+Dimensions are ordered **by renderer risk**: AS/SSBO indexing and GPU-struct
+layout corrupt every frame silently (CRITICAL/HIGH floors); sync and memory
+leaks compound; denoiser/shader correctness is mostly visual.
+
+---
+
+### CRITICAL tier — silent whole-frame corruption
+
+#### Dimension 1: Acceleration Structures (BLAS/TLAS correctness)
+**Entry points**: `crates/renderer/src/vulkan/acceleration/` (`blas_static.rs`, `blas_skinned.rs`, `tlas.rs`, `predicates.rs`, `constants.rs`, `types.rs`), `crates/renderer/src/vulkan/context/resources.rs` (`build_blas_for_mesh`).
+**Severity floor**: wrong geometry/address in AS = CRITICAL; missing build→read barrier = HIGH.
 **Checklist**:
-- Semaphore/fence lifecycle (signal before wait, no double-signal)
-- `images_in_flight` tracking correctness
-- Swapchain recreation: are all resources properly waited on and destroyed?
-- Queue submit ordering (graphics vs present)
-- Per-frame fence wait before command buffer reuse
-- TLAS build barrier before fragment shader read (`AS_WRITE → AS_READ`, build stage → fragment stage)
-- SVGF compute dispatch barrier (compute write → fragment read)
-- G-buffer attachment transitions between render pass and compute pass
-- Composite pass dependency on SVGF output
+- BLAS build geometry: vertex format `R32G32B32_SFLOAT` at offset 0, index type `UINT32`, `OPAQUE` flag, correct prefer-trace/build flags per buffer class.
+- Build-flag constants are stable: `STATIC_BLAS_FLAGS` (`FAST_TRACE | ALLOW_COMPACTION`), `SKINNED_BLAS_FLAGS` (`FAST_BUILD | ALLOW_UPDATE` — deliberate, see memory-budget.md), `UPDATABLE_AS_FLAGS` (`FAST_TRACE | ALLOW_UPDATE`). Pinned by tests in `acceleration/`; drift = Vulkan-version-rev breakage (regression guard, #1144/#1196).
+- `BlasEntry.built_flags` records BUILD-time flags; refit must assert the same set (VUID-03667). Mismatch surfaces as validation, not silent corruption (regression guard, #1145).
+- **`instance_custom_index` encoding == draw-command index** used for SSBO lookup — this is the load-bearing AS/SSBO contract (CRITICAL). It is a 24-bit field; `MAX_INSTANCES = 0x40000` stays under `1 << 24`, pinned by the const-assert in `scene_buffer/constants.rs`.
+- TLAS build/update decision keys on the `last_blas_addresses` device-address sequence only. UPDATE mode requires matching geometry + instance count — verify padded/unused instance slots don't break it.
+- Transform: column-major `mat4` → 3×4 row-major `VkTransformMatrixKHR`. `TRIANGLE_FACING_CULL_DISABLE` on all instances (two-sided meshes).
+- Empty TLAS valid from frame 0 (no validation errors before any geometry).
+- Device-address queries require `SHADER_DEVICE_ADDRESS` usage on the source buffer.
+- LRU/shrink wiring (regression guards): `shrink_tlas_scratch_to_fit` uses TLAS-calibrated slack matching `tlas_instance_should_shrink` (`predicates.rs`), called at cell-unload (#1226); the three `missing_blas` cause-counters (skinned/rigid/ssbo_evicted) all increment and surface via `mem.stats` (#1228); post-TLAS `rt_flag` patch in `draw_frame` keeps cell-load frames from rendering RT-disabled (#1227).
 **Output**: `/tmp/audit/renderer/dim_1.md`
 
-### Dimension 2: GPU Memory
-**Entry points**: `crates/renderer/src/vulkan/buffer.rs`, `crates/renderer/src/vulkan/allocator.rs`, `crates/renderer/src/vulkan/scene_buffer/`, `crates/renderer/src/vulkan/acceleration/`
+#### Dimension 2: SSBO/Index plumbing & RT ray queries (shader)
+**Entry points**: `crates/renderer/shaders/triangle.frag` (all `rayQueryEXT`), `crates/renderer/shaders/water.frag`.
+**Severity floor**: SSBO index mismatch = CRITICAL; ray self-intersection / wrong tMin = HIGH.
 **Checklist**:
-- gpu-allocator usage: correct memory types (CpuToGpu vs GpuOnly)
-- Buffer/image destruction before allocator drop
-- Allocator dropped before device destruction
-- No leaked VkDeviceMemory on shutdown
-- BLAS scratch buffer reuse (high-water mark pattern — never shrinks; verify no use-after-free)
-- TLAS instance buffer: HOST_VISIBLE, per-frame, properly sized with padding
-- Global vertex/index SSBO growth policy (do they ever need resize? what happens?)
-- G-buffer image allocations: properly freed on swapchain recreate
-- SVGF history buffers: allocated once, recreated on resize
+- `instance_custom_index` (NOT `gl_InstanceID`) indexes `GpuInstance[]`; `materials[instance.material_id]`, vertex/index SSBOs (Set 1 bindings 8/9 per shader-pipeline.md) use the same offsets the Rust upload writes.
+- Shadow rays: origin = surface world pos with normal/tMin bias, direction toward light, `TerminateOnFirstHit`, `CommittedIntersectionNone` → 0/1. Disk/cone jitter geometry correct (point/spot concentric disk, directional angular cone).
+- Reflection rays: normal-biased origin, `reflect(viewDir, N)` sign, metalness/roughness gate consistent with PBR intent, barycentric UV interp from vertex SSBO, descriptor-valid texture lookup.
+- 1-bounce GI: cosine-weighted hemisphere with correct tangent-basis, distance cutoff, miss → sky/ambient fill with no NaN/inf.
+- Glass / IOR refraction:
+  - Roughness-spread basis via **Frisvad** orthonormal basis (not `cross(N, up)`, which degenerates vertical) — verify tangent/bitangent unit length (#820).
+  - Window-portal demote on coincident glass to break the IOR self-passthrough infinite loop (#789).
+  - `GLASS_RAY_BUDGET` (from `shader_constants.glsl`) cap wired; the budget `atomicAdd` overshoots unconditionally by design (#1438) — that's documented, not a bug; verify the doc comment is intact and no CPU reads the counter.
+  - Interior miss falls back to cell-ambient, not open-sky tint (no daylight leak in dungeons).
+  - `DBG_VIZ_GLASS_PASSTHRU` viz still wired at the diagnostic-state setup + the two refraction-loop viz-write branches.
+- RT gating: `sceneFlags.x > 0.5` checked before every ray query; TLAS binding is the correct descriptor (Set 1, Binding 2).
+- Interleaved-gradient noise seeded by frame counter — deterministic per-pixel-per-frame so TAA can converge (no true RNG).
 **Output**: `/tmp/audit/renderer/dim_2.md`
 
-### Dimension 3: Pipeline State
-**Entry points**: `crates/renderer/src/vulkan/pipeline.rs`, `crates/renderer/src/vulkan/descriptors.rs`, `crates/renderer/src/vulkan/context/helpers.rs`
+#### Dimension 3: GPU-struct layout (lockstep with shaders)
+**Entry points**: `crates/renderer/src/vulkan/scene_buffer/gpu_types.rs`, `scene_buffer/constants.rs`, `crates/renderer/src/vulkan/material.rs`, the layout-pin tests in `scene_buffer/` (`gpu_instance_layout_tests.rs`, `material_hash_tests.rs`, `instance_hash_tests.rs`) and `material.rs`.
+**Severity floor**: `#[repr(C)]` GPU struct drifting from its shader struct = HIGH (silent per-instance/per-material corruption).
 **Checklist**:
-- Vertex input matches shader layout (binding, location, format, offset)
-- Push constant ranges match shader declarations
-- Dynamic state correctly set each frame (viewport, scissor)
-- Pipeline compatible with render pass (attachment formats, subpass)
-- G-buffer pipeline outputs to all 6 render targets (direct, raw indirect, albedo, normal, motion, mesh ID)
-- Composite pipeline inputs match G-buffer + SVGF outputs
-- SSAO compute pipeline descriptor layout
-- Cluster cull compute pipeline descriptor layout
+- Sizes pinned by tests — confirm they hold and match shader-pipeline.md: `GpuInstance` = **112 B** (`size_of::<GpuInstance>() == 112`), `GpuCamera` = **336 B** (`gpu_camera_is_336_bytes` — grew 320→336 with the `render_origin` vec4, #markarth-precision / #1492), `GpuMaterial` = **300 B** (`gpu_material_size_is_300_bytes`; NOTE the size grew 260→…→300 via #804/#1249/#1250 — the `_300_` test name is current, the old `_260_` name is gone).
+- Per-field offset pins: `gpu_material_field_offsets_match_shader_contract` asserts every named field offset across all vec4 slots (#806) — a size-only pin can't catch within-vec4 reorders. Any added field needs a matching offset assertion plus updates to the Rust struct AND the GLSL `struct GpuMaterial` (only declared in `triangle.frag`).
+- All `GpuMaterial` fields are scalar f32/u32 — **never** `[f32;3]` (std430 vec3 alignment would desync the byte-hash dedup). Named pad fields explicitly zeroed (no uninit bytes feeding Hash/Eq).
+- `struct GpuInstance` is mirrored in **5 shaders** — verify lockstep via `grep -l "struct GpuInstance" crates/renderer/shaders/*` → `triangle.vert`, `triangle.frag`, `ui.vert`, `water.vert`, `caustic_splat.comp` (`ui.vert`/`water.vert` reading wrong offsets is the recurring trap, #785/#1498). Per `feedback_shader_struct_sync.md`.
+- Flag constants are the single source of truth in `crates/renderer/src/shader_constants_data.rs`, emitted into `crates/renderer/shaders/include/shader_constants.glsl` and `#include`d — never hand-written shader-side: `INSTANCE_FLAG_*`, `MATERIAL_KIND_*`, `MAT_FLAG_*` (bits 0–9, including `PBR_BSDF` bit 5, `TRANSLUCENCY` bit 6, `MODEL_SPACE_NORMALS` bit 7, `TRANSLUCENCY_THICK_OBJECT` bit 8, `TRANSLUCENCY_MIX_ALBEDO` bit 9 — all canonical post-#1357, the `BGSM_*` prefix is gone), and the 13 `DBG_*` bits (`0x1`…`0x1000`, value-pinned by the shared catalog, `8eaade44`).
+- Capacity constants match memory-budget.md: `MAX_INSTANCES = 0x40000`, `MAX_MATERIALS = 16384` (`scene_buffer/constants.rs`), `MAX_INDIRECT_DRAWS = MAX_INSTANCES`. Over-cap material intern returns id 0 + one-shot `warn!` (no SSBO-index corruption, #797); upload truncates to `min(intern_count, MAX_MATERIALS)`.
 **Output**: `/tmp/audit/renderer/dim_3.md`
 
-### Dimension 4: Render Pass & G-Buffer
-**Entry points**: `crates/renderer/src/vulkan/context/helpers.rs` (create_render_pass), `crates/renderer/src/vulkan/gbuffer.rs`
-**Checklist**:
-- Attachment load/store ops (CLEAR + STORE for all G-buffer outputs)
-- Layout transitions (UNDEFINED → COLOR_ATTACHMENT → SHADER_READ for G-buffer targets)
-- Subpass dependencies cover all stage/access masks
-- G-buffer format choices match shader output types (RG16_SNORM octahedral-packed for normals per Schied 2017, R16G16_SFLOAT for motion vectors, **R32_UINT** for mesh ID per `gbuffer.rs::MESH_ID_FORMAT` — 31-bit id + bit 31 (0x80000000) = ALPHA_BLEND_NO_HISTORY flag for SVGF disocclusion (encoded shader-side at `triangle.frag:1255` `outMeshID = meshIdBase | (alphaBlendFrag ? 0x80000000u : 0u)`, bit-31 comment at `triangle.frag:1243`), encoding ceiling `0x7FFFFFFF`, runtime cap `MAX_INSTANCES = 0x40000` per `scene_buffer/constants.rs::MAX_INSTANCES`. There is **no `encode_mesh_id` fn** — the encoding lives as the format/ceiling comment block at `context/helpers.rs:64-73` and the runtime overrun guard at `context/draw.rs:1665-1685` (a one-shot `warn!` + clamp via `upload_instances`, NOT a `debug_assert!` — #956 / REN-D5-NEW-05 moved off the assert to avoid leaking the in-flight cmd buffer on unwind); see #992)
-- Depth attachment format and load/store ops
-- G-buffer images created with SAMPLED usage (needed by SVGF and composite reads)
+---
+
+### HIGH tier — sync, memory, leaks, denoiser correctness
+
+#### Dimension 4: Synchronization & barriers
+**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (`draw_frame`), `sync.rs`, `context/resize.rs`. Cross-check the submission order in shader-pipeline.md.
+**Checklist** (flag invisible-failure-mode items as **needs RenderDoc**):
+- Semaphore/fence lifecycle: signal-before-wait, no double-signal, per-frame fence waited before command-buffer reuse, `images_in_flight` tracking.
+- `render_finished` is **per-swapchain-image, indexed by `image_index`** (not per-frame) — per-frame signalling fires VUID-vkQueueSubmit-pSignalSemaphores-00067 when `MAX_FRAMES_IN_FLIGHT` > swapchain image count (regression guard, `548c1b69`).
+- AS build → fragment read barrier (`AS_WRITE → AS_READ`, build stage → fragment stage); skin compute write → BLAS refit → fragment read chain (Dim 9).
+- G-buffer attachment transitions between render pass and the compute consumers (SVGF/TAA/SSAO); caustic-accum atomic-add → SHADER_READ.
+- egui render pass supplies its own incoming dependency after composite's outgoing `dstStage = NONE` (explicit EXTERNAL dependency, #1433) — missing it is a WAR hazard on the swapchain image.
+- Swapchain recreate: all in-flight work waited and resources destroyed before rebuild.
 **Output**: `/tmp/audit/renderer/dim_4.md`
 
-### Dimension 5: Command Buffer Recording
-**Entry points**: `crates/renderer/src/vulkan/context/draw.rs` (draw_frame command recording)
+#### Dimension 5: GPU memory & resource lifecycle
+**Entry points**: `crates/renderer/src/vulkan/buffer.rs`, `allocator.rs`, `scene_buffer/`, `acceleration/memory.rs`, `crates/renderer/src/vulkan/context/mod.rs` (Drop), `context/resize.rs`. Cross-check ceilings in memory-budget.md.
+**Severity floor**: any per-frame leak = HIGH.
 **Checklist**:
-- Reset before re-record (RESET_COMMAND_BUFFER flag on pool)
-- Begin/end balanced
-- Render pass begin/end balanced
-- TLAS build recorded before render pass begin (outside render pass)
-- Per-draw state: depth bias for decals, pipeline bind, descriptor set bind, push constants, draw indexed
-- Batch coalescing: draws sharing same texture use same descriptor set
-- SVGF compute dispatch recorded after render pass end, before composite
-- Composite render pass recorded last
-- No commands recorded outside render pass that require it (or vice versa)
-- **DrawCommand input count vs GPU-call count distinction** (#1258): `DrawCommand` enumeration is the pre-batch input set; the post-batch GPU draw count is a separate metric. `mem.stats` / `bench-stats` surface both. Regression pattern is reporting a single conflated number — confirm the two counters are independent
-- **Blend pipeline pre-pop fast path** (#1259): in steady state, the blend pipeline cache hit avoids the full pipeline rebuild on every draw. Verify the cache hit path exists at the per-draw blend-state bind site and is not silently fallen through to the slow path
-- **Off-frustum flag assembly skip** (#1260): draws outside the camera frustum skip the `GpuInstance.flags` assembly cost (post-batch they're already gated out by `in_raster=false`). Verify the skip path doesn't accidentally drop required state on visible draws bordering the frustum
-- **SceneFlags parity at cell-loader spawn boundary** (#1235): every REFR spawned during cell load sees the same `SceneFlags` ((`flags.x` RT-enabled, `jitter.w` is_exterior) as the steady-state draws. Drift here is a 1-frame visual glitch at cell-load completion — verify the spawn path reads `SceneFlags` from the world resource, not a cached snapshot
-- **`render_finished` semaphore — per-swapchain-image, not per-frame** (`548c1b69`, fix for VUID-vkQueueSubmit-pSignalSemaphores-00067): if signal is per-frame, queue-submit validation fires when MAX_FRAMES_IN_FLIGHT > swapchain image count. Verify the semaphore is allocated per swapchain image and indexed by `image_index`, not `frame_index`
+- gpu-allocator memory-type correctness (`CpuToGpu` vs `GpuOnly`); buffers/images destroyed before allocator; allocator dropped before device; no leaked `VkDeviceMemory` on shutdown.
+- **`AllocatorResource` ECS-ordering**: must be removed from the `World` BEFORE `VulkanContext::drop()` — the allocator holds a live `Arc<Device>`; a `World` outliving the context fires the allocator Drop against a destroyed device (use-after-free). Verify the drop/remove ordering in `main.rs`, and that it survives a panic-unwind path (#1406). Allocator-independent destroys are hoisted out of the allocator-guarded Drop block (#1483).
+- BLAS scratch high-water-mark reuse never shrinks mid-life (verify no use-after-free); shrink fns (`shrink_blas_scratch_to_fit`, `shrink_tlas_to_fit`) run at cell-unload with the slack constants from memory-budget.md.
+- TLAS resize calls `device_wait_idle()` before `allocator.free()` of the old allocation (`tlas.rs`) — absence opens a use-after-destroy window under resize-while-build-in-flight (latent, #1390).
+- Vertex/index pool growth: soft cap `warn!`, hard cap error (`check_pool_growth`); `NifImportRegistry` LRU cap (`BYRO_NIF_CACHE_MAX`, default 2048) bounds scene count.
+- Deferred-destroy countdown = `MAX_FRAMES_IN_FLIGHT` frames, ticked after the in-flight fence wait (memory-budget.md); BGSM/failed-path caches half-evict on overflow (#1430).
+- Reverse-order teardown of all `VulkanContext` fields; per-subsystem `destroy()` for `AccelerationManager`, `SvgfPipeline`, `GBuffer`, `CompositePipeline`, `Ssao`, `WaterCausticAccum`, `EguiPass`, `GpuPerFrameTimers`, `TextureRegistry`; framebuffers before render pass, image views before swapchain, device last.
 **Output**: `/tmp/audit/renderer/dim_5.md`
 
-### Dimension 6: Shader Correctness
-**Entry points**: `crates/renderer/shaders/triangle.vert`, `crates/renderer/shaders/triangle.frag`, `crates/renderer/shaders/svgf_temporal.comp`, `crates/renderer/shaders/composite.frag`, `crates/renderer/shaders/ssao.comp`, `crates/renderer/shaders/cluster_cull.comp`
+#### Dimension 6: NIFAL material canonical translation
+**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` — the single `ImportedMesh → Material` boundary), `crates/core/src/ecs/components/material.rs` (`Material`, `resolve_pbr`, `EmissiveSource`), the particle slice `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params`/`extract_emitter_rate`) → `byroredux/src/systems/particle.rs` (`apply_emitter_params`) → `byroredux/src/render/particles.rs` (`emit_particles`). Spec: `docs/engine/nifal.md`. See also `/audit-nifal`.
+**Severity floor**: wrong/divergent `Material` out of `translate_material` = HIGH (one boundary, all-game blast radius, no per-draw fallback to mask it).
 **Checklist**:
-- SPIR-V matches GLSL source (recompile and diff)
-- Push constant struct layout matches Rust-side byte offsets
-- Vertex attribute locations match Vertex struct field order
-- Descriptor set/binding indices match Rust-side descriptor layout
-- TLAS binding (set 1, binding 2) type is `accelerationStructureEXT`
-- Global vertex/index SSBO bindings (set 1, bindings 8, 9) match MeshRegistry offsets
-- `instance_custom_index` used correctly to index into SSBOs (not `InstanceId`)
-- RT flag gating: `sceneFlags.x > 0.5` consistently checked before all ray queries
-- Light SSBO struct layout matches Rust GpuLight fields (position, color, direction, params)
-- Camera UBO layout: `position.w` = frame counter, `flags.x` = RT enabled
-- SVGF temporal shader: motion vector reprojection math, mesh ID rejection, accumulation blend factor
-- Composite shader: ACES tone mapping, direct + denoised indirect reassembly
+- **Single boundary**: `translate_material` has exactly two callers — `byroredux/src/scene/nif_loader.rs` (loose NIF) and `byroredux/src/cell_loader/spawn.rs` (REFR placement). A third `Material {…}` literal downstream is a translation leak.
+- `Material::metalness` / `roughness` are plain resolved `f32` (not `Option`); `resolve_pbr` runs once at translate (NaN-sentinel → `classify_pbr_keyword`, then clamp `metalness 0..1`, `roughness 0.04..1`), idempotent (`resolve_pbr_is_idempotent`). No per-frame re-classification anywhere.
+- `EmissiveSource` (None/Material/Lighting/Effect) resolved at translate; the renderer reads the resolved `emissive_mult`, not the raw per-game property (Effect = diffuse-tint multiplier conflated into emissive — drift mis-tints FO4+ glow).
+- **No per-game branch between `Material` and `MaterialTable::intern`** — per-game quirks resolve here, never in the renderer (`feedback_format_translation.md`).
+- Particle slice: authored emitter rate/size override the preset but NOT color (`apply_emitter_params_overrides_kinematics_and_size_not_color`); render assembly reads `ParticleEmitter` post-overlay.
 **Output**: `/tmp/audit/renderer/dim_6.md`
 
-### Dimension 7: Resource Lifecycle
-**Entry points**: `crates/renderer/src/vulkan/context/mod.rs` (Drop impl, struct fields), `crates/renderer/src/vulkan/context/resize.rs`
+#### Dimension 7: Material table (R1 dedup)
+**Entry points**: `crates/renderer/src/vulkan/material.rs` (`MaterialTable::intern`), `scene_buffer/upload.rs`, `byroredux/src/render/mod.rs` (`build_render_data`), `byroredux/src/render/static_meshes.rs`.
+**Upstream**: the interned `Material`s come from Dim 6 (NIFAL) — a corrupt `GpuMaterial` may be a translate-side bug.
 **Checklist**:
-- All VkShaderModule, VkPipeline, VkPipelineLayout destroyed in Drop
-- Framebuffers destroyed before render pass
-- Swapchain image views destroyed before swapchain
-- Device destroyed after all resources
-- AccelerationManager cleanup: all BLAS entries, TLAS states, scratch buffers
-- SvgfPipeline cleanup: history images, descriptor sets, pipeline, layout
-- GBuffer cleanup: all attachment images and views
-- CompositePipeline cleanup: pipeline, layout, descriptor sets
-- SSAO cleanup: noise texture, kernel buffer, output image
-- TextureRegistry cleanup: all per-texture descriptor sets and images
-- Reverse-order teardown of all 54+ VulkanContext fields
-- **`AllocatorResource` ECS ordering (#1406, `299e6a84`)**: `AllocatorResource` MUST be removed from the ECS `World` BEFORE `VulkanContext::drop()` executes. The `gpu-allocator` holds a live `Arc<Device>`; if the `World` outlives the `VulkanContext`, the allocator's `Drop` fires against a destroyed logical device → use-after-free. Verify `main.rs` / `app_event_loop.rs` drops the world or removes the resource before the renderer is dropped, and that this ordering is not bypassable by a panic unwind path.
-- **TLAS resize safety (#1390, `a7e1502b`)**: the TLAS resize path (triggered when the instance buffer is too small) calls `device_wait_idle()` before destroying the old allocation. Verify the wait is present in `tlas.rs` before any `allocator.free()` call in the resize branch — its absence opens a use-after-destroy window when resize runs while the prior frame's TLAS build is still in flight (a latent hazard that would materialise under a future resize-under-load refactor).
+- `intern` produces stable `material_id`s within a frame; identical materials collapse to one entry. Over-cap returns id 0 + warn-once, surfaced via `mem.stats` (#7823eb59/#797). Per-frame SSBO sized to `min(intern_count, MAX_MATERIALS)`.
+- Hash/Eq treat `GpuMaterial` as raw bytes (depends on the Dim-3 scalar-fields + zeroed-pad invariant).
+- Dedup-ratio telemetry surfaced (unique vs placement count) — a drop in hit-rate is a finding even if correctness holds (#780).
+- Import-side scalars feeding the table (regression guards): BSLightingShaderProperty smoothness/IOR/specular into `MaterialInfo` for the Disney lobe, BGSM smoothness normalized once (no double-apply, #1241); WaterShaderProperty + bare BSShaderProperty produce distinct entries (no dedup collapse with glass/opaque, #1243/#1244); `HasModelSpaceNormals` routed for direct-TXST REFRs (#972).
+- Identity invariant: N copies of one material render byte-identical pre/post dedup. No per-instance field remains in `GpuInstance`/`DrawCommand` that should now live in `GpuMaterial` (R1 Phase 6 closeout).
 **Output**: `/tmp/audit/renderer/dim_7.md`
 
-### Dimension 8: Acceleration Structures (RT)
-**Entry points**: `crates/renderer/src/vulkan/acceleration/`, `crates/renderer/src/vulkan/context/resources.rs` (build_blas_for_mesh)
+#### Dimension 8: Denoiser & composite
+**Entry points**: `crates/renderer/src/vulkan/svgf.rs`, `composite.rs`, `crates/renderer/shaders/svgf_temporal.comp`, `composite.frag`.
+**Severity floor**: SVGF using wrong motion vectors = HIGH; ghosting / wrong tone-map order = MEDIUM.
 **Checklist**:
-- BLAS build: vertex format matches Vertex struct (R32G32B32_SFLOAT at offset 0)
-- BLAS build: index type matches mesh index buffer (UINT32)
-- BLAS build: OPAQUE geometry flag correct (no transparency in AS traversal)
-- BLAS build: PREFER_FAST_TRACE flag (not PREFER_FAST_BUILD)
-- BLAS scratch buffer: SHADER_DEVICE_ADDRESS usage, proper alignment
-- BLAS result buffer: ACCELERATION_STRUCTURE_STORAGE + SHADER_DEVICE_ADDRESS
-- TLAS instance buffer: host write → AS read barrier correct
-- TLAS build/update decision: `last_blas_addresses` comparison is correct (only device address sequence matters)
-- TLAS UPDATE mode: spec requires same geometry count, same instance count — verify
-- TLAS padding strategy (max(2x, 4096)) — does UPDATE work with unused instance slots?
-- `instance_custom_index` encoding: matches draw command index for SSBO lookup
-- Transform matrix conversion: column-major to 3×4 row-major (VkTransformMatrixKHR)
-- `TRIANGLE_FACING_CULL_DISABLE` on all instances — correct for two-sided meshes
-- Empty TLAS at init: valid descriptors from frame 0 (no validation errors)
-- Device address queries: buffer must have SHADER_DEVICE_ADDRESS usage flag
-- **TLAS-scratch shrink alive (#1226, was dead code)** (`cf3d8ec6`): `shrink_tlas_scratch_to_fit` now uses TLAS-calibrated slack (was BLAS-calibrated, effectively unreachable). Verify the slack calculation matches `tlas_instance_should_shrink` predicate at `acceleration/predicates.rs` and the function is called from the end-of-frame / cell-unload site
-- **`missing_blas` counter split by cause** (#1228, `289fb07a`): three independent counters (skinned, rigid, ssbo_evicted) replace the conflated single counter. Verify all three increment-paths are wired and surfaced through `bench-stats`. Regression pattern: a fix that only updates one bucket while another silently inflates
-- **`built_flags` pinned as runtime VUID-03667 flag check** (#1145, `b2fd533f`): `BlasEntry.built_flags` records the BUILD-time AS flag set; the matching refit asserts the pair (UPDATABLE | PREFER_FAST_TRACE | ALLOW_COMPACTION must match the original BUILD). Regression here surfaces as Vulkan validation, not silent corruption
-- **`SKINNED_BLAS_FLAGS` / `UPDATABLE_AS_FLAGS` bit composition pinned by tests** (#1144, `a2597487`): the flag-set constants live as module constants in `crates/renderer/src/vulkan/acceleration/`. Drift here is a Vulkan-version-rev breaking change risk; the pin-tests fail loud if either constant flips
-- **GpuCamera.rt_flag post-TLAS patch — cell-load warmup gone** (#1227, `6dd40d3f`): first 1-2 frames after a cell load no longer render with RT-disabled. Verify the post-TLAS rt_flag patch is in `draw_frame` and not removed by a future refactor — regression pattern is visible as a 1-2-frame raster-only flash on cell entry
+- SVGF history ping-pong (read prev, write current); reprojection motion vectors match the vertex-shader output; mesh-ID disocclusion rejection prevents ghosting; blend α clamped, first-frame uses current (no garbage history); dispatch covers exactly the image (ceil division); per-frame history descriptor swap.
+- Firefly rejection hoisted ahead of the `hasHistory` branch (regression guard, `48906670`) — verify the clamp applies on the no-history path too.
+- Composite reassembly: direct + SVGF-denoised indirect + albedo (+ TAA-resolved HDR when TAA on), ACES tone-map applied **after** reassembly, bloom added **before** tone-map (Dim 16). Fog applied to direct only, not indirect. SSAO modulates indirect only.
+- Caustic accumulator (`R32_UINT`) sampled via `usampler2D`, divided by the fixed-point scale, added to **direct** (never the SVGF-denoised indirect — double-count guard, Dims 14/15).
+- Composite output to swapchain (correct format/layout transition to `PRESENT_SRC_KHR`).
 **Output**: `/tmp/audit/renderer/dim_8.md`
 
-### Dimension 9: RT Ray Queries (Shader)
-**Entry points**: `crates/renderer/shaders/triangle.frag` (all `rayQueryEXT` usage)
+#### Dimension 9: GPU skinning compute + BLAS refit (M29)
+**Entry points**: `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/shaders/skin_vertices.comp`, `skin_palette.comp`, `acceleration/blas_skinned.rs`, `byroredux/src/render/skinned.rs`, `byroredux/src/render/bone_palette_overflow_tests.rs`.
 **Checklist**:
-- Shadow rays: origin = fragment world position, direction = toward light, tMin/tMax correct
-- Shadow rays: point/spot jitter (concentric disk sampling on light physical disk) — correct geometry
-- Shadow rays: directional jitter (~2.8° angular cone) — cos/sin correct, unit vector normalization
-- Shadow ray result: `gl_RayQueryCommittedIntersectionNoneEXT` check → binary 0/1 shadow
-- Contact-hardening penumbra: distance-dependent width scaling formula
-- Reflection rays: origin bias along normal to avoid self-intersection
-- Reflection rays: direction = reflect(viewDir, normal) — sign conventions correct
-- Reflection rays: metalness/roughness gating thresholds (>0.3, <0.6) — consistent with PBR intent
-- Reflection hit: barycentric interpolation of UVs from global vertex SSBO — index math correct
-- Reflection hit: texture lookup from interpolated UV — descriptor indexing valid
-- GI bounce rays: cosine-weighted hemisphere sampling — correct tangent-space construction
-- GI bounce rays: distance cutoff (1500 units from camera) — check applied correctly
-- GI miss: sky fill contribution — no NaN or inf from miss
-- Window portal rays: through-ray direction, 2000-unit distance limit; window-portal demote path on glass that would otherwise infinite-loop (#789 — texture-equality identity check breaks the IOR refraction self-passthrough on coincident glass surfaces)
-- IOR refraction: roughness spread basis built via Frisvad orthonormal basis (#820 / REN-D9-NEW-01) — the legacy `cross(N, world-up)` construction degenerates near vertical surfaces; verify Frisvad is in use and tangent/bitangent are unit-length
-- IOR refraction: ray budget is `GLASS_RAY_BUDGET = 8192` (raised from 512 in 9a4dc15) — verify cap is wired and not silently exceeded; sky-tint fallback on miss is replaced by cell-ambient for interiors (bb53fd5 — no more open-sky tint inside dungeons)
-- IOR refraction diagnostics: `DBG_VIZ_GLASS_PASSTHRU = 0x80` flag exposes the passthrough decision per-fragment for bisecting glass loops; verify it's still wired in `triangle.frag` (symbol-anchored: `DBG_VIZ_GLASS_PASSTHRU` callsites at the diagnostic-state setup + the two viz-write branches in the refraction/glass loop) and not stripped by a refactor
-- Interleaved gradient noise: frame counter seeded correctly, no visible patterns
-- All ray queries: `rayQueryInitializeEXT` flags (gl_RayFlagsTerminateOnFirstHitEXT for shadows + reflection + glass)
-- All ray queries: TLAS binding is the correct descriptor (set 1, binding 2)
+- `VERTEX_STRIDE_FLOATS = 25` (100 B/vertex) is defined in `crates/renderer/src/shader_constants_data.rs`, consumed by `skin_compute.rs` via `use crate::shader_constants::VERTEX_STRIDE_FLOATS` (NOT a hardcoded `25`), pinned against `size_of::<Vertex>()` by the assert in `skin_compute.rs` — drift corrupts every skinned vertex.
+- `skin_palette.comp` (palette = `bone_world × bind_inverse`, GPU-side) pre-dispatches before `skin_vertices.comp`; both share a 64-wide workgroup; dispatch `(vertex_count + 63) / 64`.
+- `SkinPushConstants` (vertex_offset/count, bone_offset) matches the GLSL push-constant struct, ≤ 128 B.
+- Skinned output buffer usage flags include `STORAGE_BUFFER`, `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR`, and `VERTEX_BUFFER` (#681).
+- COMPUTE → AS-BUILD → FRAGMENT barrier scopes correct; refit (UPDATE mode) matches original BUILD geometry/vertex count; skinned BLAS pinned against LRU eviction while in flight; refit-count rebuild threshold per memory-budget.md.
+- Bone-palette overflow guard fires (`Once`-gated warn) at the cap — silent truncation past `MAX_TOTAL_BONES` was the M29 regression, pinned by `bone_palette_overflow_tests.rs`.
 **Output**: `/tmp/audit/renderer/dim_9.md`
 
-### Dimension 10: Denoiser & Composite Pipeline
-**Entry points**: `crates/renderer/src/vulkan/svgf.rs`, `crates/renderer/src/vulkan/composite.rs`, `crates/renderer/shaders/svgf_temporal.comp`, `crates/renderer/shaders/composite.frag`
+#### Dimension 10: Camera-relative render origin & f32 precision (#1495/#1496)
+**Entry points**: `crates/renderer/src/vulkan/scene_buffer/gpu_types.rs` (`GpuCamera.render_origin`), `byroredux/src/render/camera.rs`, `crates/renderer/shaders/triangle.vert` / `triangle.frag`, `byroredux/src/cell_loader/references.rs` (`RT_ABSOLUTE_PRECISION_CEILING`). Spec: shader-pipeline.md "Coordinate Spaces & Precision".
+**Severity floor**: a path mixing the two conventions = HIGH (large-world precision corruption).
 **Checklist**:
-- SVGF temporal accumulation: history buffer ping-pong correct (read previous, write current)
-- SVGF reprojection: motion vector application matches vertex shader output
-- SVGF mesh ID rejection: disocclusion detection prevents ghosting
-- SVGF blend factor: alpha clamped to valid range, first frame handled (no history → use current)
-- SVGF dispatch: workgroup size matches image dimensions (ceiling division)
-- SVGF descriptor updates: per-frame history buffer swap
-- Composite pass: direct light + denoised indirect + albedo + TAA-resolved HDR reassembly formula
-- Composite pass: ACES tone mapping applied after reassembly (not before)
-- Composite pass: fog handled correctly (applied to direct, not indirect)
-- Composite pass: output to swapchain image (correct format, correct layout transition)
-- SSAO integration: AO factor applied to indirect lighting (not direct)
-- Caustic accumulator (R32_UINT) sampled via `usampler2D`, divided by fixed-point scale, added to direct lighting (not indirect)
+- **Two conventions, never mixed.** Raster runs render-origin-**relative** (`viewProj × worldPos_rel` keeps full f32 at large offsets); RT stays **absolute** (TLAS transforms, skinned BLAS, ray origins/lighting/fog reconstructed as `worldPos_rel + render_origin`).
+- Rigid `GpuInstance.model` translation rebased on CPU; skinned path rebases blended bone-palette translation by `−render_origin` in `triangle.vert` (#1486).
+- `triangle.vert` emits `fragWorldPosRel` (location 3) **relative**; `triangle.frag` reconstructs absolute at top of `main()` (#1496) so `dFdx/dFdy` consumers (flat-shading normal, `perturbNormal` TBN, `parallaxDisplaceUV`, rtLOD footprint) see small magnitudes. Verify no derivative consumer was moved back to the absolute varying.
+- `RT_ABSOLUTE_PRECISION_CEILING = 2^20 = 1_048_576` — `references.rs` `debug_assert!`s loaded-cell max `|coord|` stays under it via `worldspace_extent_over_rt_ceiling` (unit-tested). Any new absolute-space shader consumer inherits this ceiling.
+- DoF: degenerate `focus_dist` guarded (#1525); `GpuCamera` doc accuracy (#1526).
 **Output**: `/tmp/audit/renderer/dim_10.md`
 
-### Dimension 11: TAA — Temporal Antialiasing (M37.5)
-**Entry points**: `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/shaders/taa.comp`, camera-UBO jitter assembly in `byroredux/src/render/camera.rs` and `crates/renderer/src/vulkan/scene_buffer/`
-**Checklist**:
-- Halton (2,3) sequence: index advances per frame, wraps without seam, jitter applied to projection matrix in NDC pixel units (not clip units)
-- Camera UBO carries the un-jittered projection alongside the jittered one (motion-vector reconstruction must use un-jittered)
-- Per-frame-in-flight history slot: this frame writes its own slot, next frame reads it via reprojection — confirm `MAX_FRAMES_IN_FLIGHT` slots, no aliasing
-- Reprojection: motion-vector sample uses linear filtering (or 5-tap dilation), not point — wrong filter causes edge wobble
-- YCoCg neighborhood clamp: 3×3 min/max in YCoCg, prev-frame sample clamped before blend (prevents history bleed during disocclusion)
-- Mesh ID disocclusion: prev-frame mesh_id sampled at reprojected UV, mismatch → discard history (use current pixel as pure)
-- First-frame / `should_force_history_reset` path: no NaN, no garbage history read, weight α forced to 1.0
-- Layout: history images held in `GENERAL` (storage write + sampled read), no UNDEFINED transitions per frame
-- Descriptor sets: 7 bindings (curr HDR, motion, curr+prev mesh_id, prev history, out storage, params UBO) match the docstring layout in `taa.rs`
-- SPIR-V reflection (`validate_set_layout` from `reflect.rs`) actually fires and matches Rust-side bindings
-- Composite samples the TAA output (not the raw HDR) when TAA is on
-- Disable path: when TAA off, composite must read raw HDR; the TAA dispatch should be skipped entirely (not run + ignored)
+---
+
+### MEDIUM tier — per-feature passes, shader correctness, visual
+
+#### Dimension 11: Pipeline state & render pass / G-buffer
+**Entry points**: `crates/renderer/src/vulkan/pipeline.rs`, `descriptors.rs`, `context/helpers.rs` (`create_render_pass`), `gbuffer.rs`.
+**Severity floor**: G-buffer format mismatch (shader output vs attachment) = HIGH.
+**Checklist** (formats/bindings are in shader-pipeline.md — audit the *match*, don't restate the table):
+- Vertex input matches `crates/renderer/src/vertex.rs` (binding/location/format/offset); push-constant ranges match shader declarations; dynamic viewport/scissor (and dynamic `CULL_MODE` for water two-sided) set each frame.
+- G-buffer pipeline writes all six color attachments; composite inputs match G-buffer + denoiser outputs; SSAO/cluster-cull compute descriptor layouts correct.
+- Mesh-ID encoding: `R32_UINT`, bits 0–30 = instance id + 1, bit 31 (`0x80000000`) = `ALPHA_BLEND_NO_HISTORY` (SVGF skip). Encoded shader-side in `triangle.frag` (`outMeshID = meshIdBase | (alphaBlendFrag ? 0x80000000u : 0u)`); runtime overrun is a one-shot `warn!` + clamp in `draw_frame`/`upload_instances` (NOT a `debug_assert!` — moved off the assert to avoid leaking the in-flight cmd buffer on unwind, #956/#992).
+- Render-pass load/store ops, layout transitions, subpass dependencies cover all stage/access masks; G-buffer images created `SAMPLED` (SVGF/composite read). **Flag barrier/dependency changes as needs-RenderDoc.**
+- Pipeline cache: header pre-validated against the device before handoff; mismatch → warning + empty cache, no crash (`context/helpers.rs`, SAFE-11/#91).
 **Output**: `/tmp/audit/renderer/dim_11.md`
 
-### Dimension 12: GPU Skinning Compute + BLAS Refit (M29.5 + M29.3)
-**Entry points**: `crates/renderer/src/vulkan/skin_compute.rs`, `crates/renderer/shaders/skin_vertices.comp`, `crates/renderer/shaders/skin_palette.comp` (M29.5 palette pre-dispatch — `palette[i] = bone_world[i] * bind_inverses[i]`, SPIR-V at `skin_compute.rs:32`), `crates/renderer/src/vulkan/acceleration/` (per-skinned-entity BLAS refit), `byroredux/src/render/skinned.rs` (skinned-mesh enumeration + `build_skinned_palettes` at `:64`)
+#### Dimension 12: Command buffer recording
+**Entry points**: `crates/renderer/src/vulkan/context/draw.rs`.
 **Checklist**:
-- `VERTEX_STRIDE_FLOATS = 25` matches `crates/renderer/src/vertex.rs::Vertex` exactly (100 B / vertex; widened from the pre-M-NORMALS 21 / 84 B per #783 once tangent + bitangent_sign landed). The const lives in `crates/renderer/src/shader_constants_data.rs:36` (generated into `shaders/include/shader_constants.glsl`) and is consumed by `skin_compute.rs` via `use crate::shader_constants::VERTEX_STRIDE_FLOATS` (NOT a hardcoded `25` in skin_compute.rs); pinned against `size_of::<Vertex>()` by the assert at `skin_compute.rs:923`. Drift here corrupts every skinned vertex
-- `skin_palette.comp` and `skin_vertices.comp` share the same 64-wide workgroup (`skin_compute.rs:35`); the palette pre-dispatch runs before the vertex skin so the bone palette is `bone_world × bind_inverse`-resolved on the GPU, not host-side
-- `SkinPushConstants` (vertex_offset, vertex_count, bone_offset) matches the GLSL `PushConstants` struct in skin_vertices.comp; total ≤ 128 B
-- Per-skinned-mesh output buffer usage flags include `STORAGE_BUFFER` AND `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR` (BLAS reads it). M29.3 Phase 3 also re-adds `VERTEX_BUFFER` (#681 / `MEM-2-6` regression note in roadmap)
-- Bone palette SSBO is DEVICE_LOCAL with HOST_VISIBLE staging, uploaded once per frame, sized for `MAX_TOTAL_BONES`
-- COMPUTE → AS-BUILD → FRAGMENT barrier chain: skin write → BLAS refit → ray-query read in fragment shader (audit barrier scopes match)
-- BLAS refit (UPDATE mode) called per frame for skinned entities; geometry count + vertex count must match the original BUILD or Vulkan validation faults
-- BLAS refit budget / LRU interaction: skinned BLAS must not be evicted by M36 LRU mid-frame (pin while in flight)
-- `MAX_TOTAL_BONES` overflow guard (in `byroredux/src/render/skinned.rs` — `Once`-gated warn at the bone-palette emit site) actually fires when the bone-palette buffer is full — silent truncation past the cap was the regression in M29. Pinned by `byroredux/src/render/bone_palette_overflow_tests.rs`
-- Workgroup size 64 matches `local_size_x` in skin_vertices.comp; dispatch uses `(vertex_count + 63) / 64` invocations
-- Phase status: confirm whether raster reads inline-skinning (`triangle.vert:147-204`) or pre-skinned (M29.3) — both are valid but cannot coexist in a single mesh
+- Reset-before-record, begin/end balanced (command buffer + render pass), AS build recorded outside the render pass, SVGF/compute after RP end and before composite, composite last (then egui, then optional screenshot copy).
+- Per-draw: depth bias for decals, pipeline/descriptor bind, push constants, indexed draw; batch coalescing groups draws by texture/descriptor.
+- Counter independence (regression guards): `DrawCommand` input count vs post-batch GPU draw count are separate metrics, both surfaced (#1258); blend-pipeline cache-hit fast path exists at the per-draw bind site (#1259); off-frustum draws skip `GpuInstance.flags` assembly without dropping state on frustum-border visible draws (#1260); cell-loader REFR spawn reads `SceneFlags` from the world resource, not a cached snapshot (#1235).
 **Output**: `/tmp/audit/renderer/dim_12.md`
 
-### Dimension 13: Caustic Splat (#321 Option A)
-**Entry points**: `crates/renderer/src/vulkan/caustic.rs`, `crates/renderer/shaders/caustic_splat.comp`, composite consumption in `crates/renderer/shaders/composite.frag`
+#### Dimension 13: TAA (M37.5)
+**Entry points**: `crates/renderer/src/vulkan/taa.rs`, `crates/renderer/shaders/taa.comp`, jitter assembly in `byroredux/src/render/camera.rs`.
 **Checklist**:
-- Per-frame-in-flight `caustic_accum` images created with `STORAGE | SAMPLED | TRANSFER_DST` and R32_UINT format
-- Frame begins with `vkCmdClearColorImage` to zero the accumulator BEFORE the dispatch
-- HOST→COMPUTE barrier on params UBO + CLEAR→COMPUTE barrier on the image, both before dispatch
-- Atomic accumulation: shader uses `imageAtomicAdd` on a u32 fixed-point representation (no float storage, no race)
-- Fixed-point scale documented in CausticParams matches the divide in composite.frag
-- COMPUTE→FRAGMENT barrier before composite samples the accumulator (or layout-transition-equivalent dependency)
-- Layout stays in `GENERAL` for the accumulator (composite reads via usampler2D, legal in GENERAL)
-- 9-binding descriptor set matches the layout table in caustic.rs docstring (depth, normal, mesh_id, lights, camera, instances, TLAS, accum image, params UBO)
-- Source-pixel selection (only refractive / water surfaces splat): material flag check pulls from the right field after R1 indirection (`materials[material_id]`, not the legacy GpuInstance copy)
-- Output added to direct lighting only — never doubled into the indirect path that SVGF already denoised
+- Halton(2,3) jitter advances per frame (no seam), applied in NDC pixel units; un-jittered projection retained for motion-vector reconstruction.
+- Per-frame-in-flight history slot (no aliasing); reprojection samples motion with linear/dilated filter (point causes edge wobble); 3×3 YCoCg neighborhood clamp on the history sample; mesh-ID disocclusion discards stale history; first-frame / `should_force_history_reset` forces α = 1.0 with no garbage read.
+- Moving-pixel accumulation α floored under a parked camera (regression guard, #1497).
+- History images in `GENERAL` (no per-frame UNDEFINED); `validate_set_layout` (`reflect.rs`) fires and matches Rust bindings; composite samples TAA output only when TAA on; disable path skips the dispatch entirely.
 **Output**: `/tmp/audit/renderer/dim_13.md`
 
-### Dimension 14: Material Table (R1)
-**Entry points**: `crates/renderer/src/vulkan/material.rs`, `crates/renderer/src/vulkan/scene_buffer/` (GpuInstance, **`MAX_MATERIALS = 16384`** post-`7823eb59` — was 4096; bump came after Riverwood / FO4 cells saturated the 4096 cap), `byroredux/src/render/mod.rs` (build_render_data), `byroredux/src/render/static_meshes.rs` (material intern call sites), all 5 shaders that declare `struct GpuInstance` (`triangle.vert`, `triangle.frag`, `ui.vert`, `water.vert`, `caustic_splat.comp`) — verify via `grep -l "struct GpuInstance" crates/renderer/shaders/`
-**Upstream**: the `Material` records this table interns are produced by the NIFAL boundary (Dim 22, `byroredux/src/material_translate.rs::translate_material`) — a corrupt `GpuMaterial` here may be a translate-side bug, not an intern-side one. See also `/audit-nifal`.
+#### Dimension 14: Caustic splat (#321)
+**Entry points**: `crates/renderer/src/vulkan/caustic.rs`, `crates/renderer/shaders/caustic_splat.comp`, composite consumption in `composite.frag`.
 **Checklist**:
-- `GpuMaterial` is exactly **300 bytes** (`gpu_material_size_is_260_bytes` asserts `300` at `material.rs:1157` — the test NAME is historical, kept for grep continuity, NOT the asserted value; rationale at `material.rs:41-42`). Past size changes: #804, #1249, #1250. Any field add/remove must update the Rust struct, the GLSL `struct GpuMaterial` (in `triangle.frag` — the only shader that declares it), and the `gpu_material_field_offsets_match_shader_contract` offsets in lockstep
-- Per-field offset pinning (`gpu_material_field_offsets_match_shader_contract`, #806): all 65 named-field offsets across 16 vec4 slots are asserted; size-only pin cannot catch within-vec4 reorders (e.g. swapping `texture_index ↔ normal_map_index`). Any new field must add a matching offset assertion
-- ALL `GpuMaterial` fields are scalar (f32/u32) — NEVER `[f32; 3]`. std430 vec3 alignment would silently desync byte-Hash dedup
-- Hash + Eq impls treat `GpuMaterial` as raw bytes; named pad fields explicitly zeroed at construction (no uninit bytes from `MaybeUninit`)
-- `MaterialTable::intern` produces stable `material_id`s within a frame; identical materials collapse to one entry. **Cap**: over-cap interns return id `0` (sharing the first material's record) with a one-shot `warn!` — verify the warn fires and over-cap entries do NOT corrupt SSBO indexing (#797 SAFE-22)
-- Per-frame MaterialBuffer SSBO uploaded once, sized to `min(intern_count, MAX_MATERIALS)`; truncation at the upload site is the safety net, capping at intern is the source of truth (no over-allocation, no reuse-without-resize bug)
-- **Capacity overflow surfaced via mem stats** (`7823eb59`): when intern overflows `MAX_MATERIALS = 16384`, the over-cap counter is exposed in `mem.stats` for diagnostic visibility. Verify the counter is reset per-frame and the warn-once still fires
-- Dedup-ratio telemetry exposed (#780 PERF-N1): unique material count vs placement count surfaced via console — Prospector baseline 1200 placements → 87 unique (~14× hit rate). Regression = audit finding even if correctness holds
-- **Shader flag bits routed through generated header** (#1190 / TD4-NEW-01): `MAT_FLAG_*` bits in `crates/renderer/src/shader_constants_data.rs` emit into the auto-generated `crates/renderer/shaders/include/shader_constants.glsl` consumed by `triangle.frag`. Any new flag added Rust-side must NOT be hand-written into the shader — the generated header is the source of truth. Sibling of the `DBG_*` lockstep contract pinned at Dim 16
-- **BSLightingShaderProperty PBR scalars at import** (#1241): smoothness / IOR / specular-strength surfaced into `MaterialInfo` so the Disney lobe (Dim 21) has authored data to consume. BGSM smoothness is normalized to glossiness scale at parse (`98383caf`); verify the conversion doesn't double-apply on raw FO4 BGSM authoring
-- **WaterShaderProperty + BSShaderPropertyBaseOnly consumers wired at import** (#1243 / #1244, FO3/FNV legacy): water materials and bare BSShaderProperty stubs both route through MaterialInfo now. Verify both produce distinct GpuMaterial entries (no dedup collapse with glass / opaque siblings)
-- **HasModelSpaceNormals flag routed for direct-TXST REFRs** (#972): FO4 TXST records with model-space normals (no DerivedNormalMap) flag through to the shader, gating the PBR / SSS path at `triangle.frag` (#1147 Phase 2b)
-- `GpuInstance.material_id: u32` ships in the Phase 3+ instance struct; legacy per-instance fields confirmed dropped from Phases 4–6 already-migrated slices
-- Shader-side `materials[instance.material_id].foo` reads use the same offsets as the Rust struct (Phase 4–5 mechanical migration check). The #785 R-N1 regression of `ui.vert` reading the wrong MaterialBuffer offset is a recurring trap — verify `ui.vert` is in lockstep with the offset-pin contract, not just `triangle.frag`
-- All 5 shaders updated in lockstep — `triangle.vert`, `triangle.frag`, `ui.vert`, `water.vert`, `caustic_splat.comp` (per `feedback_shader_struct_sync.md`). Use `grep -l "struct GpuInstance" crates/renderer/shaders/` as the canonical drift check
-- Identity invariant: render output for a scene with N copies of the same material must be byte-identical pre/post R1 dedup
-- Phase status check: any per-instance fields that R1 did NOT migrate yet should be flagged (Phase 6 was the closeout — verify nothing remains in DrawCommand/GpuInstance that should now live in GpuMaterial)
+- Per-FIF `caustic_accum` (`R32_UINT`, `STORAGE|SAMPLED|TRANSFER_DST`); cleared via `vkCmdClearColorImage` before dispatch; HOST→COMPUTE + CLEAR→COMPUTE barriers before dispatch; COMPUTE→FRAGMENT before composite sample; stays in `GENERAL`.
+- Accumulation via `imageAtomicAdd` on u32 fixed-point (no float race); fixed-point scale in `CausticParams` matches the composite divide.
+- Source-pixel selection reads the material flag from `materials[material_id]` (post-R1), using `INSTANCE_FLAG_CAUSTIC_SOURCE` macro (not a hex literal, #1234). Output added to direct only.
+- `caustic_splat.comp` "water-side caustic is the water shader's responsibility" comment matches the live `water.frag` impl, not a stub (Dim 15).
 **Output**: `/tmp/audit/renderer/dim_14.md`
 
-### Dimension 15: Sky / Weather / Exterior Lighting (M33 / M33.1 / M34)
-**Entry points**: `byroredux/src/systems/weather.rs` (weather_system; post-Session-34 split — was in monolithic systems.rs), `byroredux/src/render/sky.rs` (sun arc + TOD palette assembly; post-#1115 split — was in monolithic render.rs), `crates/plugin/src/esm/records/weather.rs`, `crates/renderer/shaders/triangle.frag` (sky gradient + cloud sample + fog application)
+#### Dimension 15: Water (M38) + water-side caustics
+**Entry points**: `crates/renderer/src/vulkan/water.rs`, `crates/renderer/src/vulkan/water_caustic.rs` (`WaterCausticAccum`), `crates/renderer/shaders/water.vert`/`water.frag`, `byroredux/src/cell_loader/water.rs`, `byroredux/src/systems/water.rs` (`submersion_system`). Shared water components live in `crates/core/src/ecs/components/water.rs`.
 **Checklist**:
-- `weather_system` advances game time monotonically; sun arc derived from CLMT TNAM hours, not hardcoded
-- TOD color interpolation between WTHR NAM0 colors uses the right easing (linear vs cosine) — verify against legacy
-- Weather fade (`WeatherTransitionRes`) blends over 8 s post-TOD-sample (color blend AFTER TOD lookup, not before)
-- All 4 cloud layers active in exterior cells (M33.1 closed) — layers 2/3 sample ANAM/BNAM with parallax scroll
-- Cloud parallax direction vector is in world XY, not screen-space; magnitude scales with TOD wind multiplier
-- Sky gradient: zenith → horizon RGB pulled from active TOD palette, applied in non-RT miss-fill path; consistent with the GI miss "sky fill contribution" used in Dim 9
-- Sun directional: direction vector from sun arc, color/intensity from TOD, shadow ray budget bounded
-- Fog: applied to direct lighting only, NOT to indirect (composite Dim 10 invariant — re-check after sky changes)
-- Interior fill at 0.6× ambient + `radius=-1` (unshadowed); `triangle.frag` `isInteriorFill = radius < 0.0` gates RT shadow on `!isInteriorFill` — verify the gate (symbol-anchored, post-#1200 convention) hasn't drifted
-- Disabled-WTHR fallback: when no weather record loaded, defaults must produce neutral lighting (no NaN, no pitch-black)
-- M40 streaming interaction: cell transition does not strobe TOD (palette is per-worldspace + global TOD clock, not per-cell)
+- WaterPlane spawned from interior/exterior cell water records (height/extent match); vertex displacement bounded, no NaN, no Z-fight at shoreline; Fresnel base ~0.02 (do NOT reuse glass IOR 1.5); RT reflect/refract (IOR ~1.33) miss → sky/backdrop with fog (not black/magenta).
+- `submersion_system` flips `SubmersionState` at the water plane with no per-frame strobe; cell unload despawns water cleanly (no leaked BLAS vs post-unload TLAS); water doesn't cast opaque shadows; two-sided via dynamic `CULL_MODE`; sort key places water per `byroredux/src/render/sort_key_tests.rs` ordering; distinct `GpuMaterial` entry (no dedup collapse with glass).
+- Procedural-noise precision bound marked for absolute-world UVs (regression guard, #1502).
+- Water-side caustic synthesis (regression guards): `sun_direction` plumbed through `GpuCamera` and uploaded each frame (not stale-from-init); `WaterCausticAccum` lifecycle (per-FIF `R32_UINT`, GENERAL/TRANSFER_DST/GENERAL, reverse-order `destroy`) lives in `water_caustic.rs` while `water.rs` owns only the descriptor set/layout/pool; `water.frag` actually writes the accumulator via `imageAtomicAdd`; composite samples it into **direct** lighting (#1210 Phases A–E / #1255–#1257).
 **Output**: `/tmp/audit/renderer/dim_15.md`
 
-### Dimension 16: Tangent-Space & Normal Maps (M-NORMALS)
-**Entry points**: `crates/nif/src/import/mesh/tangent.rs` (extract_tangents_from_extra_data, synthesize_tangents), `crates/nif/src/import/mesh/bs_tri_shape.rs` (BSTriShape inline-tangent decode), `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (VF_TANGENTS = 0x010, packed-vertex tangent stride; split out post-#1118), `crates/renderer/shaders/triangle.frag` (perturbNormal, DBG_BYPASS_NORMAL_MAP / DBG_VIZ_NORMALS / DBG_VIZ_TANGENT)
-**Checklist**:
-- Oblivion / FO3 / FNV path: per-vertex tangents pulled from `NiBinaryExtraData` named `"Tangent space (binormal & tangent vectors)"` — Bethesda's blob is `[tangents..., bitangents...]` Z-up, but their "tangent" field is actually `∂P/∂V` and "bitangent" is `∂P/∂U` (`CalcTangentSpace` swap). The decoder MUST read the **bitangent half** (offset `num_verts * 12`) into `Vertex.tangent.xyz` and use the tangent half to derive the bitangent sign — handedness regression here was #786 (fixed 5dde345). Audit for any new path that re-reads the blob without honoring the swap
-- FO4+ BSTriShape inline tangents: when `VF_TANGENTS | VF_NORMALS` are both set on the packed-vertex flag (`tri_shape/bs_tri_shape.rs::BsTriShape` packed-vertex loop, symbol-anchored per post-#1040 convention), tangents ship inline in the packed-vertex blob, NOT in a separate `NiBinaryExtraData`. This is distinct from the Skyrim path; verify the FO4 inline decode (#795 / #796, b63ab0c) still fires and is not gated behind the wrong BSVER
-- Synthesized fallback: when the authored blob is missing or malformed (size mismatch warns, see `mesh.rs:87`), the importer falls through to nifly's `CalcTangentSpace` synthesis (`synthesize_tangents`). Verify the fallback path produces unit-length tangents and consistent bitangent signs
-- Bitangent sign convention: `B = bitangent_sign * cross(N, T)` — the sign is reconstructed shader-side from `Vertex.tangent.w`. Verify the convention is consistent across the three import paths (Bethesda authored, FO4 inline, synthesized)
-- Coordinate conversion: Z-up (Gamebryo) → Y-up (renderer) applied to tangent xyz components in lockstep with normal conversion (no path that converts N but not T, or vice versa)
-- `perturbNormal` is **default-on** (#787 / #788, b8ab477) with the Path-1 transform fixed; `DBG_BYPASS_NORMAL_MAP = 0x10` is the runtime opt-out for bisecting (`crates/renderer/shaders/triangle.frag::DBG_BYPASS_NORMAL_MAP`). Verify the bit is still recognized
-- Permanent diagnostic bit catalog (Rust source-of-truth at `crates/renderer/src/shader_constants_data.rs::DBG_*`; emitted by `build.rs` into the auto-generated `crates/renderer/shaders/include/shader_constants.glsl` which `triangle.frag` `#include`s): `DBG_BYPASS_POM = 0x1`, `DBG_BYPASS_DETAIL = 0x2`, `DBG_VIZ_NORMALS = 0x4`, `DBG_VIZ_TANGENT = 0x8`, `DBG_BYPASS_NORMAL_MAP = 0x10`, `DBG_RESERVED_20 = 0x20` (formerly `DBG_FORCE_NORMAL_MAP`, no-op post-#1035), `DBG_VIZ_RENDER_LAYER = 0x40`, `DBG_VIZ_GLASS_PASSTHRU = 0x80`, `DBG_DISABLE_SPECULAR_AA = 0x100`, `DBG_DISABLE_HALF_LAMBERT_FILL = 0x200`. Pinned in lockstep by two tests in `crates/renderer/src/shader_constants.rs`: `tests::generated_header_contains_all_defines` (positive side — every `DBG_*` const is emitted into the generated header with the correct value) and `tests::triangle_frag_dbg_bits_not_redeclared` (negative side — `triangle.frag` does NOT redeclare the const block, polarity-flipped post-#1162 when the consts moved out of the shader). Audit for drift: any added bit must not collide; any dropped bit must not orphan shader code
-- "Chrome posterized walls" red herring: per `feedback_chrome_means_missing_textures.md`, that artifact is the magenta-checker placeholder × a (correctly loaded) tangent-space normal map. Audit findings claiming a tangent-space bug from chrome fragments alone are stale — the audit MUST run `tex.missing` first before recommending a tangent-space fix
+#### Dimension 16: Volumetrics (M55) & bloom (M58)
+**Entry points**: `crates/renderer/src/vulkan/volumetrics.rs`, `bloom.rs`, `crates/renderer/shaders/volumetrics_inject.comp`, `volumetrics_integrate.comp`, `bloom_downsample.comp`, `bloom_upsample.comp`, composite consumption in `composite.frag`.
+**Checklist** — volumetrics:
+- Froxel grid 160×90×128 matches the inject `local_size`; dispatch covers exactly the grid; per-FIF buffer (~14 MiB/slot, no cross-frame WAR); inject does a single `TerminateOnFirstHit` shadow ray per froxel; integrate multiplies transmittance across the walk; HG `g` clamped to (−0.999, 0.999).
+- Gate `VOLUMETRIC_OUTPUT_CONSUMED` (#928): if composite drops the sample, the dispatch must be skipped (not dispatched + ignored). Interior cells (no sun) produce neutral non-NaN output; resize rebinds both volumetric and composite descriptors (#905).
+
+**Checklist** — bloom:
+- 5 down-mips + 4 up-mips, `B10G11R11_UFLOAT` throughout (no R16G16B16A16 mid-chain); 4-tap bilinear down (weights sum 1.0), additive up (no [0,1] clamp); per-FIF mip chain (cross-frame WAR gated by fence — do NOT reintroduce the redundant pre-barriers removed in #931).
+- Bloom added **before** ACES tone-map (HDR add); intensity constant in `composite.frag`; source is the un-tone-mapped HDR (NOT the TAA output — descriptor-binding regression pattern); disable path short-circuits both dispatch and composite addition.
 **Output**: `/tmp/audit/renderer/dim_16.md`
 
-### Dimension 17: Water Rendering (M38)
-**Entry points**: `crates/renderer/src/vulkan/water.rs` (WaterPipeline — owns the water-caustic descriptor set/layout/pool), `crates/renderer/src/vulkan/water_caustic.rs` (`WaterCausticAccum` struct at `:57`, per-frame R32_UINT accumulator image lifecycle, `new()` at `:68`), `crates/renderer/shaders/water.vert/frag`, `byroredux/src/cell_loader/water.rs` (water-plane spawn from XCWT / cell water refs), `byroredux/src/systems/water.rs` (`submersion_system`), `byroredux/src/components.rs` (WaterPlane, WaterVolume, SubmersionState components)
-**Checklist**:
-- WaterPlane ECS component spawned from interior/exterior cell water records; height + extent match cell record
-- WaterPipeline vertex displacement: amplitude bounded, no NaN at edge tessellation, no Z-fighting with shoreline geometry
-- Fresnel term: schlick approximation against view dir, base reflectance ~0.02 for water (do not reuse glass IOR 1.5)
-- RT reflection ray: TLAS query reflected about water normal; missed rays sample sky (not black, not magenta)
-- RT refraction ray: TLAS query along refracted dir, IOR ~1.33; missed rays sample backdrop with proper fog
-- Camera SubmersionState write: `submersion_system` flips component when camera Y crosses water plane; underwater fog / tint applied via composite (verify no per-frame strobe at the boundary)
-- Cell unload: water entities despawn cleanly; no leaked BLAS entries against post-unload TLAS (`AccelerationManager::evict_unused_blas` covers them)
-- Shadow casting: water surface does NOT contribute to shadow rays for opaque geometry (reflection-only)
-- Two-sided rendering: water disables back-face cull (underwater view from below); confirm via dynamic CULL_MODE not pipeline duplicate
-- Sort key: water plane rendered after opaques, before transparents (or in transparent pass with alpha-blend) — verify against `render::sort_key` ordering
-- Material slot: water uses a distinct GpuMaterial entry (separate from glass) — verify dedup doesn't collapse them
-- **Water-side caustic synthesis — landed across #1210 Phases A-E.** Verify each phase is still live:
-  - **Phase A+B** (`8a1a06b4`): `sun_direction` plumbed through `CameraUBO` — required input for water-side caustic synthesis. Verify `camera_ubo.sun_direction.xyz` is uploaded each frame and not stale-from-init
-  - **Phase C** (`5f1a9158` / #1255): `WaterCausticAccum` image lifecycle correct (per-frame-in-flight, R32_UINT, STORAGE|SAMPLED|TRANSFER_DST). Layout: GENERAL for compute write, TRANSFER_DST for clear, GENERAL for composite sample. The accumulator image now lives in the dedicated `crates/renderer/src/vulkan/water_caustic.rs` (`WaterCausticAccum`), NOT inline in `water.rs` — verify its `destroy`/teardown reverse-order; `water.rs` only owns the matching descriptor set/layout/pool (`water_caustic_set_layout` etc. at `water.rs:170-177`)
-  - **Phase D** (`19dfc79c` / #1256): water-side caustic synthesis ACTIVE in `water.frag` — verify the synthesis code (sun-direction-based caustic pattern) actually runs and writes to the accumulator via `imageAtomicAdd`. Sibling check: `caustic_splat.comp:223-224`'s "the water-side caustic is the water shader's responsibility (M38)" comment should now match a live water.frag implementation, not a stub
-  - **Phase E** (`c87ca9db` / #1257): composite samples the accumulator at the gather site (composite.frag) and adds to direct lighting (not indirect — same invariant as the glass/MultiLayerParallax caustics from Dim 13)
-  - **INSTANCE_FLAG_CAUSTIC_SOURCE** (#1234): `caustic_splat.comp` uses the named macro from `shader_constants_data.rs`, not a hex literal. Sibling of the `MAT_FLAG_*` lockstep contract (Dim 14)
+#### Dimension 17: Disney BSDF / PBR gating (#1248–#1254) + soft shadows
+**Entry points**: `crates/renderer/shaders/triangle.frag` (Disney lobe fns + gate sites), `crates/renderer/src/vulkan/material.rs` (Disney preset constructors), `byroredux/src/render/sky.rs` (`sun_angular_radius`).
+**Checklist** — Disney (symbol-anchored; flag bits live in `shader_constants_data.rs`, NOT hand-declared in the shader — verify, this was the #1357 migration):
+- Gate is `MAT_FLAG_PBR_BSDF` (bit 5) only — grep `MAT_FLAG_PBR_BSDF` gate sites in `triangle.frag` and confirm each lights the Disney lobe (no FNV/FO3/Skyrim legacy path tripping it). FNV/FO3/Oblivion: zero materials set the flag → lobe unreachable. FO4/FO76/Starfield: BGSM is canonical → lobe is the expected path (regression is a BGSM falling back to Lambert).
+- `dielectricF0FromIor(eta)` derives F0 from per-material IOR (not hardcoded 0.04), with input-domain clamp guarding `eta ≤ 0` (#1248/#1253).
+- `distributionGGXAniso(NdotH, HdotX, HdotY, ax, ay)` MUST degenerate exactly to isotropic GGX when `ax == ay` (legacy-compat contract, #1250); `deriveAxAy(roughness, anisotropic, …)` clamps `anisotropic` to [0,1] (half-axis convention per GLSL-PathTracer, NOT Disney-2012 `[-1,1]`) — verify no `sqrt(<0)` at `anisotropic = 1.0` (#1254).
+- `disneyDiffuseSplit(...)` returns split lobes (Burley retro + sheen + Hanrahan-Krueger SSS); sheen is additive, NOT divided by π (#1249/#1252).
+- `#1147 Phase 2b` siblings fire independently: `MAT_FLAG_TRANSLUCENCY` (bit 6) → SSS, modulated by `MAT_FLAG_TRANSLUCENCY_THICK_OBJECT` (bit 8) / `MAT_FLAG_TRANSLUCENCY_MIX_ALBEDO` (bit 9); `MAT_FLAG_MODEL_SPACE_NORMALS` (bit 7, set by #972) → model-space sampling. No spurious cross-activation.
+- Disney preset constructors in `material.rs` match documented values (cross-ref GLSL-PathTracer per `reference_glsl_pathtracer.md`).
+
+**Checklist** — soft shadows (M-LIGHT):
+- `sun_angular_radius` ships in `GpuCamera`; shipping default `0.020` rad (sky-params assert caps < 0.10) — drift changes shadow softness globally.
+- Single-tap stochastic cone sample around the sun, deterministic per-pixel-per-frame (no true RNG that breaks TAA history); `TerminateOnFirstHit`; TAA absorbs the noise (YCoCg clamp tolerance allows convergence).
+- Interior fill (`radius < 0.0` → `isInteriorFill`) bypasses the cone sample; disocclusion single-sample fallback is not black.
 **Output**: `/tmp/audit/renderer/dim_17.md`
 
-### Dimension 18: Volumetric Lighting (M55)
-**Entry points**: `crates/renderer/src/vulkan/volumetrics.rs` (160×90×128 froxel grid, ~14 MiB / slot), `crates/renderer/shaders/volumetrics_inject.comp`, `crates/renderer/shaders/volumetrics_integrate.comp`, composite consumption in `crates/renderer/shaders/composite.frag`
+#### Dimension 18: Sky / weather / exterior lighting (M33/M34)
+**Entry points**: `byroredux/src/systems/weather.rs`, `byroredux/src/render/sky.rs`, `crates/plugin/src/esm/records/weather.rs`, `crates/renderer/shaders/triangle.frag` (sky gradient + cloud + fog). See also `/audit-exal`.
 **Checklist**:
-- Froxel dimensions `160 × 90 × 128` match `volumetrics_inject.comp` `local_size_x/y/z`; dispatch group count covers exactly the grid (no over-dispatch)
-- Per-frame-in-flight buffer sizing: one ~14 MiB image per frame-in-flight slot, not shared across frames (avoid WAR hazard on integrate read)
-- Inject pass: per-froxel HG phase scattering, single shadow ray vs TLAS per froxel — verify `gl_RayFlagsTerminateOnFirstHitEXT` is set so cost stays bounded
-- Integrate pass: depth-walk integration produces an accumulated luminance + transmittance per froxel; transmittance is multiplied (not added) across the walk
-- HG phase function: anisotropy `g` clamped to (-0.999, 0.999) — `g = ±1` produces division-by-zero
-- Output consumed: composite shader samples the integrated 3D image at fragment depth → world Z mapping; the gate `VOLUMETRIC_OUTPUT_CONSUMED: bool` (#928) must remain in lockstep — if composite path drops the sample, the dispatch must be skipped
-- Disabled path: when volumetrics is off, integrate dispatch is skipped entirely (not dispatched + ignored — was the audit finding from #928)
-- Resize: image-view rebind on composite resize (#905); verify both volumetric and composite descriptor sets get refreshed
-- Sun-arc dependency: scattering color/intensity reads from the TOD palette; interior cells with no exterior sun must still produce neutral non-NaN output
-- Performance: budget allows the inject+integrate pair to complete in <2 ms on RTX 4070 Ti at the documented exterior bench
+- `weather_system` advances game time monotonically; sun arc from CLMT TNAM hours (not hardcoded); TOD color easing matches legacy; weather fade blends AFTER the TOD lookup (`WeatherTransitionRes`); all 4 cloud layers active with world-XY parallax scaled by TOD wind.
+- Sky gradient (zenith→horizon) from active TOD palette in the non-RT miss-fill, consistent with the GI miss "sky fill" (Dim 2); fog applied to direct only (Dim 8); interior fill at 0.6× ambient with `radius = −1` (unshadowed), gating RT shadow on `!isInteriorFill` (symbol-anchored, #1200).
+- Disabled-WTHR fallback is neutral (no NaN / pitch-black); cell transition does not strobe TOD (palette is per-worldspace + global clock, not per-cell).
 **Output**: `/tmp/audit/renderer/dim_18.md`
 
-### Dimension 19: Bloom Pyramid (M58)
-**Entry points**: `crates/renderer/src/vulkan/bloom.rs` (5-mip down + 4-mip up, B10G11R11_UFLOAT), `crates/renderer/shaders/bloom_downsample.comp`, `crates/renderer/shaders/bloom_upsample.comp`, composite addition in `crates/renderer/shaders/composite.frag`
+#### Dimension 19: Tangent-space & normal maps (M-NORMALS)
+**Entry points**: `crates/nif/src/import/mesh/tangent.rs`, `crates/nif/src/import/mesh/bs_tri_shape.rs`, `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (`VF_TANGENTS`), `crates/renderer/shaders/triangle.frag` (`perturbNormal`).
 **Checklist**:
-- Pyramid size: 5 down-mips + 4 up-mips; each mip is half the previous in X+Y; format `B10G11R11_UFLOAT` everywhere (no R16G16B16A16 mid-chain)
-- Down-pass: 4-tap bilinear box filter — sample offsets at half-pixel centers, weights sum to 1.0
-- Up-pass: 4-tap bilinear additive blend with previous up-mip; no clamp to [0,1] (HDR additive)
-- Per-frame-in-flight slot owns its own mip chain — cross-frame WAR is gated by the per-frame fence (#931 audit: do NOT reintroduce the 9 redundant pre-barriers that were removed)
-- Barrier count: 10 barriers per dispatch (down to 47% from pre-#931's 19); regression = audit finding even if correctness holds
-- Intensity: composite multiplies bloom by 0.15 (tuned down from 0.20 on Prospector saloon); the constant lives in `composite.frag` — drift here is a visual regression
-- Image-view rebind on composite resize (#905) — verify bloom + composite descriptor sets both refresh
-- Disabled path: when bloom is off, neither down nor up is dispatched; composite must short-circuit the addition
-- Tone-map order: bloom is added BEFORE ACES tone mapping (HDR addition), not after (LDR addition would clip)
-- Source pyramid input: must read the un-tone-mapped HDR (`composite.frag` input), not the TAA output (TAA inputs to bloom is a regression pattern — verify the descriptor binding)
+- Oblivion/FO3/FNV: per-vertex tangents from `NiBinaryExtraData` "Tangent space …" — Bethesda's "tangent" is `∂P/∂V` and "bitangent" is `∂P/∂U` (the `CalcTangentSpace` swap). The decoder must read the **bitangent half** into `Vertex.tangent.xyz` and derive the sign from the tangent half (handedness regression #786). 
+- FO4+ BSTriShape inline tangents when `VF_TANGENTS | VF_NORMALS` set (packed-vertex loop) — distinct from Skyrim, not gated on the wrong BSVER (#795/#796).
+- Synthesized fallback (`synthesize_tangents`) produces unit-length tangents + consistent signs when the blob is missing/malformed.
+- Sign convention `B = bitangent_sign * cross(N, T)` reconstructed from `Vertex.tangent.w`, consistent across all three import paths; Z-up→Y-up conversion applied to tangent xyz in lockstep with the normal (no path converting N but not T).
+- `perturbNormal` default-on (#787/#788); `DBG_BYPASS_NORMAL_MAP` (0x10) runtime opt-out still recognized; the 13-bit `DBG_*` catalog pinned in lockstep (Dim 3).
+- "Chrome posterized walls" is the magenta-checker placeholder × a correctly-loaded normal map — per `feedback_chrome_means_missing_textures.md`, run `tex.missing` before recommending any tangent-space fix.
 **Output**: `/tmp/audit/renderer/dim_19.md`
 
-### Dimension 21: Disney BSDF / PBR Gating (#1248–#1252)
-**Entry points**: `crates/renderer/shaders/triangle.frag` (Disney lobe functions + gate sites; flag `#define`s at `triangle.frag:204-208` are the source of truth — `MAT_FLAG_*` bits 5-9 are NOT in `shader_constants_data.rs` today), `crates/renderer/src/vulkan/material.rs` (Disney material preset table from #1251). **Naming note**: these flags dropped the `BGSM_` prefix (`TRANSLUCENCY` / `MODEL_SPACE_NORMALS` / `TRANSLUCENCY_THICK_OBJECT` / `TRANSLUCENCY_MIX_ALBEDO`).
+#### Dimension 20: Debug overlay & GPU telemetry
+**Entry points**: `crates/renderer/src/vulkan/egui_pass.rs` (`EguiPass`), `crates/renderer/src/vulkan/gpu_timers.rs` (`GpuPerFrameTimers`), `crates/debug-ui/`, wired in `context/draw.rs` + `context/mod.rs`.
 **Checklist**:
-- **Gate is `MAT_FLAG_PBR_BSDF` (bit 5) only** — verify the consumer sites in `triangle.frag` ALL test this single flag (no path lights FNV / FO3 / Skyrim legacy materials with the Disney lobe). Gate-site grep target: `if ((mat.materialFlags & MAT_FLAG_PBR_BSDF) != 0u)`. **Current count: 2** — `:2610` (Disney diffuse consumer in the main `diffuseBrdf` branch) and `:2861` (second Disney diffuse consumer in the deferred-specular path); the F0-derivation gate is no longer flag-gated at a separate site (F0 is selected via `dielectricF0FromIor(mat.ior)` at `:1760` unconditionally). Drift here is a per-game lighting regression — FNV's Lambert-only world would suddenly get Burley retro-reflection
-- **`dielectricF0FromIor(eta)`** (#1248, `454b7a26`): Fresnel F0 derivation from per-material IOR (not the legacy hardcoded 0.04); declared at `triangle.frag:703`, consumed at `:1760` (`f0Dielectric = dielectricF0FromIor(mat.ior)`). Input-domain clamp on `eta` landed via #1253 (`e8e66b61`) — verify the clamp protects against `eta = 0` / `eta < 0` from corrupted material authoring. Symbol-anchored at `triangle.frag::dielectricF0FromIor`
-- **`distributionGGXAniso(NdotH, HdotX, HdotY, ax, ay)`** (#1250, `c0374d00`): anisotropic GGX (Trowbridge-Reitz with ax ≠ ay) for brushed-metal / vinyl / satin authoring. **MUST degenerate exactly to `distributionGGX` when ax == ay** — that's the legacy compatibility contract, regression would break every isotropic material in the catalog. Symbol-anchored at `triangle.frag::distributionGGXAniso`
-- **`deriveAxAy(roughness, anisotropic, out ax, out ay)`** (#1250 + #1253/#1254): declared at `triangle.frag:667`; remaps perceptual roughness + `anisotropic[0..1]` (ByroRedux follows the GLSL-PathTracer half-axis convention, NOT the Disney 2012 paper's full `[-1, 1]`; see the convention-sync comment at `triangle.frag:646-656`) to ax/ay. Input-domain clamp `clamp(anisotropic, 0.0, 1.0)` at `triangle.frag:675` landed in #1254 — verify the clamp returns a fully-degenerate-needle behavior at `anisotropic = 1.0` (Disney convention), not black/undefined fragments from `sqrt(1 - 0.9·a) < 0`
-- **`disneyDiffuseSplit(...)`** (#1249 / #1252, `005eba25` + `32e768af`): Burley retro-reflection + sheen + Hanrahan-Krueger subsurface, **split into separate lobes** post-#1252 to prevent per-light × π sheen over-amplification. Returns `DisneyDiffuseSplit` struct. Verify sheen is NOT divided by π (Disney 2012 spec: layered material on Lambertian base — sheen is additive, not a Lambertian itself)
-- **Disney material preset table** (#1251, `c09d63a6`): documented presets (glass IOR 1.45, copper, gold, plastic, etc.) live in `crates/renderer/src/vulkan/material.rs` as `pub fn` constructors. Verify each preset's authoring matches Disney 2012 documented values (cross-reference the GLSL-PathTracer reference at `/mnt/data/src/reference/GLSL-PathTracer/` per the `reference_glsl_pathtracer.md` memory; the disney lobe lives under `src/shaders/common/` in that external repo — backticked only when checking the local copy)
-- **GLSL-PathTracer reference compliance**: Disney lobe math at `triangle.frag` cites GLSL-PathTracer line numbers in the doc comments (e.g. disney.glsl:56-57 for F0, :67-87 for diffuse — see external reference repo, not a local path). Verify the citations are still accurate — if GLSL-PathTracer upstream has changed, our port is now an undocumented divergence
-- **#1147 Phase 2b gate sibling** (`fe22e64c`): PBR / SSS / model-space-normals are ALSO gated separately in `triangle.frag` (NOT all behind `MAT_FLAG_PBR_BSDF`). Verify:
-  - `MAT_FLAG_TRANSLUCENCY (1u << 6)` → SSS path (sibling modulators: `MAT_FLAG_TRANSLUCENCY_THICK_OBJECT (1u << 8)` and `MAT_FLAG_TRANSLUCENCY_MIX_ALBEDO (1u << 9)` select the SSS sub-mode)
-  - `MAT_FLAG_MODEL_SPACE_NORMALS (1u << 7)` (set by #972 for direct-TXST REFRs) → model-space sampling path
-  - Each gate fires independently; no spurious cross-activation when only one flag is set
-- **Per-game regression-guard checklist** (extends `audit-fnv` / `audit-fo3` / `audit-skyrim` regression guards):
-  - **FNV**: zero materials set `MAT_FLAG_PBR_BSDF` (no BGSM authoring shipped). Disney lobe must be unreachable.
-  - **FO3**: same as FNV.
-  - **Oblivion**: same as FNV.
-  - **Skyrim LE / SSE**: BGSM via mods only; vanilla Skyrim materials should not trip the gate without explicit BGSM intent.
-  - **FO4 / FO76 / Starfield**: BGSM authoring is canonical — Disney lobe is the EXPECTED path. Regression pattern is the opposite: a FO4 BGSM that falls back to Lambert.
-**Output**: `/tmp/audit/renderer/dim_21.md`
-
-### Dimension 20: M-LIGHT v1 — Stochastic Soft Shadows
-**Entry points**: `crates/renderer/shaders/triangle.frag` (sun shadow ray + cone-sample), `byroredux/src/render/sky.rs` (`sun_angular_radius` upload), `crates/renderer/src/vulkan/scene_buffer/`
-**Checklist**:
-- `sunAngularRadius` ships in the camera/scene UBO at the documented offset; current shipping value `0.020` (bumped from `0.0047`) — drift here changes shadow softness globally
-- Per-fragment single-tap stochastic cone sample around the sun direction: random offset derived from frame index + pixel coords (deterministic per-pixel-per-frame), not a true RNG that breaks TAA history
-- Shadow ray flags include `gl_RayFlagsTerminateOnFirstHitEXT` (no closest-hit needed; visibility query only)
-- TAA accumulation absorbs the per-frame noise — verify the YCoCg clamp tolerance allows the noise to converge (too-tight clamp = persistent noise; too-loose = over-blur)
-- Interior `radius=-1` gate (`triangle.frag` `isInteriorFill = radius < 0.0`, symbol-anchored) still bypasses the cone sample — soft-shadow code must not fire inside interior cells
-- Disocclusion: when TAA mesh-id mismatches discard history, the un-converged single-sample frame is visible — verify the fallback isn't black (a black single-sample frame is the regression pattern)
+- egui pass uses `loadOp = LOAD` + `initialLayout = PRESENT_SRC_KHR` and is recorded after composite; supplies its own incoming dependency (Dim 4, #1433); framebuffers recreated on resize; `Option<EguiPass>` taken + `destroy()`d before device teardown; disabled (`= None`) path skips the dispatch with no layout drift.
+- GPU timers: one `VkQueryPool` per FIF slot; `cmd_reset_query_pool` before re-recording brackets; results read `MAX_FRAMES_IN_FLIGHT` behind; driver-absent (`timestamp_supported == false`) → `new()` returns `Ok(None)`, no unwrap in the draw path; skipped passes omit their bracket (no bogus interval).
+- `dispatches_skipped` is a **skin-coverage** counter (`skin_compute.rs`, incremented in `draw.rs` when the bone palette is unchanged), surfaced via `mem.stats`/console — NOT a `GpuPerFrameTimers` field. Issued dispatches = total − skipped (#1194).
 **Output**: `/tmp/audit/renderer/dim_20.md`
 
-### Dimension 22: NIFAL Material Canonical Translation
-**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` at `:65` — the single ImportedMesh→`Material` boundary), `crates/core/src/ecs/components/material.rs` (`Material` struct + `resolve_pbr` at `:588` + `EmissiveSource` enum at `:354`), `crates/nif/src/import/walk/mod.rs` (`extract_emitter_params` at `:670` / `extract_emitter_rate` at `:713` — particle NIFAL slice), `byroredux/src/systems/particle.rs` (`apply_emitter_params` at `:29`), `byroredux/src/render/particles.rs` (`emit_particles` at `:31`). Spec: `docs/engine/nifal.md`. **This is the upstream tier that produces the data Dim 14's `MaterialTable::intern` consumes** — a regression here corrupts every `GpuMaterial`. See also `/audit-nifal` for the full canonical-translation-tier audit (single-boundary / no-fabrication / no-render-time-fallback); this dimension only covers the renderer-facing invariants.
+#### Dimension 21: Cornell-box RT harness
+**Entry points**: `byroredux/src/cornell.rs` (`setup_cornell_scene`, `--cornell` flag), `mat.*` console commands in `byroredux/src/commands.rs`.
 **Checklist**:
-- **Single boundary**: `translate_material` is the ONLY site that turns a per-game `ImportedMesh` into a canonical `Material`. Verify exactly two callers — `byroredux/src/scene/nif_loader.rs:808` (loose-NIF load) and `byroredux/src/cell_loader/spawn.rs:861` (REFR cell placement). A third `Material` struct literal anywhere downstream is a translation leak (the duplication this module was created to kill)
-- **`Material.metalness` / `Material.roughness` are plain resolved `f32`** (`material.rs:216,222`), NOT `Option`. The old per-draw `classify_pbr` indirection is gone — the render path reads the resolved scalars directly (`render/static_meshes.rs:268` comment confirms). Verify no code path re-classifies metalness/roughness per-frame
-- **`resolve_pbr` runs once at translate, not per-draw**: it resolves the NaN-sentinel via `classify_pbr_keyword` only when the field is NaN, then clamps (`metalness.clamp(0.0,1.0)`, `roughness.clamp(0.04,1.0)`). Idempotent (`resolve_pbr_is_idempotent` test) — verify it is invoked at the translate boundary, not from a render system
-- **`EmissiveSource` (None / Material / Lighting / Effect) is resolved at translate**: the Effect variant is semantically a diffuse-tint multiplier conflated into the emissive slot (`material.rs:368` doc) — verify the renderer reads the already-resolved `emissive_mult`, not the raw per-game shader-property field. Drift here mis-tints FO4+ effect-shader glow
-- **Feeds Dim 14 with NO per-game branching downstream**: confirm `GpuMaterial` is built from the canonical `Material` fields only (no `if game == FNV` style branch between `Material` and `MaterialTable::intern`); per `feedback_format_translation.md`, per-game quirks MUST be resolved at this boundary, never in the renderer
-- **Particle NIFAL slice**: typed `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` blocks (`crates/nif/src/blocks/particle.rs`) flow through `extract_emitter_params` / `extract_emitter_rate` (`import/walk/mod.rs`) into `ImportedScene`, then `apply_emitter_params` (`systems/particle.rs`) overlays authored values onto the preset, and `emit_particles` (`render/particles.rs:31`) assembles the billboard render data. Verify the authored emitter rate/size override the preset but do NOT override color (`apply_emitter_params_overrides_kinematics_and_size_not_color` test), and that the render-data assembly reads `ParticleEmitter` post-overlay
-**Output**: `/tmp/audit/renderer/dim_22.md`
-
-### Dimension 23: Debug Overlay & GPU Telemetry Passes (#1194)
-**Entry points**: `crates/renderer/src/vulkan/egui_pass.rs` (`EguiPass` struct — `new()` at `:60`, `record`/paint with the egui render pass at `:176`, `destroy()` at `:194`), `crates/debug-ui/` (debug overlay crate), `crates/renderer/src/vulkan/gpu_timers.rs` (`GpuPerFrameTimers` at `:148` + `GpuTimerSnapshot` at `:109`, `new()` at `:184`, `destroy()` at `:733`), wired into `crates/renderer/src/vulkan/context/draw.rs` (egui dispatch at `:2897`, timer resolve at `context/mod.rs:2476`) + `context/mod.rs` (`egui_pass: Option<EguiPass>` at `:1287`, `gpu_timers: Option<GpuPerFrameTimers>` at `:1051`)
-**Checklist**:
-- **egui render-pass ordering — composite then egui LAST**: the egui pass uses `loadOp = LOAD` (`egui_pass.rs:213`, doc at `:41`/`:206`) + `initialLayout = PRESENT_SRC_KHR` to preserve the composite's swapchain write. Verify egui is recorded after the composite/main pass (`draw.rs:2897`), not before — a pre-composite egui would be overwritten
-- **egui incoming barrier chains after composite's swapchain write**: composite's outgoing RP dependency sets `dstStage = NONE`, so the egui RP must supply its own incoming dependency (`egui_pass.rs:229`). Verify the dependency exists; missing it is a WAR hazard on the swapchain image
-- **egui descriptor / texture lifecycle**: `EguiPass` owns its pipeline + per-texture descriptors via `egui-ash-renderer`'s `Renderer`. Verify framebuffers are recreated on resize (`egui_pass.rs:114`) and that the `Option<EguiPass>` is taken + `destroy()`d before the device teardown (`context/mod.rs:2576`)
-- **egui disabled / uninitialised path**: when `init_egui` never ran, `egui_pass = None` and the dispatch is skipped (`draw.rs:2897` guard) — verify no swapchain layout drift when the overlay is absent
-- **GPU timer query-pool lifecycle**: `GpuPerFrameTimers` owns one `VkQueryPool` per `MAX_FRAMES_IN_FLIGHT` slot (`gpu_timers.rs:149`). Verify `cmd_reset_query_pool` runs before re-recording the bracket timestamps (results read `MAX_FRAMES_IN_FLIGHT` behind the current frame, `gpu_timers.rs:50`), and `destroy_query_pool` for every pool at teardown (`gpu_timers.rs:737`)
-- **GPU timer driver-absent path**: when `DeviceCapabilities::timestamp_supported == false`, `new()` returns `Ok(None)` (`gpu_timers.rs:185`) and the caller continues without timers — verify no unwrap on a `None` timer in the draw path
-- **Per-pass timestamp correctness**: bracket pairs (`cmd_write_timestamp` at `:338`+) must wrap exactly the pass they measure; on frames where a pass is skipped (e.g. TAA off, `gpu_timers.rs:58`) the bracket must be omitted or the snapshot reports a bogus interval
-- **`dispatches_skipped` counter** (#1194 / PERF-DIM7-INSTR): this is a **skin-coverage** counter (`skin_compute.rs:136`, incremented at `draw.rs:1035` when the bone palette is unchanged), surfaced via `mem.stats` / the console (`commands.rs:653`) — NOT a field on `GpuPerFrameTimers`. Verify the skip path increments it and the GPU dispatch count actually issued = total − `dispatches_skipped`
-**Output**: `/tmp/audit/renderer/dim_23.md`
+- The harness is a self-contained RT material/lighting reference scene (no on-disk game data) — verify it still builds a valid TLAS and renders without the asset pipeline, so it stays usable for bisecting glass/GI/caustic regressions (the Session 47 arc).
+- `mat.*` live commands drive material params at runtime for A/B verification — confirm they round-trip into `GpuMaterial` via the same `MaterialTable` path as game content (no Cornell-only material shortcut that would invalidate it as a reference).
+- Known confound (per memory): metalness-vs-lighting and the glass-stipple / IGN refraction jitter on opaque glass are open observations, not harness bugs — don't re-report them as new.
+**Output**: `/tmp/audit/renderer/dim_21.md`
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/renderer/dim_*.md` files
-2. Combine into `docs/audits/AUDIT_RENDERER_<TODAY>.md` with structure:
-   - **Executive Summary** — Total findings by severity, pipeline areas affected
-   - **RT Pipeline Assessment** — BLAS/TLAS correctness, ray query safety, denoiser stability
-   - **Rasterization Assessment** — Pipeline state, render pass, command recording
-   - **Findings** — Grouped by severity (CRITICAL first), deduplicated
-   - **Prioritized Fix Order** — Correctness fixes first, then safety, then optimization
-3. Remove cross-dimension duplicates
+1. Read all `/tmp/audit/renderer/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_RENDERER_<TODAY>.md`:
+   - **Executive Summary** — findings by severity, pipeline areas affected.
+   - **RT Pipeline Assessment** — BLAS/TLAS + SSBO indexing + ray-query safety + denoiser stability.
+   - **GPU-Struct & Memory Assessment** — layout pins, leaks, lifecycle/teardown.
+   - **Findings** — grouped by severity (CRITICAL first), deduplicated.
+   - **Prioritized Fix Order** — correctness → safety → optimization.
+   - **Needs-RenderDoc** — sync/barrier findings deferred for capture-based verification.
+3. Remove cross-dimension duplicates.
 
 ## Phase 4: Cleanup
 
-1. `rm -rf /tmp/audit/renderer`
-2. Inform user the report is ready
-3. Suggest: `/audit-publish docs/audits/AUDIT_RENDERER_<TODAY>.md`
+1. `rm -rf /tmp/audit/renderer`.
+2. Inform the user the report is ready.
+3. Suggest: `/audit-publish docs/audits/AUDIT_RENDERER_<TODAY>.md`.

--- a/.claude/commands/audit-runtime/SKILL.md
+++ b/.claude/commands/audit-runtime/SKILL.md
@@ -1,103 +1,130 @@
 ---
 description: "Runtime telemetry regression audit — drives headless engine on per-game cells, diffs against checked-in baselines"
-argument-hint: "--game <name|all> [--regen] [--cell <EDID>]"
+argument-hint: "--game <key|all> [--regen] [--cell <EDID>]"
 ---
 
 # Runtime Telemetry Audit
 
-Drive the engine headless against per-game representative cells, harvest the
-visible-symptom telemetry (`tex.missing`, `mesh.cache failed`, `light.dump`,
-`stats`, `bench-stats`), and compare against the checked-in baseline TSV at
-`.claude/audit-baselines/runtime/<game>-<cell>.tsv`. Regressions (counts
-moving in the wrong direction) become audit findings.
+Drive the engine headless against a per-game representative cell, harvest the
+visible-symptom telemetry (`stats`, `tex.missing`, `mesh.cache failed`,
+`light.dump` plus the `bench:` summary line), and diff it against a checked-in
+baseline TSV under `.claude/audit-baselines/runtime/`. Counts that move the
+wrong way become findings.
 
-**Structural fix** for the original #1277 epic complaint that audits inspect
-*code* but never *rendered output*. This skill makes runtime behavior
-auditable on every relevant commit — the per-game `audit-*` skills cover
-the static code; this one covers what actually shows up on screen.
+This is the **runtime arm** of the audit suite: the per-game `audit-*` skills
+inspect *code*; this one inspects what actually renders. It is the structural
+answer to the recurring complaint that static audits never see the screen.
 
-See `.claude/commands/_audit-common.md` for project layout, methodology,
-deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game-data paths,
+deduplication, severity, and the base finding format. This skill only adds the
+drive→capture→diff loop.
 
-## Game Context
+## Invocation surface (verified against `byroredux/src/main.rs`)
 
-Per-game representative cells (interior-only by default — interiors load
-fast, contain dense per-cell artifacts, and don't require worldspace
-streaming). Override with `--cell <EDID>`.
+The engine resolves a whole game install from one `--game <key>` flag via the
+profile registry in `assets/debug_profiles.toml` (`expand_game_profile_args`).
+That replaces the old hand-written `--esm`/`--bsa`/`--textures-bsa` table — you
+no longer spell out archives per game.
 
-> **Baseline reality check.** Only ONE baseline is checked in today:
-> `.claude/audit-baselines/runtime/fnv-FreesideAtomicWrangler.tsv`. The
-> rows below are the *candidate* representative cells; a row only becomes
-> a diffable regression guard once its baseline TSV is committed (Phase 4
-> emits "BASELINE CREATED" on first run). Before relying on a row, confirm
-> its baseline exists; otherwise the run only establishes a new baseline.
+- `--game <key>` expands to the profile's `--esm`, `--bsa`,
+  `--textures-bsa`, and (FO4+) `--materials-ba2` args, joined under
+  `<--games-root | $BYROREDUX_GAMES_ROOT | /mnt/data/SteamLibrary/steamapps/common>/<subdir>`.
+- `--cell <EDID>` loads an interior cell (omit to fall through to the profile's
+  `[defaults].cell`, if any).
+- `--bench-frames N` runs N frames then prints the single `bench:` summary line.
+- `--bench-hold` keeps the engine alive after the bench window so `byro-dbg`
+  can attach on port 9876 (prints a `bench-hold:` notice to stderr).
 
-| Game        | Cell EDID                             | Baseline | Rationale                                                                 |
-|-------------|---------------------------------------|----------|---------------------------------------------------------------------------|
-| FNV         | `FreesideAtomicWrangler`              | ✓        | The one committed baseline today (9 250 entities, post-#1284 schema). Primary regression guard. |
-| FNV (alt)   | `GSDocMitchellHouse`                  | —        | `FALLOUT_SYMPTOMS_2026-05-26.md` F2 investigation; well-characterized fallback-texture distribution. |
-| Oblivion    | `ICMarketDistrictTheGildedCarafe`     | —        | The "gorgeous baseline" per `FALLOUT_SYMPTOMS_2026-05-26.md` — zero fallback textures, zero parse fails. Catches regressions on the cleanest path. |
-| FO3         | `MegatonPlayerHouse`                  | —        | F2 sibling; 929 REFRs, exterior-style architecture in interior shell.    |
-| Skyrim SE   | `WhiterunDragonsreach`                | —        | Stress-tests the per-entity hot path.                                    |
-| FO4         | `InstituteBioScience`                 | —        | FO4 BGSM-heavy + bhkNPCollisionObject test bed (#1277 Task 1).           |
-| Starfield   | `CityCydoniaMainLevel`                | —        | SF ESM Phase 1 (`eac91535`) now loads cells; first walkable SF render in Session 42 (`83e4326d`, see `docs/audits/SF_FIRST_RENDER_2026-05-28.md`). First SF runtime-telemetry candidate (`--materials-ba2` required for BGSM resolution). |
+**Profile keys** (the literal `[profiles.<key>]` blocks in
+`assets/debug_profiles.toml`): `fnv`, `fo3`, `oblivion`, `skyrim_se`, `fo4`,
+`starfield`. There is no `fo76` profile. Use these exact keys for `--game`.
 
-`--game all` runs the suite across every game whose data is available
-(`BYROREDUX_*_DATA` env-var lookup per
-`crates/nif/tests/common/mod.rs::game_data_dir`).
+## Checked-in baselines (verified — `ls .claude/audit-baselines/runtime/`)
+
+Two runtime baselines are committed today:
+
+| Baseline TSV | Cell | Notes |
+|--------------|------|-------|
+| `.claude/audit-baselines/runtime/fnv-FreesideAtomicWrangler.tsv` | FNV `FreesideAtomicWrangler` | Primary FNV guard. ~9 250 entities, post-#1284 `SkinSlotPool` schema, `MAX_TOTAL_BONES=196608`. |
+| `.claude/audit-baselines/runtime/fo4-InstituteBioScience.tsv` | FO4 `InstituteBioScience` | Post-M49 precombine-CSG render + LOD fix. 1 722 precombine entities. Profile `sample_cells` lists this EDID. |
+
+> The `.claude/audit-baselines/sf-esm/` dir holds Starfield **ESM resolve-rate**
+> baselines for the `--sf-smoke` harness (`byroredux/src/sf_smoke.rs`), NOT this
+> skill. Don't diff them here.
+
+Any other `(game, cell)` row below is a *candidate* — running it with no
+baseline present establishes one (Phase 4 emits "BASELINE CREATED") rather than
+producing a diffable regression guard.
+
+## Candidate cells
+
+Interior-only by default (interiors load fast, are artifact-dense, and skip
+worldspace streaming). Override with `--cell <EDID>`. Where a profile ships a
+probe-verified `sample_cells` entry, prefer it.
+
+| Game (`--game`) | Cell EDID | Baseline | Rationale |
+|-----------------|-----------|----------|-----------|
+| `fnv` | `FreesideAtomicWrangler` | ✓ | Committed primary guard. |
+| `fnv` | `GSDocMitchellHouse` | — | Profile sample; well-characterised fallback-texture distribution (`docs/audits/FALLOUT_SYMPTOMS_2026-05-26.md` F2). |
+| `oblivion` | `ICMarketDistrictTheGildedCarafe` | — | Profile sample; cleanest path — zero fallback textures / parse fails. Catches regressions on a known-good cell. |
+| `fo3` | `MegatonPlayerHouse` | — | Profile sample; 929 REFRs, exterior-style architecture in an interior shell. |
+| `skyrim_se` | `WhiterunDragonsreach` | — | Profile sample; per-entity hot-path stress. |
+| `fo4` | `InstituteBioScience` | ✓ | Committed guard; BGSM-heavy + precombine CSG (M49). |
+| `starfield` | — | — | Starfield profile ships empty archives + no `sample_cells`; runtime cell render not yet a stable guard. Use `--sf-smoke` for SF coverage until a cell baseline lands. |
+
+`--game all` runs every game whose profile data dir resolves (existence-checked
+per `expand_game_profile_args`); games whose install is absent are skipped.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--game <name|all>`: Required. One of `oblivion`/`fnv`/`fo3`/`skyrim-se`/`fo4`/`fo76`/`starfield`/`all`.
-- `--cell <EDID>`: Override the per-game default cell (e.g., for re-running a
-  user-reported symptom against the specific scene that triggered it).
-- `--regen`: After running, OVERWRITE the baseline TSV with the current
-  values. Use only after an intentional change you've eyeballed — same
-  semantics as `BYROREDUX_REGEN_GOLDEN=1` for `golden_frames.rs`.
+- `--game <key|all>`: Required. One of the profile keys above, or `all`.
+- `--cell <EDID>`: Override the per-game default cell — e.g. to re-run a
+  user-reported symptom against the exact scene that triggered it.
+- `--regen`: After running, OVERWRITE the baseline TSV with the current values.
+  Use only after an intentional change you've eyeballed — same intent as
+  `BYROREDUX_REGEN_GOLDEN=1` for `golden_frames.rs`.
 
 ## Phase 1: Setup
 
 1. Parse `$ARGUMENTS`.
 2. `mkdir -p /tmp/audit/runtime`.
-3. `mkdir -p .claude/audit-baselines/runtime` (if first run on the repo).
-4. Fetch dedup baseline:
+3. Fetch dedup baseline:
    `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels > /tmp/audit/issues.json`.
-5. Confirm `cargo build --release -p byroredux -p byro-dbg` succeeds.
+4. Confirm `cargo build --release -p byroredux -p byro-dbg` succeeds.
 
-## Phase 2: Per-game Headless Launch
+## Phase 2: Per-game headless launch
 
-For each `(game, cell)` pair selected by `--game` / `--cell`:
+For each selected `(game, cell)`:
 
-1. Skip the game if its `BYROREDUX_*_DATA` env var doesn't resolve to a
-   directory (per `crates/nif/tests/common/mod.rs::game_data_dir`).
-2. Launch the engine under `xvfb-run -a` (no real Vulkan-on-display
-   needed — the swapchain still presents to the headless X server,
-   `byro-dbg` reads telemetry through the TCP debug protocol):
+1. Skip the game if its profile data dir doesn't resolve (the engine logs
+   `--game <key>: resolved data dir does not exist`).
+2. Launch under `xvfb-run -a` (the swapchain presents to the headless X server;
+   `byro-dbg` reads telemetry over the TCP debug protocol):
 
    ```bash
    xvfb-run -a --server-args="-screen 0 1280x720x24" \
      ./target/release/byroredux \
-       --esm "<ESM>" --cell "<CELL_EDID>" \
-       --bsa "<MESHES_BSA>" --textures-bsa "<TEXTURES_BSA>" \
+       --game <KEY> --cell "<CELL_EDID>" \
        --bench-frames 240 --bench-hold \
        > "/tmp/audit/runtime/<game>-<cell>.engine.log" 2>&1 &
    ```
 
-   Capture PID for cleanup.
+   Capture the PID for cleanup. (Starfield needs its `--materials-ba2`
+   archives, which the empty SF profile does not supply — pass them explicitly
+   if you ever baseline an SF cell.)
 
 3. Poll `byro-dbg` for ping success (up to 90 s):
 
    ```bash
    for i in $(seq 1 90); do
-     if echo "ping" | timeout 2 ./target/release/byro-dbg | grep -q -i pong; then
-       break
-     fi
+     if echo "ping" | timeout 2 ./target/release/byro-dbg | grep -q -i pong; then break; fi
      sleep 1
    done
    ```
 
 4. Sleep 3 s to let the cell settle past initial load.
-5. Drive the telemetry capture sequence:
+5. Drive the capture sequence (the four live console commands —
+   `byroredux/src/commands.rs`):
 
    ```bash
    printf "stats\ntex.missing\nmesh.cache failed\nlight.dump\nquit\n" \
@@ -105,168 +132,144 @@ For each `(game, cell)` pair selected by `--game` / `--cell`:
      > "/tmp/audit/runtime/<game>-<cell>.telem.txt" 2>&1
    ```
 
-   > **No `bench-stats` console command exists.** The four live commands
-   > are `stats` / `tex.missing` / `mesh.cache failed` / `light.dump`
-   > (`byroredux/src/commands.rs`); there is no `bench-stats`. Bench
-   > scalars (`wall_fps`, `draws=N/Mb/Kc`) are parsed from the single
-   > `bench:` summary line printed to stdout at `--bench-frames` exit
-   > (`byroredux/src/main.rs:2096`), so they land in the
-   > `<game>-<cell>.engine.log` file, **not** the byro-dbg telemetry
-   > stream. Likewise `skin_pool_*` is NOT in the `stats` command output
-   > (`commands.rs:48`) nor the `bench:` line — it is emitted to the
-   > `engine::stats` log target once per wall-second
-   > (`byroredux/src/systems/debug.rs:46`, `skin=L/M+S`), so grep the
-   > engine log for the last `skin=` line.
-
 6. Tear down: `kill -INT $PID; sleep 2; kill -9 $PID; wait $PID`.
 
-Runs for up to 4 games in parallel (Xvfb auto-display lets them coexist).
+Up to 4 games run in parallel (Xvfb auto-display lets them coexist).
 
-## Phase 3: Extract Comparable Metrics
+> **Where each metric lives.** The bench scalars (`wall_fps`, `draws=N/Mb/Kc`,
+> `entities=`) are on the single `bench:` line printed at `--bench-frames` exit
+> (`byroredux/src/main.rs`, the `println!("bench: …")` block) — they land in the
+> `.engine.log`, NOT the `byro-dbg` stream. The `skin=L/M+S` line is emitted to
+> the `engine::stats` log target once per wall-second
+> (`byroredux/src/systems/debug.rs`, format `skin={}/{}+{}`), so grep the
+> `.engine.log` for the LAST `skin=`. There is no `bench-stats` command.
 
-For each captured `.telem.txt` / `.engine.log` file, parse out the
-comparable scalars. These keys are the LIVE baseline contract — they must
-match the checked-in TSV exactly (see
-`.claude/audit-baselines/runtime/fnv-FreesideAtomicWrangler.tsv`), or the
-skill cannot diff its own baseline:
+## Phase 3: Extract comparable metrics
 
-| Metric                        | Source line                          | Direction       |
-|-------------------------------|--------------------------------------|-----------------|
-| `entities_total`              | `stats` output (`Entities:`)         | exact match     |
-| `tex_missing_unique_paths`    | `tex.missing` summary line           | ≤ baseline      |
-| `mesh_cache_failed_count`     | `mesh.cache failed` summary          | ≤ baseline      |
-| `light_count_directional`     | `light.dump` (`CellLightingRes`)     | exact match     |
-| `skin_pool_live`              | engine-log `skin=L/M+S` (`L`)        | ≤ baseline      |
-| `skin_pool_max`               | engine-log `skin=L/M+S` (`M`)        | exact match     |
-| `skin_pool_overflow_attempts` | engine-log `skin=L/M+S` (`S`)        | `== 0` (exact)  |
-| `bench_fps_p50`               | `bench:` line `wall_fps` (main.rs:2096) | ≥ baseline ×0.9 |
-| `bench_fps_avg`               | `bench:` line `wall_fps` (main.rs:2096) | ≥ baseline ×0.9 |
-| `bench_draws_cmds`            | `bench:` line `draws=N/Mb/Kc` (`N`)  | ≤ baseline ×1.1 |
-| `bench_draws_batches`         | `bench:` line `draws=N/Mb/Kc` (`M`)  | ≤ baseline ×1.1 |
-| `bench_draws_gpu_calls`       | `bench:` line `draws=N/Mb/Kc` (`K`)  | ≤ baseline ×1.1 |
+Parse these scalars from the captured files. The keys are the live baseline
+contract — they must match the committed TSV exactly (cf.
+`.claude/audit-baselines/runtime/fnv-FreesideAtomicWrangler.tsv`) or the skill
+cannot diff its own baseline:
 
-Notes on the bench scalars:
-- The engine emits a single `wall_fps` (`main.rs:2059`), NOT a p50/avg
-  percentile distribution. The baseline's `bench_fps_p50` / `bench_fps_avg`
-  are therefore both mapped from that one `wall_fps` value (capture it
-  twice, or re-run and average across runs if you want a true mean). Do
-  not invent a percentile the engine never computes.
-- `bench_draws_*` is the #1258 three-way split (`30e2360f`): `N` input
-  DrawCommands / `M` post-merge batches / `K` actual GPU calls
-  (`main.rs:2122`). The pre-#1258 single `bench_draw_calls_total` is gone.
-- The `light.dump` command (`commands.rs:1669`) dumps
-  `CellLightingRes` / `SkyParamsRes` / `GameTimeRes` only — it surfaces the
-  one directional sun, NOT a per-point-light count, so there is no
-  `light_count_point` metric.
+| Metric | Source | Direction |
+|--------|--------|-----------|
+| `entities_total` | `bench:` `entities=` (or `stats` `Entities:`) | exact match |
+| `tex_missing_unique_paths` | `tex.missing` summary line | ≤ baseline |
+| `mesh_cache_failed_count` | `mesh.cache failed` summary | ≤ baseline |
+| `light_count_directional` | `light.dump` `CellLightingRes` (always 1 sun) | exact match |
+| `skin_pool_live` | `.engine.log` last `skin=L/M+S` (`L`) | ≤ baseline |
+| `skin_pool_max` | `.engine.log` last `skin=L/M+S` (`M`) | exact match |
+| `skin_pool_overflow_attempts` | `.engine.log` last `skin=L/M+S` (`S`) | `== 0` (exact) |
+| `bench_fps_p50` | `bench:` `wall_fps` | ≥ baseline ×0.9 |
+| `bench_fps_avg` | `bench:` `wall_fps` | ≥ baseline ×0.9 |
+| `bench_draws_cmds` | `bench:` `draws=N/Mb/Kc` (`N`) | ≤ baseline ×1.1 |
+| `bench_draws_batches` | `bench:` `draws=N/Mb/Kc` (`M`) | ≤ baseline ×1.1 |
+| `bench_draws_gpu_calls` | `bench:` `draws=N/Mb/Kc` (`K`) | ≤ baseline ×1.1 |
 
-Write the extracted scalars to a per-run TSV:
-`/tmp/audit/runtime/<game>-<cell>.current.tsv`.
+Quirks of these scalars (don't fabricate around them):
 
-## Phase 4: Diff Against Baseline
+- The engine emits ONE `wall_fps`, not a percentile distribution. The baseline's
+  `bench_fps_p50` and `bench_fps_avg` both map from that one value (re-run and
+  average if you want a true mean). Do not invent a percentile the engine never
+  computes.
+- `draws=N/Mb/Kc` is the #1258 three-way split: `N` input DrawCommands / `M`
+  post-merge batches / `K` actual GPU calls. The pre-#1258 single draw count is
+  gone.
+- `light.dump` (`commands.rs` `LightDumpCommand`) dumps `CellLightingRes` /
+  `SkyParamsRes` / `GameTimeRes` only — it surfaces the one directional sun, not
+  a per-point-light tally, so `light_count_directional` is effectively a
+  constant 1 and there is no `light_count_point`.
 
-For each `(game, cell)` pair, compare
-`/tmp/audit/runtime/<game>-<cell>.current.tsv` against
+Write the extracted scalars to `/tmp/audit/runtime/<game>-<cell>.current.tsv`.
+
+## Phase 4: Diff against baseline
+
+Compare `/tmp/audit/runtime/<game>-<cell>.current.tsv` against
 `.claude/audit-baselines/runtime/<game>-<cell>.tsv`:
 
-- **Baseline absent**: first run — copy current to baseline with a `# regenerated:
-  YYYY-MM-DD` header. NOT a finding; surfaces in the report as "BASELINE CREATED".
-- **`--regen` set**: overwrite baseline with current. NOT a finding;
-  surfaces as "BASELINE UPDATED".
-- **Metric regressed** (against the direction in the Phase 3 table):
-  emit a finding per metric with severity per the regression magnitude:
-  - HIGH: `tex_missing_*` or `mesh_cache_failed_count` grew,
-    `skin_pool_overflow_attempts` moved off `0` (any spill means at least
-    one entity is rendering in bind pose for lack of a slot — pin to #1284
-    `SkinSlotPool` cap + descriptor-pool fix, `a3c2836a`), OR
-    `bench_fps_p50` dropped > 20 %.
+- **Baseline absent** — first run: copy current to baseline with a
+  `# regenerated: YYYY-MM-DD` header. NOT a finding; report as "BASELINE CREATED".
+- **`--regen` set** — overwrite baseline with current. NOT a finding; report as
+  "BASELINE UPDATED".
+- **Metric regressed** (against its Phase 3 direction) — emit one finding per
+  metric, severity per magnitude (see `_audit-severity.md`):
+  - HIGH: `tex_missing_*` or `mesh_cache_failed_count` grew;
+    `skin_pool_overflow_attempts` moved off `0` (any spill = at least one
+    entity rendering in bind pose for lack of a slot — pin to #1284
+    `SkinSlotPool` cap + descriptor-pool fix, `a3c2836a`); OR `bench_fps_*`
+    dropped > 20 %.
   - MEDIUM: any other count moved against direction.
-  - LOW: count drift within ±5 % on tolerance metrics.
+  - LOW: count drift within ±5 % on a tolerance metric.
 
-## Phase 5: Report Finalization
+## Phase 5: Report
 
-1. Combine per-game findings into `docs/audits/AUDIT_RUNTIME_<TODAY>.md`:
+1. Combine findings into `docs/audits/AUDIT_RUNTIME_<TODAY>.md`:
 
    ```markdown
    # Runtime Telemetry Audit — YYYY-MM-DD
 
    ## Per-game baseline comparison
 
-   | Game        | Cell                              | Status                | Δ vs baseline                          |
-   |-------------|-----------------------------------|-----------------------|----------------------------------------|
-   | Oblivion    | ICMarketDistrictTheGildedCarafe   | PASS                  | tex_missing 0→0, fps 47.2→47.5         |
-   | FNV         | GSDocMitchellHouse                | REGRESSION (HIGH)     | tex_missing_unique 54→58 (+4) ←–       |
-   | FO3         | MegatonPlayerHouse                | BASELINE CREATED      | first run                              |
+   | Game | Cell | Status | Δ vs baseline |
+   |------|------|--------|---------------|
+   | fnv  | FreesideAtomicWrangler | PASS              | tex_missing 1→1, fps 141→143 |
+   | fo4  | InstituteBioScience    | REGRESSION (HIGH) | tex_missing_unique 1→6 (+5)   |
+   | fo3  | MegatonPlayerHouse     | BASELINE CREATED  | first run                     |
 
    ## Findings
 
-   ### RT-1: tex_missing_unique_paths grew on FNV GSDocMitchellHouse
+   ### RT-1: tex_missing_unique_paths grew on fo4 InstituteBioScience
    - **Severity**: HIGH
-   - **Game**: FNV
-   - **Cell**: GSDocMitchellHouse
-   - **Baseline**: 54 unique missing texture paths
-   - **Current**: 58 unique missing texture paths (+4)
-   - **Top new misses**: …
-   - **Suggested Fix**: re-run `tex.missing entities` to identify the
-     responsible REFRs; compare against the last commit touching
-     `byroredux/src/asset_provider.rs` (resolution chain) OR the NIFAL
-     canonical-translation boundary
-     `byroredux/src/material_translate.rs::translate_material` /
-     `Material::resolve_pbr`
-     (`crates/core/src/ecs/components/material.rs:588`) — a regression
-     that drops a texture slot at the single `ImportedMesh`→`Material`
-     boundary surfaces here as a runtime `tex.missing` bump. Cross-check
-     against the import-side sibling
-     `crates/nif/tests/translation_completeness.rs` (`MaterialStats`
-     per-game slot coverage), and run **`/audit-nifal`** for a static
-     audit of that translation tier.
+   - **Game**: fo4
+   - **Cell**: InstituteBioScience
+   - **Baseline**: 1 unique missing texture path
+   - **Current**: 6 (+5)
+   - **Suggested Fix**: re-run `tex.missing entities` to find the responsible
+     REFRs; bisect against the last commit touching the resolution chain
+     (`byroredux/src/asset_provider.rs`) or the single NIFAL material boundary
+     (`byroredux/src/material_translate.rs` `translate_material` →
+     `Material::resolve_pbr`, `crates/core/src/ecs/components/material.rs`). A
+     dropped texture slot at that boundary surfaces here as a `tex.missing` bump.
+     Cross-check the import-side sibling
+     `crates/nif/tests/translation_completeness.rs`, and run **`/audit-nifal`**
+     for the static audit of that tier.
    ```
 
-2. Inform the user the report is ready.
+2. Tell the user the report is ready.
 3. Suggest: `/audit-publish docs/audits/AUDIT_RUNTIME_<TODAY>.md`.
 
 ## Phase 6: Cleanup
 
-1. `rm -rf /tmp/audit/runtime` (per-run artifacts; baseline TSVs in
+1. `rm -rf /tmp/audit/runtime` (baselines under
    `.claude/audit-baselines/runtime/` are NOT touched).
-2. Confirm no `byroredux` or `byro-dbg` processes left running:
+2. Confirm nothing left running:
    `pgrep -f 'byroredux|byro-dbg' && pkill -f 'byroredux|byro-dbg'`.
 
 ## Notes
 
-- **Determinism**: the engine's TAA jitter is frame-counter driven (Halton(2,3)),
-  so frame-240 telemetry is reproducible. `BYROREDUX_FIXED_DT=0` (set per the
-  golden_frames.rs precedent) freezes the wall-clock dt so animation /
-  camera spin / cube rotation don't advance — recommended in Phase 2's
-  engine launch when surfacing tolerance metrics.
-- **Game data**: `BYROREDUX_OBLIVION_DATA` / `BYROREDUX_FO3_DATA` /
-  `BYROREDUX_FNV_DATA` / `BYROREDUX_SKYRIMSE_DATA` / `BYROREDUX_FO4_DATA` /
-  `BYROREDUX_FO76_DATA` / `BYROREDUX_STARFIELD_DATA` per
-  `crates/nif/tests/common/mod.rs`. Falls back to canonical Steam install
-  paths when unset.
-- **Composability**: a future screenshot-diff extension (sibling of
-  `byroredux/tests/golden_frames.rs` — currently cube-demo only) is the
-  natural next layer: same `(game, cell)` matrix, PNG-pixel diff instead
-  of telemetry-scalar diff. Tracked as a separate follow-up; this skill's
-  scalar-telemetry surface is the lower-bar regression guard that lands
-  first.
-- **Sibling of Task 8's `translation_completeness` harness**: Task 8
-  exercises the IMPORT path (parse + import → MaterialStats); this
-  skill exercises the RUNTIME path (cell-load + render → console
-  telemetry). Both surface regressions the per-game `audit-*` static
-  audits structurally can't catch.
+- **Determinism**: TAA jitter is frame-counter-driven (Halton(2,3)), so
+  frame-240 telemetry is reproducible. `BYROREDUX_FIXED_DT=0`
+  (`byroredux/src/main.rs`, the `BYROREDUX_FIXED_DT` env read) freezes the
+  wall-clock dt so animation / camera / spin don't advance — recommended when
+  capturing tolerance metrics.
+- **Per-game data**: resolved via the `--game` profile registry
+  (`assets/debug_profiles.toml`). The separate `BYROREDUX_*_DATA` env vars in
+  `crates/nif/tests/common/mod.rs` drive the *test* harnesses, not this skill.
+- **Composability**: a screenshot-diff extension (sibling of
+  `byroredux/tests/golden_frames.rs`, currently cube-demo only) is the natural
+  next layer — same `(game, cell)` matrix, PNG-pixel diff instead of
+  scalar-telemetry diff. This skill's scalar surface is the lower-bar guard that
+  lands first.
 
 ## References
 
 - Parent epic: [#1277](https://github.com/matiaszanolli/ByroRedux/issues/1277)
 - This workstream: [#1283](https://github.com/matiaszanolli/ByroRedux/issues/1283)
-- Symptom-record this skill operationalises: [docs/audits/FALLOUT_SYMPTOMS_2026-05-26.md](../../docs/audits/FALLOUT_SYMPTOMS_2026-05-26.md)
-- Per-game data lookup: [crates/nif/tests/common/mod.rs](../../crates/nif/tests/common/mod.rs)
+- Symptom record: [docs/audits/FALLOUT_SYMPTOMS_2026-05-26.md](../../docs/audits/FALLOUT_SYMPTOMS_2026-05-26.md)
+- Smoke-test pattern (`--bench-hold` + `byro-dbg` attach): [docs/smoke-tests/README.md](../../docs/smoke-tests/README.md)
 - Determinism precedent: [byroredux/tests/golden_frames.rs](../../byroredux/tests/golden_frames.rs)
-- Sibling import-side harness: [crates/nif/tests/translation_completeness.rs](../../crates/nif/tests/translation_completeness.rs)
-- NIFAL canonical-translation static audit (the runtime `tex.missing`
-  proxy's code-side counterpart): **`/audit-nifal`** —
-  [.claude/commands/audit-nifal.md](audit-nifal.md);
-  spec [docs/engine/nifal.md](../../docs/engine/nifal.md);
-  boundary fn [byroredux/src/material_translate.rs](../../byroredux/src/material_translate.rs)
+- Import-side sibling harness: [crates/nif/tests/translation_completeness.rs](../../crates/nif/tests/translation_completeness.rs)
+- NIFAL static audit (the `tex.missing` proxy's code-side counterpart):
+  **`/audit-nifal`** — boundary fn [byroredux/src/material_translate.rs](../../byroredux/src/material_translate.rs); spec [docs/engine/nifal.md](../../docs/engine/nifal.md)
 - SkinSlotPool cap + spill telemetry: [#1284](https://github.com/matiaszanolli/ByroRedux/issues/1284) (`a3c2836a`)
 - DrawCommand vs GPU-call split (`draws=N/Mb/Kc`): [#1258](https://github.com/matiaszanolli/ByroRedux/issues/1258) (`30e2360f`)

--- a/.claude/commands/audit-safety/SKILL.md
+++ b/.claude/commands/audit-safety/SKILL.md
@@ -4,108 +4,286 @@ description: "Safety audit — unsafe blocks, memory leaks, undefined behavior, 
 
 # Safety Audit
 
-Read `_audit-common.md` and `_audit-severity.md` for shared protocol.
+Read `_audit-common.md` (layout, methodology, dedup, report format) and
+`_audit-severity.md` (the unified scale + the Special-Rules table this domain
+leans on heavily) before starting. Do not restate their content here.
+
+Severity anchors for this domain (from `_audit-severity.md`):
+FFI lifetime violation = **CRITICAL** · BLAS/TLAS wrong geometry/address or
+SSBO index mismatch = **CRITICAL** · leak that compounds per frame = **HIGH** ·
+Vulkan spec violation = **HIGH** · `unsafe` without a safety comment = **MEDIUM**.
+
+## Scale of the surface
+
+`unsafe` is concentrated, not scattered: ~612 occurrences live in
+`crates/renderer/src` (ash FFI + gpu-allocator), then a long tail —
+~11 in `crates/nif`, ~6 in `crates/core`, and one each in `byroredux`,
+`crates/plugin`, `crates/facegen`, `crates/cxx-bridge`. Renderer carries roughly
+one `SAFETY` comment per two `unsafe` tokens; the gap is where the
+unsafe-without-comment (MEDIUM) findings live. Budget your time accordingly —
+do not audit the nif/core tail at the expense of the renderer FFI mass.
+
+Dimensions below are ordered by safety blast radius: FFI lifetime, then
+memory-corruption/UB, then per-frame leaks, then unsafe-block discipline, then
+Vulkan-spec compliance, then the narrower regression-guard surfaces.
 
 ## Dimensions
 
-### 1. Unsafe Rust Blocks
-- List every `unsafe` block in the codebase
-- For each: is there a safety comment? Is the invariant actually upheld?
-- Common risks: dangling pointers, aliasing violations, uninitialized memory
-- Focus on World::get() raw pointer extension and any FFI boundaries
-- `crates/sfmaterial` enum decode: `BuiltinType::from_u32` (`src/types.rs`) MUST stay a checked `match` over the `0xFFFFFF##` tags with an `Err` arm for unmatched patterns — the doc-comment's "transmute into this enum" wording is aspirational, NOT the impl. An actual `std::mem::transmute` of an unmatched `#[repr(u32)]` byte pattern is UB; verify the match (and its `_ => Err`) survives any "optimization"
+### 1. FFI Lifetime Safety (cxx bridge) — CRITICAL class
 
-### 2. Vulkan Spec Compliance
-- All vkCreate*/vkDestroy* paired correctly
-- No use-after-destroy (check Drop ordering)
-- Validation layers enabled in debug — run and check for ANY errors
-- Queue submission ordering correct (wait before signal)
-- Acceleration structure builds: correct geometry flags, valid device addresses
-- TLAS UPDATE mode: instance count and geometry count must match original BUILD
-- Ray query extension: `VK_KHR_ray_query` enabled before use, feature gate checked
+- **The cxx surface is currently a placeholder.** `crates/cxx-bridge/src/lib.rs`
+  exposes one bridge fn, `native_hello() -> String` (impl in
+  `crates/cxx-bridge/cpp/native_utils.cpp`). There is **no raw-pointer exchange,
+  no Rust-string-into-C++ borrow, no shared-ownership handoff** across the
+  boundary today. Do NOT report speculative "string lifetime / dangling pointer
+  across cxx" findings against this crate — they describe a surface that does not
+  exist yet. The real check here is a **scope guard**: confirm the bridge still
+  has no owned-pointer / borrowed-slice signatures. The instant a `*const`,
+  `&[u8]`, `Box<…>`, or `unsafe extern "C++"` fn taking a Rust reference appears,
+  this becomes a live CRITICAL-class dimension and the lifetime analysis from
+  `_audit-severity` applies.
+- `unsafe extern "C++"` in the bridge marks the C++ side as trusted — verify no
+  new fn returns a pointer Rust then dereferences past the call.
 
-### 3. Memory Safety
-- GPU memory: all allocations freed before allocator drop
-- GPU memory: allocator dropped before device destroy
-- **`AllocatorResource` ECS drop ordering (#1406, `299e6a84`)**: `AllocatorResource` must be removed from the ECS `World` BEFORE `VulkanContext::drop()` fires. The `gpu-allocator` holds a live `Arc<Device>`; if the `World` outlives the `VulkanContext`, the allocator's `Drop` invokes driver calls against a destroyed logical device (use-after-free). Verify the main loop / app handler removes the resource before dropping the renderer; a panic unwind that skips this removal is an equally valid failure path.
-- **TLAS resize device_wait_idle (#1390, `a7e1502b`)**: the TLAS resize path must call `device.device_wait_idle()` before freeing the old allocation. Without it, the GPU may still be consuming the old TLAS scratch during the free. Latent today but would materialise under a future resize-under-load refactor. Verify the wait is present in `acceleration/tlas.rs` in the resize branch.
-- GPU memory: BLAS scratch buffer, TLAS instance/result buffers, G-buffer images, SVGF history buffers, TAA per-frame-in-flight history images, caustic accumulator images, per-skinned-entity SkinSlot output buffers, MaterialBuffer SSBO (R1) all tracked and freed
-- Cell streaming (`byroredux/src/streaming.rs`): cell-loaded resources (NIF imports, BLAS entries, textures) freed when cell unloads — verify no leak path through the async pre-parse worker thread (M40 milestone closed, but the unload leak path is live since exterior streaming is real)
-- CPU memory: no unbounded growth (Vec without clear, HashMap without remove)
-- Material table dedup map (R1): cleared per frame or pooled? Either is fine, but unbounded HashMap growth across cells is a leak
-- Stack overflow risk: no deep recursion without bounds
+### 2. Memory Corruption / UB
 
-### 4. Thread Safety
-- RwLock: no potential for deadlock (TypeId ordering enforced?)
-- Arc<Mutex<Allocator>>: lock held for minimum duration?
-- Send + Sync bounds on Component and Resource traits correct?
+- **ECS cached-pointer contract (regression guard, #35 + #1367).** `World::get`
+  (`crates/core/src/ecs/world.rs`) returns a `ComponentRef<'_, T>`, NOT a raw
+  pointer with a dropped guard (the unsound #35 pattern). `ComponentRef`,
+  `StorageRef`, and `StorageRefMut` in `crates/core/src/ecs/query.rs` cache a
+  `*const T` / `*mut T` resolved once in `new()` and deref it in the hot path
+  (#1367). Each cached-deref `unsafe` block carries a SAFETY comment tying the
+  pointer's validity to the lock guard the wrapper pins. The invariant: **the
+  guard must outlive every deref, and `&mut self` must gate `&mut *self.storage`.**
+  Verify the SAFETY comments still match the field layout and that no refactor
+  let a guard drop before its pointer (use-after-free → CRITICAL).
+- **`#[repr(C)]` GPU-struct soundness** (`crates/renderer/src/vulkan/scene_buffer/gpu_types.rs`):
+  `GpuInstance`/`GpuCamera`/`GpuLight` etc. are uploaded byte-for-byte to SSBOs.
+  vec3 must be three scalar `f32`, never `[f32; 3]` (std430 vec3 padding). A
+  layout drift here is silent per-instance corruption — see Dimension 6 for the
+  GpuMaterial pin and `_audit-severity`'s `#[repr(C)]`-drift HIGH row.
+- **NIF bulk POD reads** (`NifStream::read_pod_vec`, `crates/nif/src/stream.rs`;
+  the header mirror `read_pod_vec_from_cursor`, `crates/nif/src/header.rs`):
+  `read_exact` of raw LE bytes into a `T: AnyBitPattern` vector. SAFETY comments
+  must hold — `T` is restricted to bit-pattern-safe types (a sealed bound stops
+  `read_pod_vec::<bool>`). Verify the byte-count overflow guard (`count × size`)
+  is present and no caller widens `T` past `AnyBitPattern`.
+- **sfmaterial enum decode** (`BuiltinType::from_u32`, `crates/sfmaterial/src/types.rs`):
+  MUST stay a checked `match` over the `0xFFFFFF##` tags with a
+  `_ => return Err(Error::UnsupportedBuiltin { raw })` arm (confirmed present).
+  The module doc's "transmute into this enum" wording is aspirational prose, NOT
+  the impl — an actual `std::mem::transmute` of an unmatched `#[repr(u32)]` byte
+  pattern is UB. Verify the `match` + `Err` arm survive any "optimization."
+- Stack-overflow risk: no unbounded recursion in block-walk / scene-graph traversal.
 
-### 5. FFI Safety (cxx bridge)
-- C++ exceptions: does cxx handle them correctly?
-- String lifetime: Rust strings passed to C++ — valid for duration of call?
-- No raw pointer exchange across FFI without clear ownership
+### 3. Memory & Resource Leaks (HIGH when per-frame/per-cell)
 
-### 6. RT Pipeline Safety
-- BLAS/TLAS device address queries: buffers must have SHADER_DEVICE_ADDRESS usage
-- Global vertex/index SSBO: `instance_custom_index` bounds not checked on GPU — verify CPU-side encoding is correct
-- Ray query origin bias: self-intersection avoidance (tMin > 0 or offset along normal)
-- TLAS refit: `last_blas_addresses` comparison must handle mesh registry changes (add/remove)
-- Skin compute (GPU pre-skinning, milestone closed): per-skinned-mesh output buffer usage flags include `STORAGE_BUFFER` AND `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR`, plus `VERTEX_BUFFER` (#681 / `MEM-2-6` regression note). Wrong usage mask = device lost — the regression guard is live regardless of milestone status.
-- Skin BLAS refit: vertex/geometry count must match the original BUILD; bone count change forces full rebuild
-- Bone palette: `MAX_TOTAL_BONES` overflow guard in `byroredux/src/render/skinned.rs` (`Once`-gated warn at the bone-palette emit site, post-#1115 split) actually fires (silent truncation past cap was the M29 regression). Regression-guard tests live at `byroredux/src/render/bone_palette_overflow_tests.rs`
+- **Rapier bodies on cell unload (regression guard, #1520, `34c7a218`).**
+  `crates/physics/src/world.rs::remove_*` and `byroredux/src/cell_loader/unload.rs`
+  must release a cell's rigid bodies, colliders, and impulse joints from
+  `RigidBodySet` / `ColliderSet` / `ImpulseJointSet` (plus broad-phase /
+  query-pipeline state) when the cell unloads. Without it they accumulate per
+  cell — a steady leak under exterior streaming. Guard test:
+  `byroredux/src/cell_loader/rapier_release_tests.rs`. Verify the release path is
+  still wired and the test still asserts emptiness post-unload.
+- **Deferred-destroy drain** (`crates/renderer/src/deferred_destroy.rs`,
+  `DeferredDestroyQueue<T>` shared by mesh + BLAS + texture + skin compute):
+  objects are destroyed only after the in-flight fence clears (#418 moved the tick
+  after fence wait; #732 added an explicit shutdown drain). Verify the tick still
+  runs **after** fence wait in `context/draw.rs` and the shutdown sweep drains the
+  queue — a missed drain leaks GPU memory across the app lifetime, a too-early
+  destroy is use-after-free (CRITICAL).
+- **`AllocatorResource` drop ordering (regression guard, #1406, `299e6a84`).**
+  `AllocatorResource` (`crates/renderer/src/vulkan/allocator.rs`; held in
+  `byroredux/src/main.rs`) must be removed from the ECS `World` BEFORE
+  `VulkanContext::drop()` runs. The allocator holds a live `Arc<Device>`; if the
+  `World` outlives the context, the allocator's `Drop` calls the driver against a
+  destroyed logical device (use-after-free → CRITICAL). Verify the main loop
+  removes the resource before dropping the renderer, including the panic-unwind
+  path that could skip the removal.
+- **GPU allocation inventory** — every long-lived allocation tracked and freed:
+  BLAS scratch/result, TLAS instance/result, G-buffer images, SVGF history, TAA
+  per-FIF history images, caustic + water-caustic R32_UINT accumulators
+  (`caustic.rs` / `water_caustic.rs`), per-skinned-entity SkinSlot output buffers,
+  MaterialBuffer SSBO, volumetric/bloom mip pyramids. Cross-check eviction
+  thresholds against `docs/engine/memory-budget.md`; do not re-derive.
+- **CPU-side unbounded growth** — `Vec`/`HashMap` keyed by cell or path that never
+  shrinks. The MaterialTable dedup map and AnimationClipRegistry (Dimension 8) are
+  the known per-cell-growth risks.
 
-### 7. New Compute Pipeline Safety (TAA, Caustic, Skin)
-- TAA history images held in `GENERAL` layout (storage write + sampled read coexist); no UNDEFINED transitions per frame
-- TAA `should_force_history_reset` path produces no NaN reads, weight α forced to 1.0 on first frame
-- Caustic accumulator R32_UINT: `imageAtomicAdd` only — never float storage, no race
-- Caustic CLEAR-before-COMPUTE invariant: missing clear = persistent ghost contributions across frames
-- Skin compute push constants ≤ 128 B (Vulkan-guaranteed minimum); current `SkinPushConstants` is 12 B
-- SPIR-V reflection (`reflect.rs::validate_set_layout`): Rust descriptor layout MUST match shader-declared bindings — reflection mismatch is the only sound layer for catching binding drift before runtime
-- Volumetrics (`crates/renderer/src/vulkan/volumetrics.rs`, froxel grid `volumetrics_inject.comp` / `volumetrics_integrate.comp`): per-frame-in-flight 3D froxel volumes held in `GENERAL` (storage write + sampled read); `initialize_layouts` does the one-time UNDEFINED→GENERAL transition AND clears to `(rgb=0, a=1)` — same persistent-ghost-accumulation class as the caustic CLEAR-before-COMPUTE invariant. Per-froxel TLAS shadow ray fires once; verify no UNDEFINED transition leaks in per frame. (Note: dispatch is currently gated behind a `false` const while per-froxel banding is fixed — verify callers honor the gate.)
-- Bloom (`crates/renderer/src/vulkan/bloom.rs`, `bloom_downsample.comp` / `bloom_upsample.comp`): the down/up `B10G11R11_UFLOAT_PACK32` mip pyramids live in `GENERAL` for their entire lifetime; `initialize_layouts` does the one-time UNDEFINED→GENERAL barrier for every mip in every frame slot (`NONE` srcStageMask, no prior writes). Same UNDEFINED-transition class as TAA — a missed mip in the init barrier is a validation error / undefined read
+### 4. Unsafe-Block Discipline (MEDIUM — the bread-and-butter sweep)
 
-### 8. R1 Material Table Safety
-- `GpuMaterial` (in `crates/renderer/src/vulkan/material.rs`) size pinned at **300 B** by the `gpu_material_size_is_260_bytes` test (the test NAME still says 260 for grep continuity, but the asserted constant is 300 — the struct grew via the BGSM translucency suite `#1147` at offsets 260–276 and the Disney-BSDF lobe scalars + IOR at offsets 280–296, `#1248`/`#1249`/`#1250`; was 272 B until #804 / R1-N4 dropped `avg_albedo`, then 260 B until those additions) — a stale 260/272 in audit prose or a test-name-vs-asserted-size mismatch both mean the GPU-side struct is reading wrong bytes
-- Per-field offset pin (`gpu_material_field_offsets_match_shader_contract`, #806): every named field's byte offset asserted against the shader contract. Size-only pin cannot catch within-vec4 reorders (e.g. swap `texture_index ↔ normal_map_index` is invisible to size, lethal at runtime). Adding a field WITHOUT updating this assertion is a regression
-- ALL fields scalar f32/u32 — never `[f32; 3]` (std430 vec3 alignment ≠ tightly-packed Rust). This includes the newest scalars: the BGSM translucency suite (`translucency_subsurface_r/g/b`, `translucency_transmissive_scale`, `translucency_turbulence`) and the Disney lobe (`ior`, `subsurface`, `sheen`, `sheen_tint`, `anisotropic`) — each is a flat f32, never folded back into a `vec3`/`vec4` pair
-- Named pad fields explicitly zeroed (no uninit bytes leak into the byte-`Hash`/`Eq` dedup — `GpuMaterial::as_bytes` hashes the raw 300 B representation, so the larger struct only widens the blast radius of any alignment hole). The Disney/translucency scalars must be zeroed in `GpuMaterial::default()` so default materials still dedup to slot 0
-- `material_id` bounds: GpuInstance.material_id used as SSBO index — CPU must guarantee in-range; GPU has no bounds check
-- `MaterialTable::intern` cap (#797 SAFE-22): over `MAX_MATERIALS = 16384` (raised from 4096 in `7823eb59`; `crates/renderer/src/vulkan/scene_buffer/constants.rs`) distinct interns return id `0` with one-shot warn — no SSBO over-index, no DEVICE_LOST. Verify the cap fires AND the SSBO upload (`scene_buffer/upload.rs::upload_materials` — `materials.len().min(MAX_MATERIALS)`) truncates to `MAX_MATERIALS`. Mismatch between intern cap and upload truncation is the class of bug the cap was added to prevent
-- `ui.vert` MaterialBuffer read offsets stay in lockstep with `triangle.frag` (#785 R-N1 was a stale-hunk regression of #776 reading wrong bytes — name `ui.vert` explicitly in any R1 audit)
+- Grep every `unsafe` in `crates/` + `byroredux/` (`.rs`). For each: is there a
+  SAFETY comment, and does the comment's stated invariant actually hold at this
+  call site? A correct unsafe block with no comment is still a MEDIUM finding
+  (`_audit-severity` Special Rules). A commented block whose invariant is FALSE is
+  the higher-severity finding.
+- Heaviest in `crates/renderer/src/vulkan/` ash FFI — the SAFETY/unsafe count gap
+  (~310 vs ~612) is the haystack. Spot-check the ash dispatch wrappers, the
+  gpu-allocator `Arc<Mutex<…>>` interactions, and any `from_raw_parts` / `cast` on
+  mapped memory.
+- Report unsafe blocks lacking comments as a batched MEDIUM finding (list the
+  sites) rather than one finding per block, unless an invariant is actually unsound.
 
-### 9. RT IOR-Refraction Safety (Sessions 27–29)
-- Glass-passthrough infinite loop (#789): texture-equality identity check at the refraction hit prevents unbounded recursion when two coincident glass surfaces share the same albedo/normal-map descriptor pair. Verify the check is still in place — a regression here is a frame-time hang under any cell with paired glass
-- Frisvad orthonormal basis (#820 / REN-D9-NEW-01): the `cross(N, world-up)` construction degenerates near vertical surfaces (zero-length basis → NaN ray). Verify Frisvad is the active code path for IOR refraction roughness spread
-- Glass ray budget bounded: `GLASS_RAY_BUDGET = 8192` (raised from 512 in 9a4dc15) — the cap exists to prevent runaway recursion, not as a quality knob. Verify the budget is enforced at every call site
-- IOR miss fallback for interiors uses cell-ambient (bb53fd5), NOT the global sky tint — open-sky leakage into dungeons is a visible regression
-- `DBG_VIZ_GLASS_PASSTHRU = 0x80` debug bit kept as a permanent diagnostic; verify the bit position has not collided with new debug-flag additions (full catalog: `crates/renderer/src/shader_constants_data.rs::DBG_*`, mirrored into the auto-generated `crates/renderer/shaders/include/shader_constants.glsl` consumed by `triangle.frag` via `#include`)
+### 5. Vulkan Spec Compliance (HIGH — but flag what cargo test can't see)
 
-### 10. NPC / Animation Spawn Safety (M41.0 long-tail)
-- B-spline pose-fallback (#772): NPC vanishing under FNV `BSPSysSimpleColorModifier` particle stacks that share keyframe time-zero with the actor's animation player must be gated on a `FLT_MAX` sentinel. Removing the gate causes whole-NPC disappearance, not just a stuck pose — verify the sentinel is still wired
-- AnimationClipRegistry dedup (#790): registry deduplicates by lowercased path so cell streaming does not grow it unboundedly. Without dedup, one full keyframe set leaks per cell load — observable as steady RAM growth across exterior streaming. Verify case-insensitive interning is preserved
-- B-splines are reachable on FNV / FO3 too (`feedback_bspline_not_skyrim_only.md`) — do NOT rule out `NiBSplineCompTransformInterpolator` audits by game era. Skyrim-only assumption is a stale premise that has bitten this audit before
-- Starfield content is now WALKABLE (Cydonia) — do NOT short-circuit spawn-safety reasoning with a "no SF content exercises this path" assumption; SF cells reach the spawn / animation path like any other game
+> Per the No-Speculative-Vulkan-Fixes rule: render-pass / barrier / pipeline-state
+> spec claims that are invisible to `cargo test` MUST be framed as **"needs
+> validation-layer or RenderDoc verification"**, not asserted as confirmed bugs.
+> Run the engine with validation layers (debug build) and report ANY emitted
+> error verbatim — that is the sound evidence channel for this dimension.
 
-### 11. NIFAL Canonical-Translation Safety (NaN sentinels at the import boundary)
-*See also `/audit-nifal` — the dedicated NIFAL canonical-translation-layer audit. This dimension covers only the safety/UB facet (NaN-on-GPU, unbounded scalars); leave correctness-of-mapping to that audit.*
-- The single import boundary `byroredux/src/material_translate.rs::translate_material` deliberately seeds `f32::NAN` into `Material.metalness` / `Material.roughness` (the unresolved sentinels: `mesh.metalness_override.unwrap_or(f32::NAN)` / `roughness_override.unwrap_or(f32::NAN)`). `Material::resolve_pbr` (`crates/core/src/ecs/components/material.rs`) is the ONLY thing that detects (`is_nan`) and clamps those sentinels (`metalness.clamp(0.0,1.0)`, `roughness.clamp(0.04,1.0)`) before the value reaches `GpuMaterial`. A translation path that skips `resolve_pbr()` ships a NaN into the SSBO — NaN-on-GPU is the UB class this dimension exists to catch. `Material.metalness`/`roughness` are now plain `f32` (no `Option`), so a missing resolve is silent until it lands on the GPU
-- Verify EVERY producer of a renderer-bound `Material` runs `resolve_pbr()` (or constructs already-finite values); the `static_meshes.rs` fallback path constructs finite defaults directly — confirm it still does
-- Collision translate (`crates/nif/src/import/collision.rs`) now covers `BhkMultiSphereShape` and `BhkConvexListShape` as additional NIFAL boundaries — verify their emitted half-extents / radii / sphere centers are finite and bounded (a NaN/inf shape param propagates into the physics + BLAS build)
-- Typed particle blocks (`crates/nif/src/blocks/particle.rs`: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier`) feed `extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs`) → `systems::particle::apply_emitter_params` (`byroredux/src/systems/particle.rs`). Verify emitter rate / lifespan / size scalars are finite and non-negative at the extract boundary — an unbounded or NaN emitter rate is an unbounded-allocation / NaN-transform risk downstream
+- All `vkCreate*`/`vkDestroy*` paired; Drop ordering destroys children before
+  parents (device-destroy is last).
+- Queue submission ordering: wait-before-signal; per-image semaphores.
+- **Acceleration structures** (`crates/renderer/src/vulkan/acceleration/`): correct
+  geometry flags, valid device addresses, buffers carry `SHADER_DEVICE_ADDRESS`.
+  TLAS UPDATE mode — instance/geometry count must match the original BUILD.
+  Skin BLAS refit — vertex/geometry count must match BUILD; a bone-count change
+  forces a full rebuild. (Wrong AS geometry/address = CRITICAL per `_audit-severity`.)
+- **TLAS resize wait (regression guard, #1390, `a7e1502b`).** The resize branch in
+  `acceleration/tlas.rs` calls `device.device_wait_idle()` before freeing the old
+  allocation (confirmed present). Verify the wait survives — without it the GPU may
+  still consume the old TLAS scratch during free under a resize-under-load refactor.
+- `VK_KHR_ray_query` enabled + feature-gated before any ray-query use.
+- Per-frame compute layout hygiene (TAA / caustic / water-caustic / volumetrics /
+  bloom): images that coexist as storage-write + sampled-read are held in `GENERAL`;
+  `initialize_layouts` does the one-time UNDEFINED→GENERAL transition for **every**
+  mip / FIF slot. A missed slot is an UNDEFINED-read validation error. CLEAR-before-
+  COMPUTE invariant (caustic R32_UINT `imageAtomicAdd`, volumetric inject) — a
+  missing clear is persistent cross-frame ghost accumulation. Verify the
+  volumetrics caller honors the dispatch gate: dispatch is dead while
+  `VOLUMETRIC_OUTPUT_CONSUMED == false` (`crates/renderer/src/vulkan/volumetrics.rs`);
+  callers MUST gate `vol.dispatch()` on that const.
+- SPIR-V reflection (`crates/renderer/src/vulkan/reflect.rs`): the Rust descriptor
+  layout must match shader-declared bindings — this is the one binding-drift check
+  that IS visible to `cargo test` (scene_descriptor_reflection_tests). Prefer it
+  over eyeballing descriptor writes.
 
-### 12. debug-ui (egui overlay) Vulkan Teardown Safety
-- `crates/debug-ui` (`src/lib.rs`) holds an `ash::Device`, a `vk::RenderPass`, and a shared `Arc<Mutex<gpu_allocator::vulkan::Allocator>>`; it is owned by the engine main loop as `byroredux::main.rs`'s `debug_ui: Option<byroredux_debug_ui::DebugUiState>`
-- The crate wraps `egui-ash-renderer`, which manages its own descriptor pool + per-texture images. Those MUST be freed before the engine destroys the `ash::Device` — ties into Dimension 3 ("allocator dropped before device destroy"). Verify `DebugUiState` Drop / explicit teardown runs ahead of `VulkanContext`'s device-destroy, not after
-- The allocator is SHARED (`Arc<Mutex<…>>`) with the renderer — verify the lock is held for minimum duration during egui texture upload (Dimension 4 lock-duration); a long hold on the shared allocator mutex stalls the render thread
+### 6. R1 Material Table Layout Soundness
 
-1. Use Grep to find all `unsafe` blocks in `crates/` (`.rs` files)
-2. Read each unsafe block and its surrounding context
-3. Check Vulkan resource pairing with Drop implementations
-4. Check RT-specific safety (acceleration structures, device addresses, SSBO indexing)
-5. Check new-compute-pipeline safety (TAA, caustic, skin compute, volumetrics, bloom)
-6. Check R1 material table layout invariants (300 B size pin + per-field offset pin + intern cap; Disney/translucency scalars stay flat f32 + zeroed in Default)
-7. Check IOR-refraction safety (glass loop, Frisvad, ray budget, interior fallback)
-8. Check NPC / animation spawn safety (B-spline FLT_MAX, AnimationClipRegistry dedup)
-9. Check NIFAL canonical-translation safety (no NaN sentinel reaches the GPU — every Material producer runs `resolve_pbr`; collision + particle extract boundaries emit finite, bounded scalars) — see also `/audit-nifal`
-10. Check debug-ui (egui overlay) Vulkan teardown ordering + shared-allocator lock duration
-11. Save report to `docs/audits/AUDIT_SAFETY_<TODAY>.md`
+- **`GpuMaterial` size is pinned at 300 B** by `gpu_material_size_is_300_bytes`
+  (`crates/renderer/src/vulkan/material.rs`) — the test name now matches the
+  asserted size (history: 272 → 260 after #804 dropped `avg_albedo`, → 296 with the
+  Disney sheen/subsurface lobe #1249, → 300 with `anisotropic` #1250). A stale
+  260/272/296 in audit prose, or any test-name-vs-asserted-size mismatch, means the
+  GPU is reading wrong bytes.
+- **Per-field offset pin** `gpu_material_field_offsets_match_shader_contract` (#806):
+  every named field's byte offset asserted against the shader contract. The size pin
+  alone cannot catch a within-vec4 reorder (swap `texture_index ↔ normal_map_index`
+  is size-invisible, runtime-lethal). Adding a field without updating this assertion
+  is a regression.
+- ALL fields are flat scalar `f32`/`u32` — never `[f32; 3]` (std430 vec3 alignment).
+  This includes the newest scalars: the BGSM translucency suite
+  (`translucency_subsurface_r/g/b`, `…_transmissive_scale`, `…_turbulence`) and the
+  Disney lobe (`ior`, `subsurface`, `sheen`, `sheen_tint`, `anisotropic`).
+- Pad fields explicitly zeroed (the byte-`Hash`/`Eq` dedup hashes the raw 300 B; an
+  uninit hole poisons dedup). New scalars must be zeroed in `GpuMaterial::default()`
+  so default materials still dedup to slot 0.
+- **Intern cap (#797).** `MaterialTable::intern` caps at `MAX_MATERIALS = 16384`
+  (`scene_buffer/constants.rs`); over-cap interns return id `0` with a one-shot warn —
+  no SSBO over-index, no DEVICE_LOST. `upload_materials` (`scene_buffer/upload.rs`)
+  `debug_assert`s `len <= MAX_MATERIALS` and clamps with `.min(MAX_MATERIALS)`. Verify
+  the intern cap and the upload truncation stay in lockstep.
+- `GpuInstance.material_id` indexes the SSBO with NO GPU bounds check — CPU must
+  guarantee in-range (SSBO index mismatch = CRITICAL).
+- `ui.vert` MaterialBuffer read offsets must stay in lockstep with `triangle.frag`
+  (#785 was a stale-hunk regression reading wrong bytes) — name `ui.vert` explicitly.
+
+### 7. RT IOR-Refraction Safety (regression guards)
+
+- **Glass-passthrough loop guard (#789):** the texture-equality identity check at
+  the refraction hit prevents unbounded recursion when coincident glass surfaces
+  share an albedo/normal-map descriptor pair. A regression is a frame-time hang on
+  any paired-glass cell. Verify the check is present.
+- **Glass ray budget** `GLASS_RAY_BUDGET = 1048576`
+  (`crates/renderer/src/shader_constants_data.rs`; raised from 8192 in `6efe1706`).
+  It is a runaway-recursion cap, not a quality knob. #1438 documented that the
+  atomicAdd accounting can overshoot the budget unconditionally — note that nuance
+  rather than reporting the overshoot as new. Verify the budget is enforced at every
+  glass call site.
+- **Frisvad orthonormal basis (#820):** the naive `cross(N, world-up)` basis
+  degenerates near-vertical (zero-length → NaN ray). Verify Frisvad is the active
+  path for IOR refraction roughness spread.
+- IOR miss fallback for interiors uses cell-ambient, not global sky tint (open-sky
+  leakage into dungeons is a visible regression).
+- `DBG_VIZ_GLASS_PASSTHRU = 0x80` is a permanent diagnostic bit — verify it hasn't
+  collided with a new debug flag (full catalog in
+  `crates/renderer/src/shader_constants_data.rs`, mirrored to the generated
+  `crates/renderer/shaders/include/shader_constants.glsl`).
+
+### 8. NPC / Animation Spawn Safety
+
+- **B-spline pose-fallback sentinel (#772):** NPCs vanishing under FNV
+  `BSPSysSimpleColorModifier` particle stacks sharing keyframe time-zero with the
+  actor's player must be gated on an `FLT_MAX` sentinel. Removing the gate is
+  whole-NPC disappearance, not a stuck pose. Verify the sentinel is wired.
+- **AnimationClipRegistry dedup (#790):** the registry interns by lowercased path so
+  cell streaming doesn't grow it unboundedly (otherwise one keyframe set leaks per
+  cell load → steady RAM growth). Verify case-insensitive interning is preserved.
+- B-splines reach FNV / FO3 too (`feedback_bspline_not_skyrim_only.md`) — do NOT
+  rule out `NiBSplineCompTransformInterpolator` by game era.
+- Starfield content is WALKABLE (Cydonia) — SF cells reach the spawn/animation path;
+  don't short-circuit spawn-safety reasoning with "no SF content exercises this."
+- `MAX_TOTAL_BONES` overflow guard at the bone-palette emit site
+  (`byroredux/src/render/skinned.rs`, `Once`-gated warn) must fire — silent
+  truncation past cap was the M29 regression. Guard tests:
+  `byroredux/src/render/bone_palette_overflow_tests.rs`.
+
+### 9. NIFAL Boundary — NaN/Inf on the GPU (UB facet only)
+
+*See `/audit-nifal` for correctness-of-mapping; this dimension covers ONLY the
+safety facet — NaN/inf scalars reaching the GPU, unbounded allocation.*
+
+- `byroredux/src/material_translate.rs::translate_material` deliberately seeds
+  `f32::NAN` into `Material.metalness`/`roughness`
+  (`mesh.metalness_override.unwrap_or(f32::NAN)`, same for roughness).
+  `Material::resolve_pbr` (`crates/core/src/ecs/components/material.rs`) is the ONLY
+  thing that detects (`is_nan()`) and clamps these sentinels before they reach
+  `GpuMaterial`. Both fields are now plain `f32` (no `Option`), so a producer that
+  skips `resolve_pbr()` ships a NaN into the SSBO silently (NaN-on-GPU = UB). Verify
+  EVERY renderer-bound `Material` producer runs `resolve_pbr()` or constructs
+  already-finite values (the `static_meshes.rs` fallback constructs finite defaults
+  directly — confirm it still does).
+- Collision translate (`crates/nif/src/import/collision.rs`, covers
+  `BhkMultiSphereShape` + `BhkConvexListShape`): emitted half-extents / radii /
+  sphere centers must be finite and bounded — a NaN/inf shape param propagates into
+  the physics solver and the BLAS build.
+- Typed particle blocks (`crates/nif/src/blocks/particle.rs`) →
+  `extract_emitter_params`/`extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs`)
+  → `apply_emitter_params` (`byroredux/src/systems/particle.rs`): emitter rate /
+  lifespan / size must be finite and non-negative at the extract boundary — an
+  unbounded or NaN rate is an unbounded-allocation / NaN-transform risk downstream.
+
+### 10. debug-ui (egui overlay) Teardown & Shared-Allocator Safety
+
+- `crates/debug-ui/src/lib.rs` `DebugUiState` holds an `ash::Device`, a
+  `vk::RenderPass`, and the renderer's shared `Arc<Mutex<gpu_allocator …>>`; it lives
+  as an ECS resource (`impl Resource for DebugUiState`) and is owned by the main loop.
+- It wraps `egui-ash-renderer`, which owns its own descriptor pool + per-texture
+  images. Those MUST be freed before the engine destroys the `ash::Device` — same
+  class as Dimension 3's allocator-before-device rule. Verify `DebugUiState` teardown
+  runs ahead of `VulkanContext`'s device-destroy.
+- The allocator mutex is SHARED with the render thread — verify it is held for
+  minimum duration during egui texture upload; a long hold stalls rendering.
+
+## Procedure
+
+1. Grep all `unsafe` in `crates/` + `byroredux/` (`.rs`); note the renderer mass
+   and the SAFETY-comment gap (Dimension 4).
+2. Confirm the cxx bridge is still a no-pointer placeholder (Dimension 1).
+3. Audit the cached-pointer ECS contract + repr(C) GPU structs + NIF POD reads +
+   sfmaterial decode (Dimension 2).
+4. Walk the leak inventory and the three drop-ordering regression guards — Rapier
+   release, deferred-destroy drain, AllocatorResource removal (Dimension 3).
+5. Sweep unsafe-block discipline; batch the comment-less blocks (Dimension 4).
+6. Vulkan-spec pass — run validation layers, report emitted errors verbatim; frame
+   barrier/layout claims invisible to cargo test as "needs RenderDoc verification"
+   (Dimension 5).
+7. R1 material layout pins (Dimension 6), IOR/glass guards (7), NPC/anim spawn (8),
+   NIFAL NaN boundary (9), debug-ui teardown (10).
+8. Dedup against open/closed issues (`_audit-common` Deduplication) — most items
+   above are regression guards; recast a confirmed-intact guard as PASS, not a NEW
+   finding.
+9. Save the report to `docs/audits/AUDIT_SAFETY_<TODAY>.md` (see `_audit-common`
+   Report Finalization).

--- a/.claude/commands/audit-skyrim/SKILL.md
+++ b/.claude/commands/audit-skyrim/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Per-game audit of Skyrim SE compatibility — BSTriShape, BSLightingShaderProperty 8 variants, BSA v105"
+description: "Per-game audit of Skyrim SE compatibility — BSTriShape packed geometry, BSLightingShaderProperty shader-type dispatch, NPC equip/FaceGen, multi-master load order"
 argument-hint: "--focus <dimensions>"
 ---
 
@@ -9,34 +9,90 @@ Deep audit of ByroRedux readiness for **The Elder Scrolls V: Skyrim Special Edit
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game-data locations,
+methodology, deduplication rules, and finding format. See
+`.claude/commands/_audit-severity.md` for the severity scale. Do not duplicate
+those here.
+
+## Why Skyrim is the hardest geometry case
+
+Skyrim SE is the engine's renderer **control bench** — cell-load and rendering
+both work (Whiterun BanneredMare). So this audit is *not* readiness scoping; it
+is **regression coverage** plus the genuinely Skyrim-specific risk surface:
+
+1. **BSTriShape packed geometry** — half-float vertex pool with a `vertex_desc`
+   bitfield, inline tangents, and a separate SSE skinned-reconstruction path
+   that is uniquely prone to silent magenta/chrome corruption.
+2. **`BSLightingShaderProperty` shader-type dispatch** — the trailing-field
+   reader branches on ~18 numeric shader types; an off-by-one drops or over-reads
+   geometry on a whole material class.
+3. **NPC equip + FaceGen** — Whiterun ships 6 named equipped NPCs via M41
+   OTFT/LVLI; this is the only vanilla cell that exercises the full outfit chain.
+4. **Multi-master load order** — DLC interiors via `--master` need cross-plugin
+   FormID remap.
+
+Dimensions below are ordered by that risk, highest first.
 
 ## Game Context
 
-| Aspect            | State                                                                              |
-|-------------------|------------------------------------------------------------------------------------|
-| NIF format        | v20.2.0.7 (BSVER 83 / 100)                                                         |
-| BSA format        | v105 ✓ (LZ4 compression)                                                           |
-| ESM parser        | Unified walker ✓ — Skyrim.esm cells parse (`parse_real_skyrim_esm`, SolitudeWinkingSkeever, 92-byte XCLL) |
-| Parse rate        | 100.00% (18862 / 18862) — Meshes0 sweep is `100.00% clean / 0 truncated / 0 recovered / 0 realignment WARN` post #836–#838 |
-| Rendering         | Cells + meshes ✓ — WhiterunBanneredMare is the renderer **control bench** (329.8 FPS / 3.03 ms / 3211 ent / 1296 draws, R6a-stale-13 refresh `4e2ebe8c` 2026-05-28) |
-| Cell loading      | Wired ✓ — WhiterunBanneredMare renders (3211 entities, 6 named NPCs via M41 OTFT/LVLI) |
-| Reference data    | `/mnt/data/SteamLibrary/steamapps/common/Skyrim Special Edition/Data/`             |
+Pull live numbers from `ROADMAP.md` (compat matrix + Bench-of-record) and
+`docs/feature-matrix.md` rather than trusting any figure transcribed here —
+benches refresh every `/session-close`.
 
-### Known Specifics
+| Aspect       | State (cite ROADMAP, do not re-transcribe) |
+|--------------|---------------------------------------------|
+| NIF format   | v20.2.0.7 (BSVER 83 / 100) |
+| BSA format   | v105 ✓ (LZ4 block compression) — `crates/bsa/src/archive/` |
+| ESM parser   | Unified `esm/` walker ✓ — `Skyrim.esm` cells parse (`parse_real_skyrim_esm`, finds `SolitudeWinkingSkeever`) |
+| Parse rate   | 100% clean on the Meshes0 sweep (cite ROADMAP compat matrix for the exact ratio) |
+| Rendering    | Cells + meshes ✓ — Whiterun BanneredMare is the renderer **control bench** (entity/FPS figures: ROADMAP Bench-of-record, currently R6a-stale-14) |
+| NPC equip    | 6 named NPCs equipped via M41 OTFT/LVLI (`byroredux/src/npc_spawn.rs`) |
+| Reference data | `/mnt/data/SteamLibrary/steamapps/common/Skyrim Special Edition/Data/` |
 
-- **BSTriShape** — packed vertex format with u16 half-precision positions/normals, optional skinning (VF_SKINNED), optional full-precision (VF_FULL_PRECISION). Per-vertex tangents ship inline in the packed-vertex blob when `VF_TANGENTS | VF_NORMALS` are set (Skyrim convention; FO4+ shares the same inline path — see #795 / #796).
-- **BSLightingShaderProperty** — 8 shader-type variants: None, EnvironmentMap, GlowShader (SkinTint for hair?), HairTint, ParallaxOcc, MultiLayerParallax, SparkleSnow, EyeEnvmap.
-- **BSEffectShaderProperty** — soft falloff depth, greyscale texture, lighting influence, env map min LOD.
-- **BSDynamicTriShape** (facegen) + **BSLODTriShape** (DLC LOD — see architectural note below) + **BSMeshLODTriShape** + **BSSubIndexTriShape**.
-- **`NiLodTriShape`** (#838 SK-D5-NEW-07, 8d416cc) — **architecturally distinct** from BSTriShape: inherits from `NiTriBasedGeom` per nif.xml, NOT from BSTriShape. Routed through a dedicated `NiLodTriShape` wrapper with `NiTriShape + 3 LOD-size u32s`. Pre-#838 dispatch through BSTriShape produced a 23-byte over-read on every Skyrim tree LOD. Audit guard: any audit that proposes "fold BSLODTriShape back into BSTriShape" is a regression of #838.
-- **`BsLagBoneController`** + **`BsProceduralLightningController`** (#837 SK-D5-NEW-03) — both have dedicated parsers. Without them, ~120 by-design `block_size` WARN events fire per Meshes0 sweep.
-- **BSTriShape `data_size` warning gate** (#836 SK-D5-NEW-02) — gated on `num_vertices != 0`. Removing the gate fires 67 false-positive WARNs/parse on the SSE skinned-body reconstruction path.
-- **BSTreeNode** — SpeedTree wind-bone lists.
-- **BSPackedCombined[Shared]GeomDataExtra** — distant LOD batches.
-- **BsDismemberSkinInstance** — dismemberment data on skinned meshes.
-- Windowed shader trailing fields are fully parsed (N23.2).
-- **Meshes0 sweep baseline (post #836–#838)**: `100.00% clean / 0 truncated / 0 recovered / 0 realignment WARNs`. Any audit observing realignment WARNs on a clean Skyrim Meshes0 corpus has hit a regression.
+### Known Specifics (verified against live code)
+
+- **BSTriShape** — packed vertex pool keyed off a 64-bit `vertex_desc` bitfield
+  (`crates/nif/src/blocks/tri_shape/bs_tri_shape.rs`, `BsTriShape` struct).
+  `VF_*` attribute bits select u16 half-precision positions/normals, optional
+  skinning (`VF_SKINNED`), optional full precision. Per-vertex tangents ship
+  inline in the packed blob when `VF_TANGENTS | VF_NORMALS` are set (Skyrim
+  convention; FO4+ shares the inline path — #795 / #796).
+- **`BsTriShapeKind`** disambiguates the five wire-distinct subclasses that share
+  the one `BsTriShape` Rust struct: `Plain` (BSTriShape), `LOD` (BSLODTriShape),
+  `MeshLOD` (BSMeshLODTriShape), `SubIndex` (BSSubIndexTriShape, boxed
+  segmentation payload, #404), `Dynamic` (BSDynamicTriShape — facegen heads).
+- **`BSLODTriShape` is routed through `NiLodTriShape`, NOT `BsTriShape`** (#838).
+  Per nif.xml, `BSLODTriShape` inherits `NiTriBasedGeom` (`#SKY##SSE#`) while
+  `BSMeshLODTriShape` inherits `BSTriShape` (`#FO4#`) — they look identical at the
+  block name but have different bodies. The dispatch in
+  `crates/nif/src/blocks/mod.rs` sends `"BSLODTriShape"` to
+  `NiLodTriShape::parse` and `"BSMeshLODTriShape"` to `BsTriShape::parse_meshlod`.
+  Pre-#838 routing of `BSLODTriShape` through BSTriShape over-read every Skyrim
+  tree LOD. **Audit guard**: any proposal to "fold BSLODTriShape into BSTriShape"
+  is a regression of #838.
+- **`BSLightingShaderProperty`** lives in `crates/nif/src/blocks/shader.rs`
+  (NOT in `crates/nif/src/blocks/properties.rs`, where it was historically
+  assumed). The shader-type-specific trailing data is the
+  `ShaderTypeData` enum — **9 Rust variants** (`None`, `EnvironmentMap`,
+  `SkinTint`, `HairTint`, `ParallaxOcc`, `MultiLayerParallax`, `SparkleSnow`,
+  `EyeEnvmap`, `Fo76SkinTint`). The dispatch (`parse_shader_type_data`) maps
+  ~18 numeric Skyrim/FO4 `BSLightingShaderType` values onto those variants
+  (most fall through to `None`). FO76 uses the distinct `BSShaderType155`
+  numbering (`parse_shader_type_data_fo76`). There is no `GlowShader` variant —
+  glow (type 2) reads `None` trailing data.
+- **`BSEffectShaderProperty`** — also in `crates/nif/src/blocks/shader.rs`: `soft_falloff_depth`,
+  `greyscale_texture`, `lighting_influence`, `env_map_min_lod`, falloff
+  start/stop angle+opacity.
+- **`BsLagBoneController`** + **`BsProceduralLightningController`** (#837) — both
+  have dedicated parsers (`crates/nif/src/blocks/controller/`). Without them a
+  large by-design `block_size` WARN burst fires per Meshes0 sweep.
+- **BSTriShape `data_size` warning gate** (#836) — gated on `num_vertices != 0`
+  so the SSE skinned-body reconstruction path doesn't fire false-positive WARNs.
+- **`BSBoneLODExtraData`** parser landed (#614, `crates/nif/src/blocks/extra_data.rs`).
+- Other specialty blocks: `BsDismemberSkinInstance` (dismemberment),
+  `BSPackedCombined[Shared]GeomDataExtra` (distant LOD batches), `BSTreeNode`
+  (SpeedTree wind bones), and the `BSFadeNode` / `BSBlastNode` / `BSMultiBoundNode`
+  NiNode subclasses unwrapped by the import walker.
 
 ## Parameters (from $ARGUMENTS)
 
@@ -51,56 +107,90 @@ See `.claude/commands/_audit-common.md` for project layout, game data locations,
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: BSTriShape Vertex Format
+### Dimension 1: BSTriShape Packed Geometry + SSE Skinned Reconstruction
 **Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (BSTriShape parser; split out into `tri_shape/bs_tri_shape.rs` post-#1118), `crates/nif/src/import/mesh/bs_tri_shape.rs`
-**Checklist**: Vertex format flag bits (`VF_*`) mapped correctly — VERTEX, UV, NORMAL, TANGENT, COLOR, SKINNED, FULL_PRECISION, EYE_DATA. Half-precision u16 → f32 conversion numerically correct (IEEE 754 binary16 decode). Packed normals → tangent-space reconstruction. Vertex index stride (u16 vs u32) chosen from the BSVER or packed-vertex flag. `extract_bs_tri_shape` in `import/mesh/bs_tri_shape.rs` handles all flag combinations. Skinned-vertex `bone_indices` / `bone_weights` extraction matches the #178 skinning pipeline. **SSE skinned-geometry reconstruction tangent path (#1204 / #1202 / #1201)**: SSE skinned bodies ship geometry in a partition-remapped global buffer, reconstructed in `crates/nif/src/import/mesh/sse_recon.rs` — confirm positions/normals are Z-up→Y-up converted AND the on-disk "bitangent" triplet is routed as the Y-up tangent (∂P/∂U) so reconstructed bodies don't read as magenta/chrome (regression guard mirroring the `feedback_chrome_means_missing_textures` failure mode). Companion alpha-property cascade gated on `alpha_property_consumed` (`crates/nif/src/import/material/walker.rs`, gate sites ~472/541; flag set in `import/material/mod.rs:494`) so skinned geometry inherits the parent `NiAlphaProperty` exactly once (#1202 / #1201).
+**Entry points**: `crates/nif/src/blocks/tri_shape/bs_tri_shape.rs` (`BsTriShape` parser, `vertex_desc` / `VF_*` flags, `BsTriShapeKind`), `crates/nif/src/import/mesh/bs_tri_shape.rs` (`extract_bs_tri_shape` / `_local`), `crates/nif/src/import/mesh/sse_recon.rs` (#559), `crates/nif/src/import/mesh/tangent.rs`
+**Checklist**:
+- `VF_*` flag bits mapped correctly (VERTEX, UVS, UVS_2, NORMALS, TANGENTS, COLORS, SKINNED, FULL_PRECISION, EYE_DATA). Half-precision u16 → f32 decode is IEEE-754 binary16 correct.
+- `extract_bs_tri_shape` handles every flag combination; index stride (u16 vs u32) chosen correctly. Skinned `bone_indices` / `bone_weights` extraction matches the skinning pipeline.
+- **SSE skinned-geometry reconstruction tangent path** (`crates/nif/src/import/mesh/sse_recon.rs` #559, tangent convention #1204 in `crates/nif/src/import/mesh/tangent.rs`): SSE skinned bodies ship geometry in a partition-remapped global buffer; confirm positions/normals are Z-up→Y-up converted AND the on-disk "bitangent" triplet is routed as the Y-up tangent (∂P/∂U) so reconstructed bodies don't read magenta/chrome (regression guard — mirrors the `feedback_chrome_means_missing_textures` failure mode).
+- **Alpha-property cascade** gated on `alpha_property_consumed` (#1201 / #1202): set in `crates/nif/src/import/material/mod.rs` (search `info.alpha_property_consumed = true`), consulted at the two gate sites in `crates/nif/src/import/material/walker.rs` (search `!info.alpha_property_consumed`). Skinned geometry must inherit the parent `NiAlphaProperty` exactly once.
 **Output**: `/tmp/audit/skyrim/dim_1.md`
 
-### Dimension 2: BSA v105 (LZ4)
-**Subagent**: `general-purpose`
-**Entry points**: `crates/bsa/src/archive/`
-**Checklist**: BSA v105 header format. LZ4 block decompression via `lz4_flex::block` — verify against known-good Skyrim mesh (e.g. sweetroll). Hash table layout differences vs v104. Folder record size. Embedded-name flag for files. Compressed-file flag priority (archive-level flag vs per-file flag — which wins when they disagree). Full-archive extraction sweep: `Skyrim - Meshes0.bsa` + `Skyrim - Textures*.bsa` all extract without error.
+### Dimension 2: BSLightingShaderProperty / BSEffectShaderProperty Shader-Type Dispatch
+**Subagent**: `renderer-specialist`
+**Entry points**: `crates/nif/src/blocks/shader.rs` (`BSLightingShaderProperty`, `BSEffectShaderProperty`, `ShaderTypeData`, `parse_shader_type_data` / `_fo4` / `_fo76`), `crates/nif/src/blocks/shader_tests.rs`, `crates/nif/src/import/material/` (mod, walker, shader_data), `crates/renderer/shaders/triangle.frag`
+**Checklist**:
+- Every numeric Skyrim/FO4 shader type dispatches to the correct `ShaderTypeData` arm and reads the right trailing-field count (EnvironmentMap = env scale; SkinTint/HairTint = Color3; ParallaxOcc = max_passes + scale; MultiLayerParallax = inner-layer fields; SparkleSnow = 4 params; EyeEnvmap = eye cubemap + two reflection centers). Types with no trailing data (0/2/3/4/8–10/12–13/15/17–19) fall through to `None` — confirm none of those silently over-read.
+- FO76 (`BSShaderType155`, `parse_shader_type_data_fo76`) uses the *different* numeric mapping (type 4 = `Fo76SkinTint` Color4, type 5 = HairTint Color3) — guard the two enums don't cross-contaminate.
+- Flag bits 0–31 (decal / alpha-test / skinned / …) — Skyrim positions differ from FO4; verify the Skyrim decode.
+- `BSEffectShaderProperty`: `soft_falloff_depth`, `greyscale_texture`, `lighting_influence`, `env_map_min_lod`, falloff angle/opacity. Environment-map slot in the texture set; alpha mask threshold.
+- **#1241 PBR scalars surfaced at import** (`crates/nif/src/import/material/lighting_shader_pbr_tests.rs`, `crates/nif/src/import/types.rs`): smoothness / IOR / specular_strength flow into `MaterialInfo`.
+- **Disney/Burley lobe pin (regression guard)**: the principled BRDF in `crates/renderer/shaders/triangle.frag` is gated on `MAT_FLAG_PBR_BSDF` (`#define MAT_FLAG_PBR_BSDF 32u` in `crates/renderer/shaders/include/shader_constants.glsl`; branch sites search `MAT_FLAG_PBR_BSDF` in the frag). Vanilla Skyrim LE/SSE materials don't author the BGSM PBR flag (BGSM is FO4+), so the lobe must stay **unreachable** for vanilla content — confirm vanilla parse runs set 0 instances of the flag on the Skyrim.esm material universe. Modded BGSM that explicitly opts into PBR is the one legitimate path that flips it. See `/audit-nifal` for the canonical boundary that sets the flag (Dimension 7).
 **Output**: `/tmp/audit/skyrim/dim_2.md`
 
-### Dimension 3: BSLightingShaderProperty Shader Variants
-**Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs` (BSLightingShaderProperty), `crates/nif/src/import/material/` (mod, walker, shader_data), `crates/renderer/shaders/triangle.frag`
-**Checklist**: All 8 shader-type enum values dispatch to the correct trailing-field reader (EnvironmentMap adds env strength + env map, HairTint adds hair color, ParallaxOcc adds height map params, MultiLayerParallax adds inner-layer fields, SparkleSnow adds sparkle params, EyeEnvmap adds eye-specific fields). Flag bits 0–31 — which are decal, alpha-test, skinned, etc. in Skyrim (differ from FO4 flag bit positions). SkinTint color for HairTint variant. Environment map slot in BSShaderTextureSet[4]. Alpha mask threshold. Subsurface scattering params parsed but not yet routed to the renderer (noted as M38 wetness/subsurface deferred). **#1241 BSLightingShaderProperty PBR scalars surfaced at import** (`a82366e9`): smoothness / IOR / specular_strength flow into `MaterialInfo`. Skyrim LE/SSE vanilla materials don't author the BGSM PBR flag (BGSM is FO4+), so the Disney lobe at `triangle.frag` should remain unreachable for vanilla content — but Skyrim SE mods CAN ship BGSM-style authoring. Audit pattern: confirm vanilla parse-rate runs show 0 instances of `MAT_FLAG_PBR_BSDF` set on Skyrim.esm material universe; modded BGSM that explicitly opts into PBR is the legitimate path. **Disney BSDF gating regression guard (#1248-#1252)** mirrors the FNV pattern for vanilla Skyrim. **Disney/Burley lobe pin**: the principled-BRDF lobe in `crates/renderer/shaders/triangle.frag` is gated on `MAT_FLAG_PBR_BSDF` (`#define MAT_FLAG_PBR_BSDF (1u << 5)`, frag line 204; branch sites frag lines 2610 / 2861) and carries the MIT GLSL-PathTracer + Burley-2012 Disney SIGGRAPH attribution block (frag lines 12-29). Confirm the lobe stays unreachable for vanilla Skyrim content (bit 5 unset) — only modded BGSM that opts into PBR should flip it. See also `/audit-nifal` for the canonical material boundary that sets this flag (Dimension 7).
+### Dimension 3: NPC Equip + FaceGen (M41)
+**Subagent**: `general-purpose`
+**Entry points**: `byroredux/src/npc_spawn.rs` (M41 actor instantiation), `crates/facegen/src/` (`.tri`/`.egm`/`.egt` morph + texture blend), `byroredux/src/systems/character.rs` (skinning consumer for heads/bodies), `crates/nif/src/import/mesh/sse_recon.rs`
+**Checklist**:
+- The Whiterun BanneredMare 6 named NPCs (saadia, brenuin, mikael, sinmir, amaundmotierreend, hulda) each land `Inventory` + `EquipmentSlots` and spawn equipped (OTFT.items + LVLI dispatch). Guard that count + components don't regress.
+- Skyrim+ `resolve_armor_mesh` walks ARMO → ARMA → worn-mesh; body-slot armor pre-scan skips `upperbody.nif` to kill z-fight + double bone-palette overhead.
+- LVLI flattening (`expand_leveled_form_id`) gated on actor level — single-pick (highest eligible) vs multi-pick. Pre-fix, default outfits referencing LVLI spawned with no gear.
+- FaceGen heads parse via `BSDynamicTriShape` + the `facegen` crate, but expected visual fidelity is limited (no FaceGen runtime morph at render time) — confirm parse, not pixel match.
+- `BSDismemberSkinInstance` partition data routes into the skinning pipeline.
 **Output**: `/tmp/audit/skyrim/dim_3.md`
 
-### Dimension 4: BSEffectShaderProperty + Specialty Nodes
-**Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs` (BSEffectShaderProperty), `crates/nif/src/import/walk/`, `crates/nif/src/blocks/mod.rs` (NiLodTriShape / BsLagBoneController / BsProceduralLightningController dispatch)
-**Checklist**: BSEffectShaderProperty soft_falloff_depth, greyscale_texture, lighting_influence, env_map_min_lod. BSDynamicTriShape (facegen dynamic verts). **`NiLodTriShape`** (Skyrim DLC tree LOD): inherits from NiTriBasedGeom per nif.xml — distinct wrapper, NOT routed through BSTriShape (#838 regression guard, 8d416cc). BSLODTriShape vs BSMeshLODTriShape vs BSSubIndexTriShape — distinct block types with distinct trailing data; dispatch + import must not confuse them. **`BsLagBoneController`** + **`BsProceduralLightningController`** (#837): dedicated parsers — without them ~120 by-design `block_size` WARN events fire per Meshes0 sweep. BSTreeNode wind-bone list parsing (SpeedTree). BSPackedCombined[Shared]GeomDataExtra — distant LOD batch layout. `as_ni_node` walker unwraps Skyrim NiNode subclasses (BSFadeNode, BSBlastNode, BSDamageStage, BSMultiBoundNode, BSTreeNode).
+### Dimension 4: Multi-Master Load Order + TES5 Cell-Load Regression
+**Subagent**: `general-purpose`
+**Entry points**: `byroredux/src/cell_loader/load_order.rs` (`--master` FormID remap), `crates/plugin/src/esm/records/` (TES5 records share the unified parser — the per-game legacy stub was removed under #390), `crates/plugin/src/esm/cell/` (CELL walker), `crates/plugin/src/esm/cell/tests/integration.rs` (`parse_real_skyrim_esm`), `ROADMAP.md`
+**Checklist**:
+- Repeatable `--master <path>` (M46.0 / #561): each plugin's TES4 master_files header drives a per-plugin FormID remap so cross-plugin REFRs land under merged global FormIDs; last-write-wins on collision (canonical Bethesda load order). Unresolved REFRs name the missing plugin. Repro: `cargo run -- --master Skyrim.esm --esm Dawnguard.esm --cell ForebearsHoldoutInt01`.
+- `parse_real_skyrim_esm` walks real `Skyrim.esm`, finds `SolitudeWinkingSkeever` — guard the unified walker keeps parsing Skyrim cells.
+- TES5 compressed-record decompression (groups can be compressed; interiors render) stays green.
+- Minimum interior-render record set parses: CELL, REFR, STAT, LIGH, WEAP, ARMO, plus Skyrim-specific LAND (heightmap scale), LTEX, TXST, ADDN.
+- Out of scope but must parse without error: NAVM, HDPT (metadata), `BSBehaviorGraphExtraData`.
+- **Control-bench guard**: Whiterun BanneredMare entity count + FPS vs the current ROADMAP Bench-of-record (R6a-stale-14). Skyrim ships real `bhk` collision, so entity count is flat across collider-gate changes — any drop in entity count or substantial FPS regression at the same entity count is a control-bench regression.
 **Output**: `/tmp/audit/skyrim/dim_4.md`
 
-### Dimension 5: Real-Data Validation & Rendering
+### Dimension 5: BSA v105 (LZ4)
 **Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, `byroredux/src/render/` (`static_meshes.rs` / `skinned.rs` — Skyrim mesh/material draw enumeration), `byroredux/src/systems/character.rs` (skinning consumer for Skyrim NPC heads/bodies), canonical CLI demos
-**Checklist**: Parse rate holds at 100% (18862 / 18862). `cargo run -- --bsa "Skyrim - Meshes0.bsa" --mesh meshes\clutter\ingredients\sweetroll01.nif --textures-bsa "Skyrim - Textures3.bsa"` still renders correctly at ≥3000 FPS (2026-04-22 baseline: ~3000-5000 FPS on RTX 4070 Ti @ 1280×720; regression if substantially below 3000). Pick: one creature (dragon skeleton, NPC head), one landscape (tree LOD), one magic effect (BSEffectShaderProperty). Trace each through `import_nif_scene` → `material_translate::translate_material` → `render/static_meshes.rs` (static) / `render/skinned.rs` (skinned via `systems/character.rs`) → verify mesh count, material extraction, and texture handle resolution. Pick a FaceGen head — parses but expected visual fidelity is limited (no FaceGen runtime).
+**Entry points**: `crates/bsa/src/archive/` (mod, open, extract, hash, tests)
+**Checklist**:
+- v105 header format; LZ4 block decompression via `lz4_flex::block` — verify against a known-good Skyrim mesh (e.g. sweetroll).
+- Hash table layout vs v104; folder record size; embedded-name flag; compressed-file flag priority (archive-level vs per-file — which wins on disagreement).
+- Full-archive extraction sweep: `Skyrim - Meshes0.bsa` + `Skyrim - Textures*.bsa` (through Textures8) all extract without error. Note the numeric-sibling auto-load gotcha: it gates on a non-digit suffix, so `Textures0.bsa` siblings must be listed explicitly.
 **Output**: `/tmp/audit/skyrim/dim_5.md`
 
-### Dimension 6: TES5 Cell-Load Regression Coverage
-**Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/records/` (TES5 records share the unified parser — the per-game legacy/tes5.rs stub was removed under `#390`), `crates/plugin/src/esm/cell/` (CELL walker + per-feature submodules), `crates/plugin/src/esm/cell/tests/integration.rs` (`parse_real_skyrim_esm`), `ROADMAP.md`
-**Checklist**: NOTE — Skyrim ESM/cell loading is **WIRED and rendering**, not a forward blocker; this dimension is regression coverage, not readiness scoping. `parse_real_skyrim_esm` walks the real `Skyrim.esm`, finds `SolitudeWinkingSkeever` (>50 refs, 92-byte XCLL) — guard that the unified walker keeps parsing Skyrim cells. TES5 group structure vs TES4 (Skyrim uses compressed records extensively — groups can be compressed); compressed-record decompression already works (interiors render) — confirm it stays green. Record types live on the minimum "interior cell renders" path (CELL, REFR, STAT, LIGH, WEAP, ARMO) plus Skyrim-specific: LAND (different heightmap scale), LTEX, TXST, ADDN (addon nodes). `WhiterunBanneredMare` is the renderer **control bench** (3211 entities @ 329.8 FPS, R6a-stale-13 `4e2ebe8c` 2026-05-28) + 6 named NPCs via M41 — any drop in entity count or substantial FPS regression at the same 3211-entity count is a control-bench regression. Out of scope but must parse without error: NAVM (navmesh), HDPT (FaceGen head parts — metadata only), `BSBehaviorGraphExtraData` (havok behavior graphs). Dialog/Quest radiant-story format is not on the render path.
+### Dimension 6: Specialty Blocks + Real-Data Rendering
+**Subagent**: `renderer-specialist`
+**Entry points**: `crates/nif/src/blocks/mod.rs` (NiLodTriShape / BsLagBoneController / BsProceduralLightningController dispatch), `crates/nif/src/blocks/controller/`, `crates/nif/src/import/walk/`, `crates/nif/examples/nif_stats.rs`, `byroredux/src/render/static_meshes.rs`, `byroredux/src/render/skinned.rs`
+**Checklist**:
+- `BSLODTriShape` (Skyrim DLC tree LOD) routed through `NiLodTriShape`, NOT BSTriShape (#838 regression guard). `BSLODTriShape` vs `BSMeshLODTriShape` vs `BSSubIndexTriShape` — distinct bodies, must not be confused.
+- `BsLagBoneController` + `BsProceduralLightningController` (#837): dedicated parsers — without them a by-design `block_size` WARN burst fires per Meshes0 sweep.
+- `BSTreeNode` wind-bone list (SpeedTree); `BSPackedCombined[Shared]GeomDataExtra` distant-LOD batch layout; the import walker unwraps `BSFadeNode` / `BSBlastNode` / `BSMultiBoundNode`.
+- **Meshes0 sweep baseline**: 100% clean / 0 truncated / 0 recovered / 0 realignment WARNs. Any audit observing realignment WARNs on a clean Skyrim Meshes0 corpus has hit a regression.
+- Real-data render trace: pick one creature (dragon skeleton / NPC head), one landscape (tree LOD), one magic effect (BSEffectShaderProperty). Trace each `import_nif_scene` → `material_translate::translate_material` → `byroredux/src/render/static_meshes.rs` (static) / `byroredux/src/render/skinned.rs` (skinned) — verify mesh count, material extraction, texture handle resolution. Single-mesh smoke: render `meshes\clutter\ingredients\sweetroll01.nif` and confirm FPS stays in the ROADMAP-documented band.
 **Output**: `/tmp/audit/skyrim/dim_6.md`
 
 ### Dimension 7: NIFAL Canonical Material Translation (Skyrim slice)
 **Subagent**: `renderer-specialist`
-**Entry points**: `byroredux/src/material_translate.rs` (`translate_material`), `crates/core/src/ecs/components/material.rs` (`Material`, `Material::resolve_pbr`, `EmissiveSource`, `classify_pbr_keyword`), `docs/engine/nifal.md`
-**Checklist**: `translate_material` (`byroredux/src/material_translate.rs:65`) is the **single canonical boundary** mapping the per-game `ImportedMesh` (BSLightingShaderProperty / BSEffectShaderProperty `MaterialInfo`) into one ECS `Material` — no second translation path, no render-time fallback. `Material.metalness` / `Material.roughness` are plain resolved `f32` (`material.rs:216` / `:222`), seeded from BGSM/BGEM authored scalars or a `f32::NAN` sentinel, then filled by `Material::resolve_pbr` (`material.rs:588`) which delegates to the keyword classifier `classify_pbr_keyword` (`material.rs:432`) — the old per-draw `Material::classify_pbr` is **deleted** (any audit proposing render-time PBR classification is a regression of the canonical boundary). Ordering at the boundary: `material.resolve_pbr()` runs **before** `crate::helpers::classify_glass_into_material` (`material_translate.rs:153`) so forced-glass roughness wins over the keyword default. **EmissiveSource discriminator (#1280)**: `enum EmissiveSource { None, Material, Lighting, Effect }` (`material.rs:354`) — Skyrim `GlowShader` / `emissive_multiple` routes through the `Lighting` variant; resolves as an effective ~1.0 no-op across variants today, but the import-side routing is Skyrim-relevant (verify GlowShader maps to `Lighting`, not `Effect`). See also `/audit-nifal` for the cross-game canonical-translation deep dive (no-fabrication / single-boundary / no-render-time-fallback invariants).
+**Entry points**: `byroredux/src/material_translate.rs` (`translate_material`), `crates/core/src/ecs/components/material.rs` (`Material`, `Material::resolve_pbr`, `EmissiveSource`, `classify_pbr_keyword`, `PbrClassifierInputs`), `docs/engine/nifal.md`
+**Checklist**:
+- `translate_material` is the **single canonical boundary** mapping the per-game `ImportedMesh` (BSLightingShaderProperty / BSEffectShaderProperty `MaterialInfo`) into one ECS `Material` — no second translation path, no render-time fallback.
+- `Material.metalness` / `Material.roughness` are plain resolved `f32` fields, seeded from BGSM/BGEM scalars or an `f32::NAN` sentinel, then filled by `Material::resolve_pbr`, which delegates to the keyword classifier `classify_pbr_keyword`. The old per-draw `Material::classify_pbr` is **deleted** — any audit proposing render-time PBR classification is a regression of the canonical boundary.
+- Ordering at the boundary: `material.resolve_pbr()` runs **before** `crate::helpers::classify_glass_into_material` so forced-glass roughness wins over the keyword default.
+- **`EmissiveSource` discriminator (#1280)**: `enum EmissiveSource { None, Material, Lighting, Effect }`. Skyrim `BSLightingShaderProperty.emissive_multiple` routes through the `Lighting` variant (genuine emissive scalar); `Effect` is the BSEffectShaderProperty diffuse-tint conflation. Verify Skyrim emissive maps to `Lighting`, not `Effect`.
+- See `/audit-nifal` for the cross-game canonical-translation deep dive (no-fabrication / single-boundary / no-render-time-fallback invariants).
 **Output**: `/tmp/audit/skyrim/dim_7.md`
 
 ## Phase 3: Merge
 
 1. Read all `/tmp/audit/skyrim/dim_*.md` files.
 2. Combine into `docs/audits/AUDIT_SKYRIM_<TODAY>.md` with structure:
-   - **Executive Summary** — Current state: both loose-mesh and cell rendering work — WhiterunBanneredMare is the renderer control bench (3211 entities). Shader coverage across 8 BSLightingShaderProperty variants + the NIFAL canonical material boundary.
-   - **Dimension Findings** — Grouped by severity per dimension.
-   - **Shader Variant Coverage Matrix** — 8 BSLightingShaderProperty variants × parse-complete / import-complete / render-complete.
-   - **Cell-Load Regression Status** — TES5 cells parse through the unified `esm/cell/` walker (compressed records decompress); Whiterun control-bench entity count + FPS vs the R6a-stale-13 baseline.
+   - **Executive Summary** — Skyrim SE is the renderer control bench (Whiterun BanneredMare, 6 equipped NPCs); both loose-mesh and cell rendering work. This audit is regression coverage + Skyrim-specific geometry/shader/equip risk.
+   - **Dimension Findings** — grouped by severity per dimension.
+   - **Shader-Type Coverage Matrix** — the `ShaderTypeData` variants × parse-complete / import-complete / render-complete (note which numeric types map to `None`).
+   - **Cell-Load Regression Status** — TES5 cells parse through the unified `esm/cell/` walker (compressed records decompress); Whiterun control-bench entity count + FPS vs the current ROADMAP Bench-of-record.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_SKYRIM_<TODAY>.md`

--- a/.claude/commands/audit-speedtree/SKILL.md
+++ b/.claude/commands/audit-speedtree/SKILL.md
@@ -1,121 +1,300 @@
 ---
-description: "Audit the SpeedTree (.spt) TLV parser + placeholder-billboard fallback shipped in Session 33 Phase 1"
+description: "Audit the SpeedTree (.spt) TLV walker + placeholder-billboard fallback shipped in Session 33 Phase 1"
 argument-hint: "--focus <dimensions> --depth shallow|deep"
 ---
 
 # SpeedTree Subsystem Audit
 
-Audit the `byroredux-spt` crate (Session 33 Phase 1, since grown to 7 `src/` modules + 5 example analyzers) for TLV walker correctness, tag coverage against the FNV/FO3/Oblivion `.spt` corpus, the ≥95% acceptance gate, the placeholder-billboard fallback that keeps cell loads alive when a tree fails to decode, and the NIFAL material translation the placeholder mesh now flows through.
+Audit the `byroredux-spt` crate — a young, deliberately small subsystem
+(Session 33 Phase 1, "S1"). It does two things: (1) walks the `.spt`
+parameter section as a tag-length-value stream for FNV / FO3 / Oblivion,
+and (2) emits a **placeholder billboard** `ImportedScene` so TREE cells
+render *something* instead of panicking or going treeless. The real
+geometry tail is **not** decoded — everything past `tail_offset` is left
+on the floor by design.
 
-**Architecture**: Single-pass — small enough to run dimensions inline rather than spawning Tasks.
+Keep the audit proportionate. The highest-risk surface is the **walker's
+byte accounting** (one mis-sized payload desyncs the whole stream), then
+the **placeholder fallback correctness**, then **TREE record → billboard
+wiring**, then **per-game `.spt` differences**. The tag dictionary is
+large but each entry is a fixed-size decode — low risk individually.
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+**Architecture**: Single-pass — small enough to run all dimensions inline
+rather than spawning Tasks.
+
+See `.claude/commands/_audit-common.md` for project layout, methodology,
+deduplication, context rules, severity, and finding format. Do not
+re-derive any of those here.
 
 ## Scope
 
-**Crate**: `crates/spt/src/` (Session 33 Phase 1 — TLV walker + placeholder fallback).
+**Crate**: `crates/spt/src/` — `parser.rs`, `tag.rs`, `version.rs`,
+`stream.rs`, `scene.rs`, `crates/spt/src/import/mod.rs`, plus the
+feature-gated `crates/spt/src/recon/mod.rs`. Public surface re-exported
+from `crates/spt/src/lib.rs`: `parse_spt`, `import_spt_scene`,
+`SptImportParams`, `SptScene`, `detect_variant`, `dispatch_tag`.
+(`compute_billboard_size` is a *private* helper in the import module, not
+an entry point.)
 
-**Cross-cuts**:
-- `byroredux/src/cell_loader/references.rs` — extension switch routes `.spt` to the SpeedTree importer instead of NIF (`is_spt` test at ~478-490 → `parse_and_import_spt` at ~1080). `refr.rs` does NOT carry the `.spt` route.
-- `byroredux/src/scene/nif_loader.rs` — `--tree` direct-visualisation CLI entry (`--tree trees\\joshua01.spt`; `--mesh foo.spt` is equivalent — both branch on the `.spt` extension)
-- `crates/plugin/src/esm/records/tree.rs` — TREE record parser (was previously falling into the generic record path and losing texture/billboard data)
-- `byroredux/src/material_translate.rs::translate_material` — the NIFAL canonical boundary that consumes the spt placeholder `ImportedMesh` at `cell_loader/spawn.rs:861` (`Material::resolve_pbr` fills any unset PBR slot). See `docs/engine/nifal.md` and `/audit-nifal`.
+**Cross-cuts** (the wiring that actually invokes the crate):
+- `byroredux/src/cell_loader/references.rs` — the production route. An
+  `is_spt` extension check (`model_path … eq_ignore_ascii_case("spt")`)
+  dispatches to `parse_and_import_spt`, which looks up the matching TREE
+  record from `record_index.trees` and threads its metadata into
+  `SptImportParams`. `refr.rs` does **not** carry a `.spt` route.
+- `byroredux/src/scene/nif_loader.rs` — the `--tree` / loose-file
+  direct-visualiser route (`parse_import_and_merge`, `is_spt` branch).
+  This is a **parallel** path: it calls `import_spt_scene` with
+  `SptImportParams::default()` — **no TREE metadata** (no ICON override,
+  no OBND/MODB/BNAM sizing). Verify the two routes don't silently diverge
+  in ways that matter (Dimension 4).
+- `crates/plugin/src/esm/records/tree.rs` — `parse_tree` → `TreeRecord`.
+  Captures OBND / ICON / MODB / SNAM / CNAM / BNAM / PFIG. `has_speedtree_binary()`
+  is the case-insensitive `.spt` predicate. Pre-S1 TREE fell into the
+  generic MODL-only path and dropped every field but MODL.
+- `byroredux/src/systems/billboard.rs` — `make_billboard_system` rotates
+  any entity carrying a `Billboard` component. `BsRotateAboutUp` (the mode
+  the spt placeholder uses) currently falls back to the world-up yaw lock
+  — confirm that's still the behaviour and that the `-Z` front-face
+  convention in `import/mod.rs` matches the rotation arc used here.
+- `byroredux/src/cell_loader/spawn.rs` — attaches the `Billboard`
+  component from `cached.placement_root_billboard`, and routes the
+  placeholder `ImportedMesh` through the NIFAL boundary
+  (`crate::material_translate::translate_material`).
 
-**Crate layout** (Session 33+ — no longer a single file; `crates/spt/src/`):
-- `parser.rs` — `parse_spt(&[u8]) -> io::Result<SptScene>`, tag-band guards `TAG_MIN = 100` / `TAG_MAX = 13_999`
-- `tag.rs` — `SptTagKind` (9 payload kinds: `Bare`/`U8`/`U32`/`Vec3`/`FixedBytes(u8)`/`String`/`ArrayBytes{stride}`/`Unknown`/`MaybeStringElseBare`) + `dispatch_tag(u32)`
-- `version.rs` — `detect_variant(&[u8])`, `SpeedTreeVariant` (`V4Oblivion`/`V5Fo3`/`V5Fnv`/`Unknown`)
-- `stream.rs` — `SptStream<'a>` (LE readers, EOF guard)
-- `scene.rs` — `SptScene` / `SptValue` / `TagEntry`
-- `recon/mod.rs` — feature-gated reconstruction
-- `import/mod.rs` — placeholder importer (`compute_billboard_size`, `ImportedMesh` build)
-- Recon analyzers live in `crates/spt/examples/` (`spt_dissect.rs`, `spt_tagmap.rs`, `spt_transitions.rs`, `spt_walk.rs`, `spt_recon.rs`); format notes at `crates/spt/docs/format-notes.md`
+**Phase 1 ("S1") acceptance** (ground truth — verify before reporting):
+- TLV walker recovered against the FNV/FO3/Oblivion `.spt` corpus
+  (133 vanilla files; Oblivion ≈ 113).
+- Acceptance gate ≥ 95 % *unknown-tag-clean* rate, asserted in
+  `crates/spt/tests/parse_real_spt.rs` (env-var gated, `#[ignore]`).
+- Placeholder fallback: un-decoded trees render as a billboard card,
+  never an `Err` out of the cell loader.
+- `.spt` REFRs route to the SpeedTree importer, not NIF.
+- `--tree` smoke path parses + imports.
 
-**Phase 1 acceptance** (ground truth — verify before reporting):
-- Single-file dissector + tag dictionary recovered against the corpus
-- TLV walker ≥95% on FNV/FO3/Oblivion `.spt` corpus (`>5 GB joshua01.spt` etc.)
-- Importer placeholder fallback — un-decoded trees render as a billboard card (better than parse panic)
-- `.spt` references in cell records route to the SpeedTree importer, not NIF
-- `--tree` smoke test passes
-
-**Future phases (NOT yet shipped — do not flag as missing unless scope includes them)**: full geometry recovery (real branch/leaf mesh, not billboard), wind-bone animation from `BSTreeNode`, distance-LOD swap, baked-shadow lookup.
+**Future phases (NOT shipped — do not flag as missing unless `--focus`
+explicitly includes them)**: real branch/leaf mesh recovery from the
+geometry tail, wind-bone animation from SNAM/CNAM, distance-LOD swap,
+baked-shadow lookup. SNAM/CNAM are *parsed but not consumed* (TD5-011
+gate) — that's intentional, not a drop.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 6.
-- `--depth shallow|deep`: `shallow` = walker contract check; `deep` = run corpus against the walker + diff against the baseline. Default: `deep`.
+- `--focus <dimensions>`: comma-separated dimension numbers. Default: all.
+- `--depth shallow|deep`: `shallow` = walker contract + wiring review from
+  source only; `deep` = also run the corpus harness against on-disk BSAs.
+  Default: `deep`.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: TLV Format | Tag Coverage | Corpus Acceptance | Placeholder Fallback | Routing & CLI | NIFAL Material Translation
+- **Dimension**: Walker Byte-Accounting | Placeholder Fallback | TREE→Billboard Wiring | Per-Game Variants | Tag Dictionary | NIFAL Material Translation
 
 ## Phase 1: Setup
 
 1. `mkdir -p /tmp/audit/speedtree`
-2. `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels --search "speedtree OR .spt OR TREE" > /tmp/audit/speedtree/issues.json`
-3. Confirm corpus path: `find /mnt/data/SteamLibrary/steamapps/common -iname '*.spt' 2>/dev/null | head` — and the in-BSA paths (`trees\\*.spt` in FNV `Fallout - Meshes.bsa`, FO3 `Fallout - Meshes.bsa`, Oblivion `Oblivion - Meshes.bsa`)
+2. Dedup query (per `_audit-common.md`):
+   `gh issue list --repo matiaszanolli/ByroRedux --limit 200 --json number,title,state,labels --search "speedtree OR spt OR TREE" > /tmp/audit/speedtree/issues.json`
+3. Read the prior report `docs/audits/AUDIT_SPEEDTREE_2026-05-13.md` —
+   its findings SPT-D4-01/02/03/04, SPT-D5-01/02, SPT-D2-01, SPT-D3-01,
+   SPT-D1-01 are all **closed** (#994/#995/#996/#997/#998/#999/#1000/#1001/#1002).
+   Treat them as **regression guards**, not open items; only re-flag if a
+   guard has actually broken.
+4. `deep` only — corpus + recon harness:
+   - corpus location: `Fallout - Meshes.bsa` (FNV/FO3), `Oblivion - Meshes.bsa`.
+   - acceptance run: `BYROREDUX_FNV_DATA=… cargo test -p byroredux-spt --release --test parse_real_spt -- --ignored --nocapture` (and `_FO3_DATA` / `_OBL_DATA`).
+   - per-file dumps: the `recon` examples are **feature-gated** —
+     `cargo run -p byroredux-spt --features recon --example spt_walk` (also
+     `spt_tagmap`, `spt_transitions`, `spt_dissect`, `spt_recon`). Findings
+     log to `crates/spt/docs/format-notes.md`.
 
 ## Phase 2: Dimensions
 
-### Dimension 1: TLV Format Correctness
-**Entry points**: `crates/spt/src/parser.rs` (`parse_spt`, `TAG_MIN`/`TAG_MAX`), `crates/spt/src/stream.rs` (`SptStream` LE readers + EOF guard), `crates/spt/src/version.rs` (`detect_variant`, `SpeedTreeVariant`), `crates/spt/tests/parse_synthetic_spt.rs`
-**Checklist**:
-- Header magic + version bytes recognised across FNV/FO3/Oblivion variants (TLV format isn't versioned by a global field — verify each entry point claims its own header)
-- Tag-length-value walker correctly skips unknown tags using their length (no byte-misalignment cascade past the first unknown tag)
-- Length field byte-width is consistent (LE u32 per current dissector; flag if any variant ships u16)
-- Walker stops cleanly at EOF — no off-by-one read past file end on the last tag
-- Negative / zero / pathological lengths bail with `Err`, not panic — `.spt` is artist-shipped data, must not crash the cell loader
-- Endian: LE everywhere (no big-endian fallback path); compile-error gate if a future big-endian host is added
+Ordered by SpeedTree risk.
 
-### Dimension 2: Tag Coverage
-**Entry points**: `crates/spt/src/tag.rs` (`SptTagKind` + `dispatch_tag`), recon analyzers in `crates/spt/examples/` (`spt_tagmap.rs`, `spt_transitions.rs`, `spt_dissect.rs`), format notes at `crates/spt/docs/format-notes.md`
+### Dimension 1: Walker Byte-Accounting
+**Highest risk.** The walker has no length-prefixed framing for most tags —
+it advances by the *payload kind's* fixed size. A single wrong size in the
+dictionary desyncs every subsequent read.
+**Entry points**: `crates/spt/src/parser.rs` (`parse_spt`, `read_payload`,
+`TAG_MIN`/`TAG_MAX`), `crates/spt/src/stream.rs` (`SptStream` LE readers +
+`is_eof`/`remaining` guards), `crates/spt/src/parser.rs` tests.
 **Checklist**:
-- `dispatch_tag` currently recognises ~14 tag values across 9 `SptTagKind` payload kinds; the ~40-known-tags target (texture path, billboard descriptor, branch geometry, leaf cluster, wind params, LOD distances) is aspirational for Phase 1 — flag the gap as an open finding, not a stale claim
-- Any tag that appears in the corpus at ≥1% frequency MUST have either a parser or an explicit skip-with-rationale comment
-- Texture-path tags resolve through the same `resolve_texture` / sibling-BSA auto-load path that NIF uses — verify no parallel "spt resolver" duplicates the logic
-- Billboard tag captures: texture, world-space width/height, mip bias — these flow into the placeholder importer
-- "Last tag wins" vs "first tag wins" semantics for duplicate tags — confirm and document
+- Each `SptTagKind` decode advances the cursor by exactly the bytes it
+  claims: `U8`=1, `U32`=4, `Vec3`=12, `FixedBytes(n)`=n, `String`=4+len,
+  `ArrayBytes{stride}`=4+count×stride, `Bare`=0. Cross-check `read_payload`
+  against the dictionary in `tag.rs` for any size mismatch.
+- The `MaybeStringElseBare` branch (tag 13005, #999) consumes the tag,
+  then peeks the next u32 to decide Bare vs String. Confirm it re-syncs
+  cleanly on **both** arms and that a `None` peek (EOF) can't panic —
+  the `tag_13005_at_eof_does_not_panic` regression guard.
+- Walker stops cleanly at `is_eof()` (sets `reached_eof`) and at an
+  out-of-range / `Unknown` tag (records `tail_offset` + `unknown_tags`),
+  never reads one tag past EOF.
+- Pathological lengths: `read_string_lp` and `ArrayBytes` both cap at
+  64 KiB and bail with `Err`, not OOM. Confirm the cap is on the *byte
+  count* (count × stride), not just `count`.
+- `parse_spt` returns `Err` only on the two fatal conditions (missing
+  magic, mid-payload underflow). In-range-but-unknown tags are non-fatal
+  (recorded, walker stops) — this is the contract the placeholder relies
+  on. Any new fatal-error path is a HIGH finding (it kills the cell-loader
+  fallback).
+- Endian: LE-only, unconditional (no version-gated readers — every `.spt`
+  is `__IdvSpt_02_`). Flag any big-endian assumption or host-endian read.
 
-### Dimension 3: Corpus Acceptance (≥95% gate)
-**Entry points**: `crates/spt/tests/parse_real_spt.rs` (or equivalent), corpus location resolved via env-var (mirror the NIF `BYROREDUX_*_DATA` pattern)
+### Dimension 2: Placeholder Fallback Correctness
+**Entry points**: `crates/spt/src/import/mod.rs` (`import_spt_scene`,
+`compute_billboard_size`, `placeholder_billboard_mesh`,
+`placeholder_root_node`, `DEFAULT_BILLBOARD_WIDTH`/`_HEIGHT`),
+`byroredux/src/systems/billboard.rs`.
 **Checklist**:
-- Acceptance harness runs over FNV + FO3 + Oblivion `.spt` corpus and reports walker-clean rate
-- Threshold: ≥95% (Phase 1 gate). Under-95% = audit finding even if every per-file failure is graceful
-- Walker-clean ≠ semantically-correct — failures should be bucketed (truncation, unknown tag exceeding length, header mismatch, etc.) with corpus-wide histogram
-- Regression-guard sample: 3-5 specific `.spt` files pinned by SHA, in-tree, should parse byte-stable across runs
-- Memory: `parse_spt` currently takes a `&[u8]` (caller pre-loads the file). The "never materialise the whole file" bar is a forward-looking quality goal that the present `&[u8]` API cannot satisfy — flag as design debt, not a walker bug; verify the largest `joshua01.spt` corpus entry doesn't blow the cell-loader's transient memory budget when slurped whole
+- `import_spt_scene` **always** returns a one-node / one-mesh
+  `ImportedScene` — there is no `Err` path out of it. The only way the
+  cell loader gets `None` is `parse_spt` returning `Err` (magic /
+  underflow); confirm that path logs + skips the REFR without aborting
+  the rest of the cell (graceful-degradation contract).
+- Leaf-texture precedence: TREE.ICON override → `.spt` tag 4003 (first
+  wins, #997) → unset (renderer magenta placeholder). Regression guards:
+  `leaf_texture_override_wins_over_spt_tag`,
+  `empty_texture_leaves_path_unset_for_renderer_placeholder`.
+- Billboard sizing precedence in `compute_billboard_size`: **OBND →
+  BNAM → MODB → 256×512 default**, every path clamped to `[16, 8192]`
+  (#1001/#1002). OBND beats BNAM intentionally (BNAM clamps tall trees,
+  e.g. WhiteOak01 OBND 802×1567 vs BNAM 768×768). Vanilla Oblivion ships
+  MODB-only / no OBND, so an OBND-first-or-default path would render
+  Cyrodiil pines at half scale. Guard the ordering.
+- Normal / winding convention (#1000): front-face normal is `-Z`, indices
+  `[0, 3, 2, 2, 1, 0]`. The billboard system rotates via
+  `Quat::from_rotation_arc(-Z, look_dir)`, so object `-Z` ends up facing
+  the camera — the textured face must be `-Z`. Pre-#1000 normals were `+Z`
+  and `two_sided: true` masked it. Guards:
+  `placeholder_normals_point_negative_z_for_billboard_arc`,
+  `placeholder_index_winding_produces_negative_z_geometric_normal`.
+- `bs_bound` Z-up → Y-up swap (#995): center via
+  `byroredux_core::math::coord::zup_to_yup_pos`, half-extents reshuffled
+  `(hx, hz, hy)`. Guard: `placeholder_uses_obnd_bounds_when_present`.
+- Two-sided + alpha-test cutout: `two_sided: true`, `alpha_test: true`,
+  `alpha_threshold: 0.5`, `alpha_test_func: 6` (GREATEREQUAL),
+  `has_alpha: false` (cutout and blend are exclusive).
+- `BsRotateAboutUp` handling in `billboard.rs::compute_billboard_rotation`
+  currently falls back to the world-up yaw lock (it lacks the local frame).
+  Verify that approximation is still acceptable for tree imposters and
+  documented — drifting it silently into pitch would tilt every tree.
 
-### Dimension 4: Placeholder Fallback
-**Entry points**: `crates/spt/src/import/mod.rs` (`compute_billboard_size`, the `ImportedMesh` billboard build at ~281+ with the normal/winding convention documented at ~249-258), `byroredux/src/scene/nif_loader.rs`, billboard mesh creation in `crates/renderer/src/mesh.rs`
+### Dimension 3: TREE → Billboard Wiring
+**Entry points**: `byroredux/src/cell_loader/references.rs`
+(`is_spt` dispatch, `parse_and_import_spt`),
+`byroredux/src/cell_loader/spawn.rs` (`placement_root_billboard` →
+`Billboard::new`), `crates/plugin/src/esm/records/tree.rs` (`parse_tree`,
+`TreeRecord`, `has_speedtree_binary`).
 **Checklist**:
-- When the walker fails OR no billboard tag was captured, importer returns a placeholder card (Quad mesh + magenta-checker placeholder texture OR the texture from the billboard tag if available)
-- Placeholder return is non-null — must never `Err` out of the cell loader (graceful degradation is the Phase 1 contract)
-- Placeholder sizing precedence is **OBND → BNAM (#1002) → Oblivion MODB (#1001) → 256×512 default** (`DEFAULT_BILLBOARD_WIDTH` / `DEFAULT_BILLBOARD_HEIGHT`); guard the `compute_billboard_size` ordering — vanilla Oblivion TREEs ship MODB-only (OBND on none) so an OBND-first-or-default path renders junipers at half scale
-- **Billboard normal faces `-Z`, winding flipped to `[0, 3, 2, 2, 1, 0]`** (#1000): the entity rotates via `Quat::from_rotation_arc(-Z, look_dir)`, so the object-space `-Z` axis ends up pointing at the camera and the front face must be `-Z` to render toward it. Pre-#1000 normals pointed `+Z` and `two_sided: true` masked the inverted convention. Verify the Z-up→Y-up `bs_bound` swap (#995) is applied
-- Two-sided rendering enabled on the placeholder (foliage shouldn't disappear when camera looks from behind); leaf-card path uses alpha-test cutout (`alpha_test: true`, `alpha_threshold: 0.5`, `alpha_test_func: 6` GREATEREQUAL)
-- Material slot: placeholder goes through the same `MaterialTable::intern` path as NIF meshes — verify dedup applies (a forest of 1000 juniper bushes should produce 1 material, not 1000)
+- The `.spt` route fires when the REFR's TREE base's MODL ends in `.spt`;
+  TREE record is fetched from `record_index.trees` by the same form id
+  resolved against `index.statics`. Mixed `.nif` + `.spt` REFRs in one
+  cell must coexist.
+- `parse_and_import_spt` returns the **same** `CachedNifImport` shape as
+  every other model, with synthetic defaults the generic spawn path must
+  not mis-read as NIF-rooted:
+  `placement_root_billboard = Some(BsRotateAboutUp)` (#994),
+  `bsx_flags = 0` (#1214), `root_flags = 0` (#1235),
+  `flame_attach_offset = None`. Confirm the spawn site never assumes the
+  placeholder carries a real NiAVObject root / BSXFlags / flame marker.
+- `spawn.rs` actually inserts the `Billboard` component when
+  `placement_root_billboard.is_some()` — without it the quad spawns static
+  (this was SPT-D4-01, now closed; it's the regression guard for the whole
+  dimension).
+- `TreeRecord` field capture is lossless for the fields the importer reads
+  (OBND→`bounds`, ICON→`leaf_texture`, MODB→`bound_radius`,
+  BNAM→`billboard_size`). SNAM/CNAM are parsed-but-not-consumed (TD5-011) —
+  don't flag as a drop, but DO flag if they're silently *mis-parsed*
+  (e.g. CNAM length not shape-tolerant across the 5-float Oblivion vs
+  8-float FO3/FNV split).
+- `.spt` files in BSAs resolve through the same `extract_mesh` lookup chain
+  as `.nif` (sibling-BSA auto-load, AE pipeline-path strip if relevant) —
+  no parallel "spt resolver".
+- Cell unload despawns the placeholder entities cleanly; no leaked BLAS
+  entries for the billboard quad.
 
-### Dimension 5: Routing & CLI
-**Entry points**: `byroredux/src/cell_loader/references.rs` (`is_spt` extension dispatch ~478-490; `parse_and_import_spt` ~1080), `byroredux/src/scene/nif_loader.rs` (`--tree` flag), `crates/plugin/src/esm/records/tree.rs` (TREE parser)
+### Dimension 4: Per-Game Variants & Route Divergence
+**Entry points**: `crates/spt/src/version.rs` (`detect_variant`,
+`SpeedTreeVariant`, `MAGIC_HEAD`), `byroredux/src/scene/nif_loader.rs`
+(`parse_import_and_merge` `is_spt` branch).
 **Checklist**:
-- Cell-loader `.spt` route fires when the REFR's base record is TREE and the model path ends in `.spt`; mixed `.nif` + `.spt` in the same cell coexist
-- `.spt` references in BSA archives resolve through the same lookup chain as `.nif` (sibling-BSA auto-load, AE pipeline-path strip applied if relevant)
-- `--tree path/to/x.spt` CLI entry instantiates the same code path as the cell-loader route (no parallel "direct viz" stub that drifts from the in-engine path)
-- TREE record parser (Session 33 dedicated dispatch) captures texture / billboard / shadow data without dropping fields — pre-fix every `.spt`-referencing TREE silently lost its authoring
-- `parse_and_import_spt` returns the same `CachedNifImport` shape every other model uses, with synthetic defaults the generic spawn path must not mis-read as NIF-rooted: `placement_root_billboard = Some(BillboardMode::BsRotateAboutUp)` (#994), `bsx_flags = 0` (#1214), `root_flags = 0` (#1235), `flame_attach_offset = None` (Phase 18). Verify the spawn site reads these without assuming an `.spt` placeholder carries a real NiAVObject root / BSXFlags / flame marker
-- Cell unload despawns the SpeedTree entities cleanly; no leaked BLAS entries for placeholder billboards
-- Failed `.spt` import does NOT block the rest of the cell from loading (graceful degradation)
+- `detect_variant` recognises any `__IdvSpt_02_`-prefixed file but cannot
+  tell V4Oblivion from V5Fnv at the magic level — it defaults to `V5Fnv`
+  and the caller is meant to override via game context. Verify nothing
+  downstream actually *depends* on the variant being correct today (the
+  placeholder path is variant-agnostic); if a consumer branches on it,
+  that's a real bug. Guards: `detect_variant_recognises_idvspt_magic`,
+  `detect_variant_unknown_for_non_speedtree_inputs`.
+- `MAGIC_HEAD` is the exact 20 bytes (`u32 1000`, `u32 12`,
+  `"__IdvSpt_02_"`). A one-byte flip must reject → placeholder. Confirm no
+  partial-prefix leakage (input shorter than 20 bytes rejects).
+- **Route divergence** (the real per-game risk here): the cell-loader
+  route threads TREE metadata; the `--tree` / loose route uses
+  `SptImportParams::default()`. That means a loose-loaded Oblivion `.spt`
+  gets the 256×512 default (no MODB sizing) and no ICON override. Confirm
+  this is understood/documented and isn't masking a sizing bug that would
+  also bite the cell route. Flag if the two routes have drifted in the
+  *parse* call (they must both call `parse_spt` + `import_spt_scene`).
+- Oblivion (SpeedTree 4.x) vs FO3/FNV (5.x): the parameter walker is
+  assumed unified across all three (same magic, same tag dictionary). The
+  geometry-tail layout is **not** confirmed unified — but the tail is
+  out-of-scope for Phase 1, so only flag a tail-decode assumption if
+  `--focus` includes the future phases.
+
+### Dimension 5: Tag Dictionary
+Lower risk (fixed-size decodes), but a wrong size here is the Dimension-1
+desync trigger, so spot-check rather than skip.
+**Entry points**: `crates/spt/src/tag.rs` (`SptTagKind`, `dispatch_tag`),
+`crates/spt/docs/format-notes.md`, recon examples (`spt_tagmap`,
+`spt_transitions`).
+**Checklist**:
+- `dispatch_tag` currently maps ~90 tag values across the payload kinds.
+  This is conservative-by-design: any tag not in the table → `Unknown` →
+  walker stops cleanly. The old "~14 tags / 40-tag aspirational target"
+  framing is stale — do **not** report dictionary size as a gap.
+- Cross-check a sample of fixed-size assignments against the
+  `format-notes.md` 2026-05-09 table and the `tag.rs` unit tests
+  (`fixed_byte_payload_tags`, `string_payload_tags`, etc.): e.g. 8003/8005/8009
+  = 52 B, 13008 = 11 B, 13013 = 7 B, 12002 = 16 B, 12003 = 20 B,
+  ArrayBytes 10002 stride 1 / 10003 stride 8. A size that contradicts the
+  observed histogram is a Dimension-1 desync waiting to happen → MEDIUM.
+- Confounder tags (`4096`, `5376`, string-length values that fell in the
+  tag band) must stay `Unknown` so the walker bails rather than misparses
+  (`unknown_for_out_of_dictionary_tags`).
+- Any tag observed in the corpus at ≥1 % frequency that's still `Unknown`
+  should have a `format-notes.md` rationale; an undocumented common-tag
+  bail is a LOW finding.
 
 ### Dimension 6: NIFAL Material Translation for Placeholders
-**Entry points**: the `ImportedMesh` material defaults in `crates/spt/src/import/mod.rs` (~281+), the canonical boundary `byroredux/src/material_translate.rs::translate_material` consumed at `byroredux/src/cell_loader/spawn.rs:861`, `crates/core/src/ecs/components/material.rs::Material::resolve_pbr`
-**See also**: `/audit-nifal` (the dedicated NIFAL canonical-translation-tier audit) — spt is one of its `Imported* → translate() → Canonical` producers; cross-check single-boundary / no-fabrication findings there rather than duplicating them here.
+The placeholder `ImportedMesh` flows through the single NIFAL boundary like
+any other mesh. Cross-cuts `/audit-nifal` — report single-boundary /
+no-fabrication findings *there*, not here.
+**Entry points**: the material defaults in
+`crates/spt/src/import/mod.rs` (`placeholder_billboard_mesh`),
+`byroredux/src/material_translate.rs` (`translate_material`, consumed at
+the `spawn.rs` call site), `crates/core/src/ecs/components/material.rs`
+(`Material::resolve_pbr`).
 **Checklist**:
-- The spt placeholder `ImportedMesh` is canonicalised at the **single** NIFAL boundary (`translate_material` → `resolve_pbr`), not at render time — no parallel "spt material" path that bypasses `material_translate.rs`
-- Billboard material defaults survive translation intact: `is_pbr: false`, `metalness_override: None`, `roughness_override: None`, `from_bgsm: false` — `resolve_pbr` should fill `Material.metalness`/`roughness` (now plain resolved `f32`, not `Option`) from the non-PBR keyword path, NOT promote the billboard to metallic-roughness
-- `emissive_source: EmissiveSource::None` (#1280) holds through translation — a tree billboard must not pick up an emissive lobe
-- `#1241` (BSLightingShaderProperty PBR scalars surfaced at import) does not regress spt: SpeedTree never resolves a BGSM/BGEM, so the PBR-scalar fields stay at their non-PBR defaults — guard that a82366e9-style import-side PBR plumbing left the spt billboard non-PBR
-- Two-sided alpha-test cutout (Dimension 4) maps to the correct canonical `Material` flags after translation (foliage silhouette preserved, not opaque-blitted)
+- The placeholder is canonicalised at the **single** `translate_material`
+  boundary — no parallel "spt material" path that bypasses it (the `--tree`
+  loose route and the cell route must both land here via `spawn.rs`).
+- Non-PBR defaults survive translation: `is_pbr: false`,
+  `metalness_override: None`, `roughness_override: None`,
+  `from_bgsm: false` (#1076/#1077). `resolve_pbr` must fill the canonical
+  `metalness`/`roughness` f32 from the non-PBR keyword path, never promote
+  the billboard to metallic-roughness. SpeedTree never resolves a
+  BGSM/BGEM (#1241/#1353) — guard that import-side PBR plumbing
+  (a82366e9-style) left the billboard non-PBR.
+- `emissive_source: EmissiveSource::None` (#1280) holds — a tree billboard
+  must not pick up an emissive lobe.
+- The two-sided alpha-test cutout maps to the correct canonical `Material`
+  flags after translation (foliage silhouette preserved, not
+  opaque-blitted).
 
 ## Phase 3: Output
 
-Write findings to **`docs/audits/AUDIT_SPEEDTREE_<TODAY>.md`** following the base finding format. Suggest `/audit-publish` on completion.
+Write findings to **`docs/audits/AUDIT_SPEEDTREE_<TODAY>.md`** using the
+base finding format from `_audit-common.md`. Mark anything already covered
+by #994–#1002 as a regression guard, not a new finding. Suggest
+`/audit-publish` on completion.

--- a/.claude/commands/audit-starfield/SKILL.md
+++ b/.claude/commands/audit-starfield/SKILL.md
@@ -1,43 +1,64 @@
 ---
-description: "Per-game audit of Starfield compatibility — BA2 v2/v3 + LZ4 block, CRC32 flag arrays, no ESM"
+description: "Per-game audit of Starfield compatibility — BA2 v2/v3 + LZ4 block, CDB materials, BSGeometry .mesh resolution, walkable Cydonia interior"
 argument-hint: "--focus <dimensions>"
 ---
 
 # Starfield Compatibility Audit
 
-Deep audit of ByroRedux readiness for **Starfield** content.
+Depth/correctness audit of ByroRedux's **Starfield** support. Starfield is a
+first-class `GameKind`: NIF + BA2 v2/v3, CDB + BGSM/BGEM materials, and a
+**walkable Cydonia interior** all ship today. This is a regression-and-depth
+audit of that bring-up surface, **not** a from-scratch gap inventory.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, game data locations, methodology, deduplication rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, game data locations,
+methodology, deduplication rules, finding format, and the SF Material / SF Smoke
+entries. See `.claude/commands/_audit-severity.md` for the severity scale (the
+NIFAL rows gate the `translate_material` boundary at HIGH minimum).
 
 ## Game Context
 
-| Aspect            | State                                                                                       |
-|-------------------|---------------------------------------------------------------------------------------------|
-| NIF format        | BSVER ≥ 168 retail (Starfield adds further extensions on top of the BSVER ≥ 155 baseline)    |
-| BA2 format        | v2 ✓ / v3 ✓ (12-byte header extension with `compression_method` field — zlib or LZ4 block)  |
-| ESM parser        | **Live** — first-class `GameKind::Starfield` (HEDR 0.96 classifier); parses end-to-end       |
-| Mesh path         | `BSGeometry` (inline + external `.mesh` companion), not `BSTriShape`                          |
-| Materials         | CDB (`crates/sfmaterial`) + BGSM/BGEM (`crates/bgsm`) — both shipped, wired `--materials-ba2` |
-| Parse rate        | NIF aggregate 98.6% (Meshes01 97.21% / 31 058); BA2 extract 100%                            |
-| Cell loading      | **Walkable Cydonia interior** (Session 42: 93 547 entities + 91 698 static colliders)        |
-| Reference data    | `/mnt/data/SteamLibrary/steamapps/common/Starfield/Data/`                                   |
+Authoritative status lives in `ROADMAP.md` (Starfield compat-matrix row +
+parse-rate breakdown), `docs/feature-matrix.md` (Starfield-Specific section),
+and the two ESM specs `docs/engine/starfield-esm-roadmap.md` +
+`docs/engine/starfield-esm-phase0-baseline.md`. Do not duplicate counts here —
+read those at audit time. Snapshot of the shape, not the numbers:
 
-### Known Specifics
+| Aspect      | State (verify against ROADMAP) |
+|-------------|--------------------------------|
+| NIF format  | BSVER 155 (FO76 baseline) → Starfield retail extensions on top |
+| BA2 format  | v2 + v3; v3 adds a 12-byte header extension carrying `compression_method` (0 = zlib, 3 = LZ4 block) |
+| ESM parser  | **Live** — `GameKind::Starfield` via HEDR-0.96 classifier; existing dispatch captures Starfield content at ~99.9% record parity (per `starfield-esm-roadmap.md` plan revision) |
+| Mesh path   | `BSGeometry` (inline geom data **or** external `geometries\<X>.mesh` companion) — NOT `BSTriShape` |
+| Materials   | CDB (`crates/sfmaterial/`) for vanilla `materialsbeta.cdb` + external BGSM/BGEM (`crates/bgsm/`), both wired via `--materials-ba2` |
+| Cell        | **Walkable Cydonia interior** (#1289/#1291/#1292/#1294/#1295) |
+| Reference   | `/mnt/data/SteamLibrary/steamapps/common/Starfield/Data/` |
 
-- **CRC32-hashed shader flag arrays** (BSVER ≥ 132) — `BSLightingShaderProperty` / `BSEffectShaderProperty` store shader flags as arrays of CRC32 hashes of named flag strings instead of bit masks.
-- **SF2 array** (BSVER ≥ 152) — additional shader flag array.
-- **BSVER == 155 (FO76 baseline)** — adds `BSShaderType155` dispatch with distinct skin-tint / hair-tint layouts, `BSSPLuminanceParams`, `BSSPTranslucencyParams`, `BSTextureArray` lists.
-- **BGSM / BGEM material references** — when `Name` is a non-empty BGSM/BGEM path the NIF parser short-circuits and returns a material-reference stub; the real material lives in the external file. That external file is now parsed: `crates/bgsm/` reads BGSM/BGEM and `asset_provider::merge_bgsm_into_mesh` folds it into the `ImportedMesh`.
-- **CDB material database** — vanilla Starfield ships all material data inside a single `materials\materialsbeta.cdb` Component Database (in `Starfield - Materials.ba2`), parsed by the dedicated `crates/sfmaterial/` consumer and extracted via the `--materials-ba2` flag (`asset_provider.rs`).
-- **WetnessParams** — extended with `Unknown 1` (BSVER > 130) and `Unknown 2` (BSVER == 155).
-- **BSEffectShaderProperty** — adds Reflectance / Lighting / Emittance / Emit Gradient textures.
-- **BA2 v3 compression** — header has a 12-byte extension (vs. 8 for v2) with `compression_method`: 0 = zlib, 3 = LZ4 block. GNRL + DX10 both dispatch through `decompress_chunk()` that selects based on archive-level method.
+### Known Specifics (where to look, not what to assume)
+
+- **CRC32-hashed shader flag arrays** (BSVER ≥ `FO4_CRC_FLAGS` = 132) —
+  `BSLightingShaderProperty` / `BSEffectShaderProperty` store shader flags as
+  arrays of CRC32 hashes (`sf1_crcs` / `sf2_crcs`) instead of bit masks. Parsed in
+  `parse_skyrim_shader_base` in `crates/nif/src/blocks/shader.rs`. SF2 array
+  gated on BSVER ≥ `FO76_SF2_CRCS` = 152.
+- **BSVER == `FO76` (155) baseline** — `BSShaderType155` dispatch + the
+  luminance / translucency / texture-array tail; this is where #1510 lived.
+- **BGSM / BGEM material references** — `is_material_reference` (`shader.rs`)
+  short-circuits when `Name` is a non-empty `.bgsm`/`.bgem` path and returns a
+  material-reference stub; the real material is the external file, parsed by
+  `crates/bgsm/` and folded in by `merge_bgsm_into_mesh` (`asset_provider.rs`).
+- **CDB material database** — vanilla Starfield ships all material data inside a
+  single `materials\materialsbeta.cdb` Component Database (in
+  `Starfield - Materials.ba2`), consumed by `crates/sfmaterial/` and extracted
+  via `--materials-ba2`.
+- **BA2 v3 compression** — header has a 12-byte extension (vs 8 for v2). GNRL +
+  DX10 both dispatch through a unified decompress path selected by archive-level
+  `compression_method` (`Ba2Compression` in `crates/bsa/src/ba2.rs`).
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3`). Default: all 9.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `2,9`). Default: all 9.
 
 ## Phase 1: Setup
 
@@ -48,70 +69,213 @@ See `.claude/commands/_audit-common.md` for project layout, game data locations,
 
 ## Phase 2: Launch Dimension Agents (parallel)
 
-### Dimension 1: NIF BSVER 155–172+ Shader Blocks
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs` (BSLightingShaderProperty, BSEffectShaderProperty), `docs/legacy/nif.xml`
-**Checklist**: CRC32 flag-array parsing for BSVER ≥ 132 — array count + per-element u32 CRC. Mapping from CRC32 hash → flag semantics (do we have a table?). SF2 array for BSVER ≥ 152. BSShaderType155 dispatch — skin-tint vs hair-tint variant layouts differ from Skyrim's 8-variant enum. BSSPLuminanceParams layout. BSSPTranslucencyParams layout. BSTextureArray — variable-length texture list vs fixed BSShaderTextureSet. WetnessParams Unknown 1 (BSVER > 130) + Unknown 2 (BSVER == 155). Refraction power on BSEffectShaderProperty (FO76-style). BSEffectShaderProperty new textures: Reflectance, Lighting, Emittance, Emit Gradient.
-**Output**: `/tmp/audit/starfield/dim_1.md`
+Dimensions are ordered by Starfield-specific risk: the highest-risk seams
+(BA2 v3/LZ4 decompression, CDB material correctness, BSGeometry `.mesh`
+resolution, ESM resolve-rate) come first.
 
-### Dimension 2: BA2 v2 / v3 — LZ4 Block Decompression
+### Dimension 1: BA2 v2 / v3 — LZ4 Block Decompression
 **Subagent**: `general-purpose`
 **Entry points**: `crates/bsa/src/ba2.rs`
-**Checklist**: v2 header format (standard Starfield — 8-byte extension). v3 header format (12-byte extension with `compression_method` at the correct offset). Dispatch: compression_method == 0 → zlib, == 3 → LZ4 block, others → error. `lz4_flex::block::decompress` usage — does it need a specific `max_size` hint, and does BA2 supply it? GNRL + DX10 both go through the unified `decompress_chunk()`. DX10 chunk layout unchanged from FO4 v1 — the per-chunk-layout-difference diagnosis for v3 was wrong; the real issue was the 4-byte compression_method field offset. Parse-rate sweep across all v2 and v3 archives.
+**Checklist**: v2 header (8-byte extension) vs v3 header (12-byte extension with
+`compression_method` at the correct offset). Dispatch via the `Ba2Compression`
+enum: `0` → zlib, `3` → LZ4 block, others → error (confirm the unsupported-method
+branch is a hard error, not a silent fall-through). `lz4_flex` block decompress —
+does it need an explicit `max_size`, and does BA2 supply it from the chunk's
+uncompressed size? Per the module doc, v3 DX10 mips can **mix raw and
+LZ4-compressed chunks within one texture** — verify the per-chunk
+compressed/uncompressed-size comparison selects raw-vs-decompress correctly.
+GNRL + DX10 must both reach the unified decompress path. Regression guard:
+DX10 chunk layout is unchanged from FO4 v1 — the v3 issue was the
+`compression_method` offset, not a per-chunk-layout difference. Parse-rate sweep
+across all v2 and v3 archives (extract rate is 100% per the compat matrix —
+confirm it holds).
+**Output**: `/tmp/audit/starfield/dim_1.md`
+
+### Dimension 2: BSGeometry Mesh Extraction (Starfield's actual mesh path)
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/import/mesh/bs_geometry.rs` (geometry extraction),
+`crates/nif/src/blocks/bs_geometry.rs` (block parse), with
+`crates/nif/src/import/mesh/bs_tri_shape.rs` as the FO4/Skyrim contrast
+(Starfield does NOT use `BSTriShape`)
+**Checklist**: `extract_bs_geometry` — Stage A inline geometry
+(`has_internal_geom_data()`) vs Stage B external `.mesh` companion.
+**#1292** — external `.mesh` resolved via the canonical `geometries\<X>.mesh`
+path; the importer must NOT prepend `meshes\` (regression-guarded by
+`normalize_mesh_path` tests in `asset_provider.rs` — confirm
+`head == "geometries\\"` is left untouched). Without this the Cydonia spawn rate
+collapses. **#1209** — iterate every LOD slot, not `meshes.first()` (a `None`
+short-circuit when LOD 0 was external despite later internal slots).
+**#1203** — skin chain resolved via `BSSkin::Instance` + `BSSkin::BoneData`.
+**#1232** — empty/zero-length tangent blobs route through
+`synthesize_tangents_yup` (Mikkelsen); verify the fallback is reached and
+produces unit-length tangents. PBR scalars `metalness_override` /
+`roughness_override` are forwarded from the BGSM-resolved `legacy_pbr`. Watch for
+new vertex-attribute bits beyond FO4's set and Starfield's far-higher vertex
+counts.
 **Output**: `/tmp/audit/starfield/dim_2.md`
 
-### Dimension 3: BGSM Material Reference Flow
+### Dimension 3: CDB Material Database Correctness
 **Subagent**: `renderer-specialist`
-**Entry points**: `crates/nif/src/blocks/properties.rs` (stopcond), `crates/nif/src/import/material/` (mod, walker, shader_data)
-**Checklist**: Stopcond check — BSVER ≥ 155 && Name is non-empty BGSM/BGEM path → return material-reference stub + **do NOT read the Phong trailing fields** (they belong in the BGSM). Name path flows through `ImportedMesh.material_path` → `Material.material_path`. Validate on a Starfield mesh that references a BGSM: `mesh.info` debug command shows the material path and `tex.missing` lists it as expected-missing (correct behavior). The external BGSM/BGEM file is now parsed by `crates/bgsm/` and merged in `asset_provider::merge_bgsm_into_mesh` (`byroredux/src/asset_provider.rs`); confirm the BGEM variant (`crates/bgsm/src/bgem.rs`) is handled distinctly from BGSM (`bgsm.rs`) — different texture-set conventions, plus the BGEM `glass_enabled` flag. **Disney BSDF / PBR (#1248-#1252)** is the canonical lobe (adapted from GLSL-PathTracer MIT + Burley 2012, attribution block at top of `crates/renderer/shaders/triangle.frag`). For Starfield, BGSM/BGEM authoring flows through `cell_loader::pack_bgsm_material_flags` (`byroredux/src/cell_loader.rs`), which sets `material_flag::BGSM_PBR` / `BGSM_AUTHORED` from `ImportedMesh.is_pbr` / `from_bgsm`. The classification itself happens at the **single NIFAL boundary** — `material_translate::translate_material` (`byroredux/src/material_translate.rs`), never per-draw in the shader; `Material.metalness` / `Material.roughness` are plain resolved `f32` set there (see also `/audit-nifal`). **#1232 empty BSGeometry tangents** (`293db681`): Starfield meshes with absent / zero-length tangent blobs now route through `synthesize_tangents_yup` (Mikkelsen) at `crates/nif/src/import/mesh/bs_geometry.rs:139` — verify the fallback is reached and produces unit-length tangents.
+**Entry points**: `crates/sfmaterial/src/reader.rs` (`ComponentDatabaseFile::parse`,
+`index_chunks`), `crates/sfmaterial/src/chunk.rs`, `string_table.rs`, `types.rs`,
+`value.rs`, `byroredux/src/asset_provider.rs` (`--materials-ba2` wiring)
+**Checklist**: `ComponentDatabaseFile::parse` consumes `materials\materialsbeta.cdb`
+extracted from `Starfield - Materials.ba2` via `--materials-ba2`. **#762** —
+guard `index_chunks` against the chunk-index regression already referenced in
+`asset_provider.rs`. Walk the parse path: header (`parse_header`) → chunk index
+(`index_chunks`) → class parse (`parse_class`). Are unknown `ChunkType` /
+`Value` variants handled (warn-and-skip) or do they bail/panic? Confirm
+`peek_magic` correctly distinguishes a CDB from a loose BGSM. Correctness, not
+just "it parses": does the per-`.mat` material resolution forward roughness /
+metalness / texture-slot values into the `ImportedMesh`, or do `.mat`-resolved
+materials currently reach the Disney lobe with NIF defaults? (Per the ROADMAP
+forward-blocker chain, per-field CDB extraction is the #1289 Phase 2 follow-up —
+confirm current state and scope the gap, don't re-report it as new.) Count
+unique CDB material handles vs loose BGSM/BGEM references in a Starfield archive
+to confirm CDB supersedes loose-file BGSM for vanilla content.
 **Output**: `/tmp/audit/starfield/dim_3.md`
 
-### Dimension 4: BSGeometry Mesh Extraction (Starfield's actual mesh path)
-**Subagent**: `legacy-specialist`
-**Entry points**: `crates/nif/src/import/mesh/bs_geometry.rs` (geometry extraction), `crates/nif/src/blocks/bs_geometry.rs` (block parse), with `crates/nif/src/import/mesh/bs_tri_shape.rs` as the FO4/Skyrim contrast (Starfield does NOT use `BSTriShape`)
-**Checklist**: `BSGeometry` is the Starfield geometry path — Stage A inline geometry (`has_internal_geom_data()`) vs Stage B external `.mesh` companion. **#1292** — external `.mesh` resolved via the canonical `geometries\<X>.mesh` path (`bs_geometry.rs:58`); without this the spawn rate collapses (Cydonia 75 → 93 547 entities). **#1209** — iterate every LOD slot, not `meshes.first()` (a `None` short-circuit when LOD 0 was `External` despite later `Internal` slots). **#1203** — skin chain resolved via `BSSkin::Instance` + `BSSkin::BoneData` (`bs_geometry.rs:171`). **#1232** — empty-tangent fallback to `synthesize_tangents_yup` (also pinned in Dim 3). PBR scalars: `metalness_override` / `roughness_override` are forwarded from the BGSM-resolved `legacy_pbr` at `bs_geometry.rs:254-255`. Watch for new VF_* / vertex-attribute bits beyond FO4's set. Vertex count limits (Starfield meshes are far higher-detail than FO4).
+### Dimension 4: Starfield ESM Resolve-Rate Baseline
+**Subagent**: `general-purpose`
+**Entry points**: `byroredux/src/sf_smoke.rs` (`--sf-smoke <CELL_EDID>` resolve-rate
+harness), `crates/plugin/examples/sf_smoke.rs` + `crates/plugin/examples/sf_parse_check.rs`
+(top-level GRUP byte-coverage tools), `docs/engine/starfield-esm-phase0-baseline.md`
+**Checklist**: The two tools answer different questions — keep them straight.
+`crates/plugin/examples/sf_smoke.rs` measures **byte/FourCC coverage** of the
+top-level GRUP walk vs `DISPATCH_HANDLED_FOURCCS`; `byroredux/src/sf_smoke.rs`
+(`--sf-smoke`) measures the **per-cell base-form resolve rate** (of N REFRs in a
+named interior cell, how many point at a base form actually decoded into
+`EsmCellIndex.statics`). Run `--sf-smoke` against Cydonia and confirm the resolve
+rate has not regressed below the Phase 0/1 baseline. A drop = the CELL handler
+silently dropped REFRs (moved subrecord size, new XCLL field) or a base record
+(STAT/MSTT/FURN/LIGH) failed to index — REFRs then spawn the 3D-unit-cube
+placeholder. Cross-check the per-record-type breakdown for new Starfield-only
+base types (GBFM/GBFT/PNDT/STDT/BIOM) showing up where a real parser is missing;
+note frequency, don't re-report the known GBFM stub gap.
 **Output**: `/tmp/audit/starfield/dim_4.md`
 
-### Dimension 5: Real-Data Validation
+### Dimension 5: ESM + Cell Bring-up Regression Surface
 **Subagent**: `general-purpose`
-**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
-**Checklist**: Parse rate holds at the compat-matrix figure (Meshes01 97.21% / 31 058; aggregate 98.6% — see `docs/engine/game-compatibility.md`) via `BYROREDUX_*_DATA=... cargo test -p byroredux-nif --test parse_real_nifs parse_rate_starfield_all_meshes -- --ignored` (walks all 5 vanilla mesh archives; `parse_rate_starfield` covers Meshes01 only). The residual truncation tail in Meshes01/MeshesPatch is tracked at #746/#747 — confirm it has not grown. Verify Starfield texture archives matching `Starfield - *Textures*.ba2` (30 as of 2026-05-21 post-Shattered-Space, was 22 in Session 7 — per #1185) extract cleanly (session 7 validated ~128K DX10 textures + 0 failures — make sure that still holds). Pick 5 representative meshes: a clutter item, a ship hull, a character body, a weapon, a landscape feature. Trace each through `import_nif_scene` (`crates/nif/src/import/mod.rs:116`). Watch for `NiUnknown` placeholders in the block histogram — these would indicate new block types introduced since N23.9.
+**Entry points**: `crates/plugin/src/esm/reader.rs` (`GameKind::Starfield` HEDR-0.96
+classifier), `crates/plugin/src/esm/records/mod.rs` (FourCC dispatch),
+`crates/plugin/src/esm/cell/walkers.rs` (XCLL + per-cell NAVM),
+`byroredux/src/cell_loader/spawn.rs` (REFR placement)
+**Checklist**: HEDR-0.96 → `GameKind::Starfield` classification (`reader.rs`).
+FourCC dispatch coverage in `records/mod.rs` — which record types are parsed vs
+warned-skip; cross-check against the resolve-rate baseline from Dim 4.
+**#1291** — `XCLL_SIZES_STARFIELD = [28, 108]` (`walkers.rs`), split off the
+Fallout-era `[28, 40]` bucket. **Important correction to any stale doc**: the
+108-byte Starfield XCLL is **NOT** "Skyrim's 92-byte body + a 16-byte tail" — per
+the `walkers.rs` doc comment it shares only bytes 0-39 with Skyrim and is decoded
+in full against xEdit SF1 `wbStruct(XCLL,'Lighting')` (the old #1293
+"16-byte-tail follow-up" framing is resolved). Per-cell NAVM collection
+(`walkers.rs`, #1272). Spawn-path regression guards in `cell_loader/spawn.rs`:
+**#1294** static-trimesh fallback gated on `base_layer` not `final_layer`
+(synthesized collider count was 0 before the fix); **#1235** `SceneFlags::from_nif`
+(`crates/core/src/ecs/components/scene_flags.rs`) attached at spawn;
+**#1295** `DoorTeleport` stamped from REFR XTEL; **#1212/#1213/#1214**
+`FormIdComponent` / `LocalBound` / `BSXFlags` at spawn; **#1284** `SkinSlotPool`
+ceiling raise (`crates/core/src/ecs/resources.rs`) for Cydonia's skinned density.
+Also confirm synthesized colliders carry `IsCollisionOnly` (`components.rs`) so
+they stay out of the BLAS (R6a-stale-13/14 collider-cost fix, see ROADMAP).
 **Output**: `/tmp/audit/starfield/dim_5.md`
 
-### Dimension 6: ESM Phase Roadmap & Forward Blockers
-**Subagent**: `general-purpose`
-**Entry points**: `ROADMAP.md`, `docs/engine/starfield-esm-roadmap.md`, `docs/engine/starfield-esm-phase0-baseline.md`
-**Checklist**: The ESM parser is **live** (not a forward blocker) — Starfield is a first-class `GameKind` and Cydonia is walkable. Re-scope this dimension to the remaining phase work, not a from-scratch gap inventory. Read `starfield-esm-roadmap.md` and confirm the phase ordering matches shipped state (Session 42 collapsed the original 7–11-session estimate to 3–4 sessions). Open follow-ups to scope: #1293 (16-byte SF XCLL tail decode), #746/#747 (NIF truncation tail). (The #1290 forward-blocker re-ordering is DONE — the chain below + `starfield-esm-roadmap.md` already reflect #762 + #1289 shipped.) Space-cell / planet / system records that have no FO4 analogue — which are parsed vs stubbed in `crates/plugin/src/esm/records/mod.rs`? Is Starfield's physics-based ship assembly (MSWP / module records) realistic to render via the form-linker? What is the lowest-effort next visible-progress milestone now that Cydonia renders (e.g., a vanilla exterior worldspace tile)?
+### Dimension 6: NIF Shader Blocks — BSVER 155+ (regression guard)
+**Subagent**: `legacy-specialist`
+**Entry points**: `crates/nif/src/blocks/shader.rs` (`parse_skyrim_shader_base`,
+`BSLightingShaderProperty`, `BSEffectShaderProperty`), `docs/legacy/nif.xml`
+**Checklist**: CRC32 flag-array parsing for BSVER ≥ `FO4_CRC_FLAGS` (132) —
+`num_sf1` + per-element u32 CRC into `sf1_crcs`; SF2 array for BSVER ≥
+`FO76_SF2_CRCS` (152) into `sf2_crcs`. Is there a CRC32 hash → flag-name table,
+or are the hashes opaque? **#1510 regression guard** — `BSShaderType155` dispatch
++ the luminance / translucency / texture-array tail in `shader.rs` previously
+over-read by 4 B, truncating all ~1036 Starfield full-body
+`BSLightingShaderProperty` blocks to `NiUnknown`; confirm the block-histogram
+NiUnknown count for these stays at 0. WetnessParams extended fields, refraction
+power on `BSEffectShaderProperty` (FO76-style), and the new BSEffectShaderProperty
+textures (Reflectance / Lighting / Emittance / Emit Gradient) — verify byte
+consumption against nif.xml.
 **Output**: `/tmp/audit/starfield/dim_6.md`
 
-### Dimension 7: Starfield ESM + Cell Bring-up
+### Dimension 7: Real-Data Validation
 **Subagent**: `general-purpose`
-**Entry points**: `crates/plugin/src/esm/reader.rs` (`GameKind::Starfield` HEDR-0.96 classifier), `crates/plugin/src/esm/records/mod.rs` (FourCC dispatch), `crates/plugin/src/esm/cell/walkers.rs` (XCLL + per-cell NAVM), `byroredux/src/cell_loader/spawn.rs` (REFR placement)
-**Checklist**: HEDR-0.96 → `GameKind::Starfield` classification (`reader.rs:140`). FourCC dispatch coverage in `records/mod.rs` — which record types are parsed vs unrecognised; cross-check against the `sf_smoke` / `sf_parse_check` baseline (`crates/plugin/examples/sf_smoke.rs`, `sf_parse_check.rs`). **#1291** — `XCLL_SIZES_STARFIELD = [28, 108]` (`walkers.rs:30`), split off the FNV-era `[28, 40]` bucket; the 108-byte body is Skyrim's 92-byte layout plus a 16-byte tail (#1293 decode follow-up). Per-cell NAVM collection (`walkers.rs:621`, #1272). Walkable-Cydonia spawn regressions in `cell_loader/spawn.rs`: **#1294** static-trimesh fallback gated on `base_layer` not `final_layer` (synthesized collider count 0 → 91 698); **#1235** `SceneFlags::from_nif` (`crates/core/src/ecs/components/scene_flags.rs:57`) attached at spawn; **#1212/#1213/#1214** `FormIdComponent` / `LocalBound` / `BSXFlags` at spawn; **#1284** `SkinSlotPool` ceiling raise (`crates/core/src/ecs/resources.rs:650`) + `WorldBound::ZERO` seed for Cydonia's skinned density.
+**Entry points**: `crates/nif/examples/nif_stats.rs`, `crates/nif/tests/parse_real_nifs.rs`
+**Checklist**: Parse rate holds at the compat-matrix figure (see ROADMAP
+Starfield row + `docs/engine/game-compatibility.md`) via
+`BYROREDUX_*_DATA=... cargo test -p byroredux-nif --test parse_real_nifs parse_rate_starfield_all_meshes -- --ignored`
+(walks all 5 vanilla mesh archives; `parse_rate_starfield` covers Meshes01 only).
+The residual truncation tail in Meshes01/MeshesPatch is tracked at #746/#747 —
+confirm it has not grown. Verify Starfield texture archives matching
+`Starfield - *Textures*.ba2` extract cleanly (compat matrix records 100% extract
+recover, post-#754). Pick 5 representative meshes — a clutter item, a ship hull,
+a character body, a weapon, a landscape feature — and trace each through
+`import_nif_scene` (`crates/nif/src/import/mod.rs`). Watch for `NiUnknown`
+placeholders in the block histogram — these flag new block types introduced since
+the FO76/Starfield baseline.
 **Output**: `/tmp/audit/starfield/dim_7.md`
 
 ### Dimension 8: NIFAL Canonical Material Translation for Starfield
 **Subagent**: `renderer-specialist`
-**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` — the single boundary), `crates/core/src/ecs/components/material.rs` (`Material::resolve_pbr`)
-**Checklist**: `translate_material` (`material_translate.rs:65`) is the **single** raw `ImportedMesh` → ECS `Material` boundary — per-game / per-material classification happens here, never per-draw in the shader (see also `/audit-nifal`). Verify BSGeometry/BGSM/CDB-resolved Starfield meshes land with `Material.metalness` / `Material.roughness` as **plain resolved `f32`** (`material.rs:216,222`), set once — no `Option<f32>` / per-draw `classify_pbr` plumbing (that pattern was removed by the NIFAL refactor). Confirm `Material::resolve_pbr` and the `EmissiveSource` discriminator (#1280, `crates/core/src/ecs/components/material::EmissiveSource`, tagged in `crates/nif/src/import/material/walker.rs`) behave for SF content. NIFAL particle slice reaching SF NIFs: typed `NiPSysEmitter` / `NiPSysEmitterCtlr` (`crates/nif/src/blocks/particle.rs`) → `extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs:670,713`) → `systems::particle::apply_emitter_params` (`byroredux/src/systems/particle.rs:29`). NIFAL collision slice (relevant to Cydonia's 91 698 colliders): `BhkMultiSphereShape` + `BhkConvexListShape` translate to `CollisionShape` in `crates/nif/src/import/collision.rs:301,397`.
+**Entry points**: `byroredux/src/material_translate.rs` (`translate_material` — the
+single boundary), `crates/core/src/ecs/components/material.rs`
+(`Material::resolve_pbr`)
+**Checklist**: `translate_material` is the **single** raw `ImportedMesh` → ECS
+`Material` boundary — per-game / per-material classification happens here, never
+per-draw in the shader (see also `/audit-nifal`). Verify BSGeometry/BGSM/CDB-
+resolved Starfield meshes land with `Material.metalness` / `Material.roughness` as
+**plain resolved `f32`** (`material.rs`), set once — no `Option<f32>` per-draw
+`classify_pbr` plumbing (removed by the NIFAL refactor; `resolve_pbr` is the
+resolve-once fill). Confirm `Material::resolve_pbr` and the `EmissiveSource`
+discriminator (#1280, tagged in `crates/nif/src/import/material/walker.rs`) behave
+for SF content. NIFAL particle slice reaching SF NIFs: typed `NiPSysEmitter` /
+`NiPSysEmitterCtlr` (`crates/nif/src/blocks/particle.rs`) →
+`extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs`)
+→ `apply_emitter_params` (`byroredux/src/systems/particle.rs`). NIFAL collision
+slice (Cydonia's synthesized + bhk colliders): `BhkMultiSphereShape` +
+`BhkConvexListShape` translate to `CollisionShape` in
+`crates/nif/src/import/collision.rs`.
 **Output**: `/tmp/audit/starfield/dim_8.md`
 
-### Dimension 9: Starfield CDB + BGSM Material Database
+### Dimension 9: BGSM/BGEM External Material Flow
 **Subagent**: `renderer-specialist`
-**Entry points**: `crates/sfmaterial/src/reader.rs` (`materialsbeta.cdb` reader, #762), `crates/bgsm/src/` (external BGSM/BGEM parser), `byroredux/src/asset_provider.rs` (`--materials-ba2` wiring)
-**Checklist**: Replaces the old "BGSM out of scope" assumption — both material paths have shipped. CDB: `ComponentDatabaseFile::parse` (`reader.rs:29`) consumes `materials\materialsbeta.cdb`, extracted from `Starfield - Materials.ba2` via `--materials-ba2` (`asset_provider.rs:492,507`). BGSM/BGEM: `crates/bgsm/src/bgsm.rs` + `bgem.rs` parsed, then `asset_provider::merge_bgsm_into_mesh` (`asset_provider.rs:922`) folds the result into `ImportedMesh`; `cell_loader::pack_bgsm_material_flags` (`byroredux/src/cell_loader.rs:177`) packs `material_flag::{BGSM_AUTHORED, BGSM_PBR, BGSM_TRANSLUCENCY, BGSM_MODEL_SPACE_NORMALS}` (#1147 / #1077 / #1076). BGEM `glass_enabled` (`bgem.rs:34`) as the authoritative glass signal (#1280, consumed in `byroredux/src/helpers.rs:202`). Count unique CDB material handles vs BGSM/BGEM file references in a Starfield archive — confirm the CDB path supersedes loose-file BGSM for vanilla content.
+**Entry points**: `crates/bgsm/src/bgsm.rs` + `crates/bgsm/src/bgem.rs` (external
+parser), `byroredux/src/asset_provider.rs` (`merge_bgsm_into_mesh`),
+`byroredux/src/cell_loader.rs` (`pack_bgsm_material_flags`)
+**Checklist**: The material-reference stub from `shader.rs` resolves to the
+external file — confirm the BGEM variant (`bgem.rs`) is handled distinctly from
+BGSM (`bgsm.rs`): different texture-set conventions plus the BGEM `glass_enabled`
+flag. `merge_bgsm_into_mesh` folds the parsed result into `ImportedMesh`;
+`pack_bgsm_material_flags` packs `byroredux_renderer::vulkan::material::material_flag::{BGSM_AUTHORED, PBR_BSDF, TRANSLUCENCY, MODEL_SPACE_NORMALS, EFFECT_PALETTE_COLOR}`
+(#1147 / #1077 / #1076 / #1280) — verify each flag derives from the right
+`ImportedMesh` field. BGEM `glass_enabled` (`bgem.rs`) is the authoritative glass
+signal (#1280), consumed in `byroredux/src/helpers.rs` (and must NOT misclassify an
+opaque architecture piece carrying a stuck flag — there's a regression test for
+that). **Disney BSDF / PBR (#1248-#1252)** is the canonical lobe (GLSL-PathTracer
+MIT + Burley 2012, attribution at top of `crates/renderer/shaders/triangle.frag`);
+the classification feeding it happens at the single `translate_material` boundary
+(Dim 8), not per-draw.
 **Output**: `/tmp/audit/starfield/dim_9.md`
-
-**Pin — #762 / sfmaterial CDB chunk index**: guard `crates/sfmaterial/src/reader.rs::index_chunks` (`reader.rs:142`) against the chunk-index regression already referenced at `byroredux/src/asset_provider.rs:2461`.
 
 ## Phase 3: Merge
 
 1. Read all `/tmp/audit/starfield/dim_*.md` files.
 2. Combine into `docs/audits/AUDIT_STARFIELD_<TODAY>.md` with structure:
-   - **Executive Summary** — Current state: Starfield is a first-class `GameKind` with NIF + BA2 at the compat-matrix rate (98.6% aggregate), CDB + BGSM/BGEM materials shipped, and a **walkable Cydonia interior** (Session 42). This is a depth/correctness audit, not a gap inventory — focus on regressions in the bring-up surface (spawn, NIFAL translation, CDB chunk index) and the remaining ESM phase work.
+   - **Executive Summary** — Current state: Starfield is a first-class `GameKind`
+     with NIF + BA2 at the compat-matrix rate, CDB + BGSM/BGEM materials, and a
+     walkable Cydonia interior. This is a depth/correctness audit — focus on
+     regressions in the bring-up surface (BA2 v3 decompress, CDB chunk index,
+     BSGeometry `.mesh` resolution, spawn gates, NIFAL translation) and the
+     remaining ESM phase work.
    - **Dimension Findings** — Grouped by severity per dimension.
-   - **CRC32 Flag Table** — Known/unknown flag-name → CRC32 mappings for the shader flag arrays (anything we can derive empirically from observed hashes).
-   - **Forward Blocker Chain** (re-ordered per #1290, closed 2026-05-29 — both the CDB parser #762 AND the consumer wiring #1289 Phase 1 have shipped) — Remaining work for full Starfield coverage, in order: per-field CDB extraction (#1289 Phase 2 follow-up — `.mat`-resolved materials currently reach the Disney lobe with NIF defaults), exterior worldspace tiles, space-cell / planet records, #1293 16-byte XCLL tail decode, and the #746/#747 NIF truncation tail — NOT the "BGSM parser first / ESM very far" chain (both have shipped).
+   - **CRC32 Flag Table** — Known/unknown flag-name → CRC32 mappings for the
+     shader flag arrays (anything derivable empirically from observed hashes).
+   - **Remaining-Work Chain** (per `starfield-esm-roadmap.md` — Phases 0+1 done,
+     2-4 invalidated by the 99.9%-parity measurement) — in order: per-field CDB
+     extraction (#1289 Phase 2 follow-up — `.mat`-resolved materials currently
+     reach the Disney lobe with NIF defaults), exterior worldspace tiles,
+     space-cell / planet / GBFM records, and the #746/#747 NIF truncation tail.
+     Do NOT frame this as a "BGSM parser first / ESM very far" chain — both have
+     shipped.
 3. Remove cross-dimension duplicates.
 
 Suggest: `/audit-publish docs/audits/AUDIT_STARFIELD_<TODAY>.md`

--- a/.claude/commands/audit-suite/SKILL.md
+++ b/.claude/commands/audit-suite/SKILL.md
@@ -5,10 +5,53 @@ argument-hint: "--preset <name>"
 
 # Audit Suite Orchestrator
 
-## Presets
+Runs a **named preset** — a curated list of other `/audit-*` skills — by fanning
+them out as background agents in parallel, then merges their reports into one
+summary. This skill owns no audit logic of its own; it only sequences and
+aggregates the individual audits. Shared protocol (project layout, severity,
+dedup, report format) lives in `.claude/commands/_audit-common.md` and
+`.claude/commands/_audit-severity.md` — not repeated here.
+
+Every audit referenced below is a live skill under
+`.claude/commands/audit-<name>/SKILL.md`, invoked as `/audit-<name>`.
+The full current set (21): audio, concurrency, ecs, fnv, fo3, fo4, incremental,
+legacy-compat, nif, nifal, oblivion, performance, publish, regression, renderer,
+runtime, safety, skyrim, speedtree, starfield, tech-debt. (`/audit-publish` is a
+post-processing step, not an analysis pass — it never appears in a preset.)
+
+**`--focus` numbers below track the dimension numbering inside each target skill.
+If a target audit is renumbered, update the focus lists here in lockstep** — the
+suite is the one place those numbers are duplicated, so it drifts first.
+
+## Preset Index
+
+| Preset | When | Audits |
+|--------|------|--------|
+| `quick` | after any change, < 10 min | incremental |
+| `pre-release` | before tagging | safety · renderer · ecs · regression |
+| `comprehensive` | monthly / pre-milestone | all subsystem + per-game + runtime |
+| `tech-debt-deep` | after a milestone closes | tech-debt · incremental |
+| `per-game-all` | per-game compat sweep | the 6 game audits |
+| `nif-all-games` | NIF parser vs every game | nif ×6 game corpora |
+| `runtime-regression` | telemetry diff vs baselines | runtime |
+| `nif-deep` | after NIF parser changes | nif · nifal · safety · incremental |
+| `nifal-deep` | after NIFAL translation changes | nifal · nif · renderer · ecs |
+| `renderer-deep` | after renderer changes | renderer · performance · concurrency · safety |
+| `rt-deep` | after RT / denoiser / G-buffer changes | renderer · performance · concurrency |
+| `material-deep` | after material-table / PBR changes | renderer · safety |
+| `water-deep` | after water-rendering changes | renderer · concurrency · safety |
+| `volumetrics-deep` | after volumetric-lighting changes | renderer · performance · safety |
+| `bloom-deep` | after bloom-pyramid changes | renderer · performance · safety |
+| `skin-deep` | after GPU-skinning / BLAS-refit changes | renderer · performance · concurrency · safety |
+| `audio-deep` | after audio (kira) changes | audio · concurrency · safety |
+| `speedtree-deep` | after SpeedTree (.spt) changes | speedtree · incremental |
+| `streaming-deep` | after world-streaming / NPC-spawn changes | performance · concurrency · safety |
+| `legacy-deep` | after compatibility-mapping work | legacy-compat · incremental |
+
+## Broad Presets
 
 ### `--preset quick`
-Fast sanity check after changes (< 10 min):
+Fast sanity check after a change (< 10 min):
 1. `/audit-incremental --commits 5`
 
 ### `--preset pre-release`
@@ -18,146 +61,40 @@ Run before tagging a release:
 3. `/audit-ecs`
 4. `/audit-regression --limit 20`
 
-### `--preset nif-deep`
-After NIF parser changes (N23 work):
-1. `/audit-nif --game fnv`
-2. `/audit-safety`
-3. `/audit-incremental --commits 10`
-
-### `--preset renderer-deep`
-After significant renderer changes:
-1. `/audit-renderer`              # all 21 dimensions (post-Session-34: dims 17 water, 18 volumetrics, 19 bloom, 20 soft shadows; dim 21 Disney BSDF / PBR Gating, #1248-#1252)
-2. `/audit-performance --focus 1,2,3,7,8`
-3. `/audit-concurrency --focus 2,3,5`
-4. `/audit-safety`
-
-### `--preset water-deep`
-After M38 water-rendering changes (incl. #1210 water-side caustics, now closed):
-1. `/audit-renderer --focus 8,9,10,13,17`   # TLAS + rays + composite + caustic splat (dim 13) + water dim (dim 17)
-2. `/audit-concurrency --focus 2,3`
+### `--preset comprehensive`
+Full coverage (longest — run monthly or before a major milestone). Every
+subsystem audit, every per-game audit, plus the runtime telemetry diff that
+catches what static audits structurally can't see:
+1. `/audit-renderer`
+2. `/audit-ecs`
 3. `/audit-safety`
-
-### `--preset volumetrics-deep`
-After M55 volumetric-lighting changes:
-1. `/audit-renderer --focus 1,2,9,10,18`    # sync + memory + RT + composite + volumetrics dim
-2. `/audit-performance --focus 1,2`
-3. `/audit-safety`
-
-### `--preset bloom-deep`
-After M58 bloom-pyramid changes:
-1. `/audit-renderer --focus 1,10,19`        # sync + composite + bloom dim
-2. `/audit-performance --focus 1,2`
-3. `/audit-safety`
-
-### `--preset speedtree-deep`
-After SpeedTree (.spt) Phase 1+ changes:
-1. `/audit-speedtree`
-2. `/audit-incremental --commits 10`
-
-### `--preset rt-deep`
-After ray tracing / denoiser / G-buffer changes:
-1. `/audit-renderer --focus 8,9,10`
-2. `/audit-performance --focus 1,2`
-3. `/audit-concurrency --focus 2,3,5`
-
-### `--preset taa-deep`
-After TAA / denoiser / motion-vector changes (M37.5):
-1. `/audit-renderer --focus 10,11`
-2. `/audit-concurrency --focus 2,5`
-3. `/audit-safety` (focus on §3 memory, §7 new compute, §6 RT)
-
-### `--preset skin-deep`
-After GPU skinning / BLAS refit changes (M29.5 / M29.3):
-1. `/audit-renderer --focus 8,12`
-2. `/audit-performance --focus 1,7`
-3. `/audit-concurrency --focus 2,3,5`
-4. `/audit-safety`
-
-### `--preset material-deep`
-After R1 material table changes (GpuMaterial layout, dedup, SSBO):
-1. `/audit-renderer --focus 6,14`
-2. `/audit-performance --focus 8`
-3. `/audit-safety` (focus on §8 R1 invariants)
-
-### `--preset nifal-deep`
-After NIFAL canonical-translation changes — the single `ImportedMesh` → `Material`
-boundary (`byroredux/src/material_translate.rs::translate_material`), `Material::resolve_pbr`
-(`crates/core/src/ecs/components/material.rs`, metalness/roughness now plain `f32`), typed
-particle emitter blocks (`NiPSysEmitter`/`NiPSysEmitterCtlr`/`NiPSysEmitterCtlrData`/
-`NiPSysGrowFadeModifier` → `extract_emitter_params`/`extract_emitter_rate` →
-`systems::particle::apply_emitter_params`), and the new collision shapes
-(`BhkMultiSphereShape` + `BhkConvexListShape` in `crates/nif/src/import/collision.rs`).
-Spec: `docs/engine/nifal.md`. See also `/audit-nifal` — the dedicated NIFAL audit owns the
-full canonical-translation tier; this preset is the cross-cutting regression sweep.
-1. `/audit-nifal`
-2. `/audit-nif --focus 7`           # NIF-parser-side translation boundary (Dimension 7: NIFAL Canonical Translation)
-3. `/audit-renderer --focus 6,14,21` # shader correctness + material table + Disney BSDF / PBR gating
-4. `/audit-ecs`                      # particle emitter components / apply_emitter_params system
-
-### `--preset pbr-deep`
-After Disney BSDF / PBR-gating changes (audit-renderer Dimension 21, #1248-#1252):
-1. `/audit-renderer --focus 9,10,21` # RT ray queries + composite + Disney BSDF / PBR gating
-2. `/audit-safety`
-
-### `--preset sky-weather-deep`
-After M33 / M33.1 / M34 sky / weather / exterior lighting changes:
-1. `/audit-renderer --focus 9,15`
-2. `/audit-incremental --commits 10`
-
-### `--preset streaming-deep`
-After M40 world streaming / M41 NPC spawn changes:
-1. `/audit-performance --focus 9`
-2. `/audit-concurrency --focus 6`
-3. `/audit-safety`
-
-### `--preset audio-deep`
-After M44 audio (kira backend) changes — emitter/listener pose sync, spatial sub-track lifecycle, reverb send, streaming music:
-1. `/audit-audio`
-2. `/audit-concurrency --focus 4,6`
-3. `/audit-safety`
-
-### `--preset normals-deep`
-After M-NORMALS / tangent-space changes (Sessions 26–29):
-1. `/audit-renderer --focus 6,16`
-2. `/audit-nif --focus 1,4`
-3. `/audit-safety`
-
-### `--preset glass-deep`
-After IOR refraction / glass-passthrough / Frisvad changes (Sessions 27–29):
-1. `/audit-renderer --focus 9,10`
-2. `/audit-safety`
+4. `/audit-concurrency`
+5. `/audit-performance`
+6. `/audit-nif`
+7. `/audit-nifal`
+8. `/audit-audio`
+9. `/audit-speedtree`
+10. `/audit-legacy-compat`
+11. `/audit-tech-debt`
+12. `/audit-fnv`
+13. `/audit-fo3`
+14. `/audit-skyrim`
+15. `/audit-oblivion`
+16. `/audit-fo4`
+17. `/audit-starfield`
+18. `/audit-regression`
+19. `/audit-runtime --game all`
 
 ### `--preset tech-debt-deep`
 Surface accumulated debt (run after a milestone closes, before opening the next):
 1. `/audit-tech-debt`
 2. `/audit-incremental --commits 30`
 
-### `--preset comprehensive`
-Full audit coverage (longest — run monthly or before major milestones):
-1. `/audit-renderer`
-2. `/audit-ecs`
-3. `/audit-safety`
-4. `/audit-nif`
-5. `/audit-nifal`              # canonical-translation tier (single ImportedMesh → Material boundary)
-6. `/audit-performance`
-7. `/audit-concurrency`
-8. `/audit-audio`
-9. `/audit-speedtree`
-10. `/audit-legacy-compat`
-11. `/audit-tech-debt`
-12. `/audit-regression`
-13. `/audit-runtime --game all`  # telemetry regression (#1283) — catches what static audits structurally can't see
-
-### `--preset nif-all-games`
-Test NIF parser against all available game data:
-1. `/audit-nif --game fnv`
-2. `/audit-nif --game skyrim`
-3. `/audit-nif --game oblivion`
-4. `/audit-nif --game fo4`
-5. `/audit-nif --game starfield`     # Starfield now walkable (Cydonia) — BSGeometry path exercised
+## Per-Game Presets
 
 ### `--preset per-game-all`
-Run every per-game compatibility audit (reference title first, then in compat-tier order):
+Run every per-game compatibility audit (reference title first, then in
+compat-tier order):
 1. `/audit-fnv`
 2. `/audit-fo3`
 3. `/audit-skyrim`
@@ -165,21 +102,135 @@ Run every per-game compatibility audit (reference title first, then in compat-ti
 5. `/audit-fo4`
 6. `/audit-starfield`
 
+### `--preset nif-all-games`
+Exercise the NIF parser against every available game corpus (the `--game` arm
+selects the on-disk data dir from `_audit-common.md`):
+1. `/audit-nif --game fnv`
+2. `/audit-nif --game fo3`
+3. `/audit-nif --game skyrim`
+4. `/audit-nif --game oblivion`
+5. `/audit-nif --game fo4`
+6. `/audit-nif --game starfield`   # Cydonia walkable — BSGeometry path exercised
+
 ### `--preset runtime-regression`
-Drive the engine headless on every supported game's representative cell
-and diff the captured telemetry against the checked-in baseline TSVs.
-Catches what static audits structurally can't see (regressions in
-`tex.missing` / `mesh.cache failed` / fps / draw-call count under a
-real cell load). See [#1283](https://github.com/matiaszanolli/ByroRedux/issues/1283).
+Drive the engine headless on every supported game's representative cell and diff
+the captured telemetry against the checked-in baseline TSVs. Catches regressions
+in `tex.missing` / `mesh.cache failed` / fps / draw-call count under a real cell
+load — see [#1283](https://github.com/matiaszanolli/ByroRedux/issues/1283):
 1. `/audit-runtime --game all`
+
+## NIF / NIFAL Presets
+
+### `--preset nif-deep`
+After NIF parser changes (stream position, version gating, block dispatch):
+1. `/audit-nif`
+2. `/audit-nifal`           # the parse → ECS material/collision boundary regresses with parser changes
+3. `/audit-safety`
+4. `/audit-incremental --commits 10`
+
+### `--preset nifal-deep`
+After NIFAL canonical-translation changes — the single `ImportedMesh` → `Material`
+boundary (`byroredux/src/material_translate.rs`), `Material::resolve_pbr`
+(`crates/core/src/ecs/components/material.rs`, metalness/roughness are plain `f32`),
+typed particle emitter blocks, and collision-shape translation
+(`crates/nif/src/import/collision.rs`). Spec: `docs/engine/nifal.md`. `/audit-nifal`
+owns the full canonical-translation tier (9 dimensions); this preset is the
+cross-cutting regression sweep around it:
+1. `/audit-nifal`
+2. `/audit-nif --focus 4,5`    # parse-side geometry/import handoff (dim 4) + collision/shader blocks (dim 5)
+3. `/audit-renderer --focus 6,7,17`  # NIFAL material (dim 6) + material table (dim 7) + Disney BSDF/PBR gating (dim 17)
+4. `/audit-ecs`                # particle emitter components + apply_emitter_params system
+
+## Renderer Presets
+
+Renderer dimension map (from `/audit-renderer`): 1 AS · 2 SSBO+rays · 3 GPU-struct
+layout · 4 sync/barriers · 5 memory/lifecycle · 6 NIFAL material · 7 material
+table · 8 denoiser/composite · 9 skinning · 10 camera-relative precision ·
+11 pipeline/render-pass · 12 cmd buffer · 13 TAA · 14 caustic splat · 15 water ·
+16 volumetrics+bloom · 17 Disney BSDF/soft shadows · 18 sky/weather · 19 tangent
+space · 20 debug/telemetry · 21 Cornell harness.
+
+### `--preset renderer-deep`
+After significant renderer changes — all 21 dimensions plus the cross-cutting
+perf/concurrency/safety passes:
+1. `/audit-renderer`
+2. `/audit-performance --focus 1,2,3,5`
+3. `/audit-concurrency --focus 1,2,3`
+4. `/audit-safety`
+
+### `--preset rt-deep`
+After ray tracing / denoiser / G-buffer changes:
+1. `/audit-renderer --focus 1,2,8`     # AS + SSBO/ray queries + denoiser/composite
+2. `/audit-performance --focus 1,3`
+3. `/audit-concurrency --focus 1,2`
+
+### `--preset material-deep`
+After material-table / PBR changes (`GpuMaterial` layout, dedup, SSBO,
+Disney BSDF gating):
+1. `/audit-renderer --focus 6,7,17`    # NIFAL material + material table + Disney BSDF
+2. `/audit-safety`
+
+### `--preset water-deep`
+After water-rendering changes (incl. water-side caustics):
+1. `/audit-renderer --focus 1,2,8,14,15`  # AS + rays + composite + caustic splat + water dim
+2. `/audit-concurrency --focus 1,2`
+3. `/audit-safety`
+
+### `--preset volumetrics-deep`
+After volumetric-lighting changes:
+1. `/audit-renderer --focus 1,2,5,16`  # AS + rays + memory + volumetrics/bloom dim
+2. `/audit-performance --focus 1,3`
+3. `/audit-safety`
+
+### `--preset bloom-deep`
+After bloom-pyramid changes:
+1. `/audit-renderer --focus 4,8,16`    # sync + composite + volumetrics/bloom dim
+2. `/audit-performance --focus 1,3`
+3. `/audit-safety`
+
+### `--preset skin-deep`
+After GPU-skinning / BLAS-refit changes (M29.x):
+1. `/audit-renderer --focus 1,9`       # AS (skinned BLAS) + GPU skinning compute
+2. `/audit-performance --focus 1,6`
+3. `/audit-concurrency --focus 1,2,3`
+4. `/audit-safety`
+
+## Subsystem Presets
+
+### `--preset audio-deep`
+After audio (kira backend) changes — emitter/listener pose sync, spatial
+sub-track lifecycle, reverb send, streaming music:
+1. `/audit-audio`
+2. `/audit-concurrency --focus 6,7`     # GPU/teardown ordering + worker threads
+3. `/audit-safety`
+
+### `--preset speedtree-deep`
+After SpeedTree (.spt) walker / billboard-fallback changes:
+1. `/audit-speedtree`
+2. `/audit-incremental --commits 10`
+
+### `--preset streaming-deep`
+After world-streaming / NPC-spawn changes (M40 / M41):
+1. `/audit-performance --focus 7`       # world streaming & cell transitions
+2. `/audit-concurrency --focus 7`       # worker threads (streaming, debug server)
+3. `/audit-safety`
+
+### `--preset legacy-deep`
+After compatibility-mapping work (Gamebryo 2.3 → Redux):
+1. `/audit-legacy-compat`
+2. `/audit-incremental --commits 10`
 
 ## Execution
 
-1. Parse the `--preset` argument from `$ARGUMENTS`
-2. `mkdir -p /tmp/audit`
-3. Launch each audit as a **background agent** (max 3 concurrent)
-4. Each writes to `docs/audits/AUDIT_<TYPE>_<TODAY>.md`
-5. When all complete, produce a summary:
+1. Parse the `--preset` argument from `$ARGUMENTS`. If unknown, list the preset
+   index above and stop.
+2. `mkdir -p /tmp/audit`.
+3. Launch each audit in the preset as a **background agent**, max 3 concurrent.
+   The audits are independent — they read the tree and write distinct reports —
+   so they fan out in parallel; no ordering dependency between them.
+4. Each audit writes its own report to `docs/audits/AUDIT_<TYPE>_<TODAY>.md`
+   (per `_audit-common.md` finalization).
+5. When all complete, produce a combined summary:
 
 ```markdown
 # Audit Suite Summary — <preset> — <date>
@@ -192,5 +243,6 @@ real cell load). See [#1283](https://github.com/matiaszanolli/ByroRedux/issues/1
 Total: X findings (C critical, H high, M medium, L low)
 ```
 
-6. If any CRITICAL findings, warn prominently
-7. Suggest: `/audit-publish docs/audits/AUDIT_<TYPE>_<TODAY>.md` for each report with findings
+6. If any CRITICAL findings exist, warn prominently at the top of the summary.
+7. For each report that has findings, suggest:
+   `/audit-publish docs/audits/AUDIT_<TYPE>_<TODAY>.md`

--- a/.claude/commands/audit-tech-debt/SKILL.md
+++ b/.claude/commands/audit-tech-debt/SKILL.md
@@ -5,238 +5,310 @@ argument-hint: "--focus <dimensions> --depth shallow|deep"
 
 # Tech-Debt Audit
 
-Audit ByroRedux for accumulated technical debt: code that compiles, passes tests, and ships, but quietly raises the cost of every future change. The goal is **not** to find correctness bugs (other audits cover that) — it's to surface decay that has crept in since the last cleanup pass.
+Audit ByroRedux for accumulated technical debt: code that compiles, passes
+tests, and ships, but quietly raises the cost of every future change. The goal
+is **not** correctness bugs (other audits own that) — it is decay that crept in
+since the last cleanup pass.
+
+**Every dimension below is a DISCOVERY RECIPE, not a finding list.** Instances
+churn between audits (markers get deleted, files get split, line numbers drift).
+So each dimension hands you a command to enumerate *current* instances, then a
+triage rule. Do not trust any hardcoded instance list — there are none here on
+purpose. Re-run the recipe; report what it surfaces today.
 
 **Architecture**: Orchestrator. Each dimension runs as a Task agent (max 3 concurrent).
 
-See `.claude/commands/_audit-common.md` for project layout, methodology, deduplication, context rules, and finding format.
+See `.claude/commands/_audit-common.md` for project layout, the 19-crate roster,
+methodology, deduplication, context rules, severity, and finding format. Do not
+duplicate any of that here.
 
 ## Parameters (from $ARGUMENTS)
 
-- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,5`). Default: all 11.
-- `--depth shallow|deep`: `shallow` = surface counts and worst offenders; `deep` = file-by-file with concrete fix proposals. Default: `deep`.
+- `--focus <dimensions>`: Comma-separated dimension numbers (e.g., `1,3,5`). Default: all 9.
+- `--depth shallow|deep`: `shallow` = surface counts + worst offenders; `deep` = per-instance triage with a concrete fix proposal. Default: `deep`.
 
 ## Extra Per-Finding Fields
 
-- **Dimension**: Stale Markers | Dead Code | Logic Duplication | Magic Numbers | Stub Implementations | Test Hygiene | Stale Documentation | Backwards-Compat Cruft | File / Function Complexity | Audit-Finding Rot | NIFAL Translation-Tier Debt
-- **Age** (when applicable): commit hash + date the debt was introduced (use `git log -L` or `git blame`)
-- **Effort**: trivial (≤30 min) | small (≤2 h) | medium (≤1 day) | large (>1 day, decompose first)
+- **Dimension**: one of the 9 below.
+- **Age** (when relevant): commit hash + date the debt landed (`git log -L` / `git blame`).
+- **Effort**: trivial (≤30 min) | small (≤2 h) | medium (≤1 day) | large (>1 day, decompose first).
+- **ID convention**: `TD<dim>-NNN` (e.g. `TD7-050` = Dim 7 Doc Rot, finding 50). The
+  path-validation gate (`_audit-validate.sh`, #1114) was itself a `TD7-*` finding —
+  recurring stale-path findings are what motivated the gate.
 
-## Severity Guidance for Tech Debt
+## Severity for Tech Debt
 
-Tech-debt findings are almost always **LOW** under the standard severity scale (see `_audit-severity.md`). Promote when there's amplification:
+Tech-debt findings default to **LOW** (see `_audit-severity.md`). Promote only on amplification:
 
 | Promotion Trigger | Floor |
 |-------------------|-------|
 | Duplicated logic with divergent bug-fix history (one branch fixed, the other regressed) | MEDIUM |
-| `unimplemented!()` / `todo!()` reachable from a shipped CLI / smoke test | MEDIUM |
-| `#[ignore]`d test guarding a fix from a closed CRITICAL/HIGH issue | MEDIUM |
-| Stale doc/audit baseline that has misled an audit in the last 90 days | MEDIUM |
-| Magic number that would silently overflow / underflow under documented use cases | HIGH |
-
-Default tech-debt findings to LOW unless one of the above fires.
+| `unimplemented!()` / `todo!()` / `panic!("not …")` reachable from a shipped CLI flag or smoke test | MEDIUM |
+| `#[ignore]`d test that guards a fix from a closed CRITICAL/HIGH issue | MEDIUM |
+| Stale doc/audit baseline that misled an audit in the last 90 days | MEDIUM |
+| Magic number that would silently over/underflow under documented use | HIGH |
+| Stale `GpuCamera`/`GpuInstance`/`GpuMaterial` size in a doc comment (lockstep-drift bait) | MEDIUM |
 
 ## Phase 1: Setup
 
-1. Parse `$ARGUMENTS` for `--focus`, `--depth`
-2. `mkdir -p /tmp/audit/tech-debt`
-3. Fetch dedup baseline:
+1. Parse `$ARGUMENTS` for `--focus`, `--depth`.
+2. `mkdir -p /tmp/audit/tech-debt`.
+3. Dedup baseline:
    ```bash
-   gh issue list --repo matiaszanolli/ByroRedux --limit 200 --label tech-debt --json number,title,state > /tmp/audit/tech-debt/issues_open.json
    gh issue list --repo matiaszanolli/ByroRedux --limit 500 --state all --label tech-debt --json number,title,state > /tmp/audit/tech-debt/issues_all.json
    ```
-4. Scan `docs/audits/` for prior tech-debt reports (`AUDIT_TECH_DEBT_*.md`)
-5. Snapshot current totals as baseline (so the report can show direction):
+4. Scan `docs/audits/` for prior `AUDIT_TECH_DEBT_*.md` (diff direction, not re-litigation).
+5. Snapshot totals so the next audit can diff:
    ```bash
    {
-     echo "TODO/FIXME/HACK/XXX: $(grep -RInE '(TODO|FIXME|HACK|XXX)\b' crates byroredux | wc -l)"
-     echo "allow(dead_code): $(grep -RInE 'allow\(dead_code\)' crates byroredux | wc -l)"
+     echo "TODO/FIXME/HACK/XXX:   $(grep -RInE '(TODO|FIXME|HACK|XXX)\b' crates byroredux | wc -l)"
+     echo "allow(dead_code):      $(grep -RInE 'allow\(dead_code\)' crates byroredux | wc -l)"
      echo "unimplemented!/todo!(): $(grep -RInE 'unimplemented!|todo!\(\)' crates byroredux | wc -l)"
-     echo "#[ignore] tests: $(grep -RIn '#\[ignore\]' . | wc -l)"
-     echo "files >2000 LOC: $(find crates byroredux -name '*.rs' -exec wc -l {} + | awk '$1 > 2000 && $2 != "total"' | wc -l)"
+     echo "#[ignore] tests:        $(grep -RIn '#\[ignore\]' . | wc -l)"
+     echo "files >2000 LOC:        $(find crates byroredux -name '*.rs' -exec wc -l {} + | awk '$1>2000 && $2!="total"' | wc -l)"
    } > /tmp/audit/tech-debt/baseline.txt
    ```
+   Orientation only (will drift — re-run, never quote): the marker total runs ~20,
+   `unimplemented!/todo!()` is currently **0** (the engine prefers explicit
+   fallbacks over panics — a fresh `todo!()` is therefore notable), `#[ignore]`
+   runs in the low-hundreds (mostly Vulkan/smoke gating, not debt), and the
+   >2000-LOC set is ~6 files (Dim 1).
 
-## Phase 2: Launch Dimension Agents
+## Phase 2: Dimension Agents
 
-### Dimension 1: Stale Markers (TODO / FIXME / HACK / XXX)
-**Entry points**: `crates/`, `byroredux/` (all `.rs`), `crates/renderer/shaders/` (all `.glsl`/`.comp`/`.vert`/`.frag`)
-**Checklist**:
-- Each marker: how old is it? (`git blame` to commit + date — anything older than 6 months gets reported)
-- Does the marker reference an issue number? Is that issue still open?
-  - Closed issue + marker still present → "marker outlived its driver" (delete or reopen)
-- Does the marker reference a milestone (M21, M29, etc.) that is now complete (per ROADMAP.md)?
-- Are there `// TODO: implement` markers in code paths that are now reachable from a shipped CLI flag?
-- Sweep the Disney-BSDF lobe in `crates/renderer/shaders/triangle.frag` for new `// TODO` / `// HACK` markers and bare magic literals around the adapted GGX / Burley diffuse code. **The third-party attribution block (~lines 12–29: GLSL-PathTracer MIT notice + Burley 2012 citation) is must-not-delete** — flag any edit that strips or truncates it (MIT requires the notice travel with the code).
-- Skip markers from the last 30 days unless they reference a closed issue
+Ordered by debt impact: complexity and duplication compound across every future
+edit; doc/audit rot misdirects the *next* audit; markers and dead code are
+cheap. Each agent writes `/tmp/audit/tech-debt/dim_<N>.md`.
 
-**Output**: `/tmp/audit/tech-debt/dim_1.md`
+### Dimension 1: File / Function / Module Complexity
+The highest-leverage debt: an oversized file taxes every edit, review, and merge.
 
-### Dimension 2: Dead Code & Unused Surface
-**Entry points**: `crates/` (19 crates — give the two newest explicit attention: `crates/sfmaterial/src/` Starfield CDB material reader, `crates/debug-ui/src/` egui overlay; both are recent and likely carry first-pass dead surface), `byroredux/`
-**Checklist**:
-- Every `#[allow(dead_code)]` — is the code actually called now, or still dead?
-- Every `pub fn` in a private module that no other module imports (run `cargo +nightly rustc -- -W unused`)
-- Re-exports through `mod.rs` / `lib.rs` that no downstream consumer uses
-- `_` -prefixed unused parameters that survived a refactor (`fn foo(_world: &World)` where `World` is no longer needed)
-- Unused crate dependencies (`cargo machete` if installed; otherwise scan `Cargo.toml` against `use` statements)
-- Trait impls for types no other code constructs (e.g., a `Display` impl that's never called)
-- **Don't flag**: `cfg(test)` / `cfg(debug_assertions)`-gated code, FFI boundary functions, public API of a workspace-internal crate that future binaries will consume (note in CLAUDE.md or ROADMAP.md)
+**Discovery**:
+```bash
+find crates byroredux -name '*.rs' -exec wc -l {} + | awk '$1>2000 && $2!="total"' | sort -rn
+```
+Session 34/35/36 (2026-05) split the original oversized set (acceleration.rs,
+dispatch_tests.rs, cell/tests.rs, draw.rs, scene_buffer.rs, context/mod.rs,
+import/mesh.rs, blocks/collision.rs, nif/anim.rs) into submodules — **all of
+those are closed; do not re-file them.** Membership has since turned over: the
+two big Vulkan-context files *grew* after re-split, and several `byroredux/`
+files crossed 2000. Re-run the command; the threshold is **2000 LOC** (the
+Session-34 split target). Whatever it lists today is the live set — including any
+file the skill once cited as a *success* (a previously-split module can grow back
+over threshold).
 
-**Output**: `/tmp/audit/tech-debt/dim_2.md`
+**Per oversized file, propose a split AXIS by responsibility** (not by line count):
+- A Vulkan `context/` file → per-pass recording groups (geometry / RT / denoise /
+  composite / overlay) or struct+new() vs Drop vs accessors. Vulkan-recording
+  splits are render-pass-adjacent — see `feedback_speculative_vulkan_fixes.md`
+  before proposing barrier/order changes.
+- `byroredux/src/asset_provider.rs` → BSA/BA2 resolution vs TextureProvider vs mesh extraction.
+- `byroredux/src/main.rs` → App/ApplicationHandler event loop vs system registration vs boot/config.
+- `byroredux/src/commands.rs` → console-command groups (stats / entities / systems / tex.* / scene).
+- `crates/nif/src/blocks/particle.rs` → typed emitter/ctlr structs vs the opaque `NiPSysBlock` fallback vs grow/fade modifiers.
 
-### Dimension 3: Logic Duplication
-**Entry points**: any subsystem with N>1 similar files (`crates/nif/src/blocks/`, `crates/plugin/src/esm/records/`, `crates/renderer/src/vulkan/`, `byroredux/src/cell_loader/`)
-**Checklist**:
-- Identical or near-identical block-parser scaffolding across `crates/nif/src/blocks/*.rs` (header read → field read → fixup) — is there a `parse_block` macro/helper this should funnel through?
-- Repeated texture-upload paths in `crates/renderer/src/vulkan/` (BC1/BC3/BC5/RGBA chains)
-- Same Vulkan barrier sequence repeated per render pass (image layout transitions)
-- Repeated descriptor set update boilerplate (vk::WriteDescriptorSet builders)
-- ESM record parsers in `crates/plugin/src/esm/records/` — common subrecord parse loops that should share a helper
-- Coordinate-system flip (Z-up → Y-up) reimplemented at multiple call sites (`crates/nif/src/import/coord.rs` is the canonical home — anything outside is a leak)
-- **Cross-reference user policy** (CLAUDE.md global): "Always prioritize improving existing code rather than duplicating logic." Each duplication finding must propose a specific consolidation site.
+**Also flag**: functions >200 LOC (propose extraction); match arms >50 cases
+(want a lookup table); nesting depth >5 (state-machine extraction); a `mod.rs` /
+`lib.rs` with >20 `pub use` (doing two jobs). `cargo +nightly clippy --all-targets
+-- -W clippy::cognitive_complexity` if available, else inspect the worst offenders.
 
-**Output**: `/tmp/audit/tech-debt/dim_3.md`
+### Dimension 2: Logic Duplication
+CLAUDE.md global policy is explicit: *improve existing code, never duplicate logic.*
+Every finding must name a concrete consolidation site.
 
-### Dimension 4: Magic Numbers & Hardcoded Constants
-**Entry points**: `crates/nif/src/blocks/`, `crates/renderer/src/vulkan/`, shaders
-**Checklist**:
-- Bare numeric literals in `crates/nif/src/blocks/*.rs` that compare against version codes (should be a `NifVersion` constant)
-- Vulkan `MAX_*` / `MIN_*` numbers hardcoded inline (should reference `vk::PhysicalDeviceLimits` queries or named constants)
-- Shader `#define` values are now generated from a single Rust source: `crates/renderer/src/shader_constants_data.rs` (e.g. `GLASS_RAY_BUDGET = 8192`) is `include!`d by both `crates/renderer/src/shader_constants.rs` (library) and `crates/renderer/build.rs`, which emits `shaders/include/shader_constants.glsl`. The check is no longer "does generated-header infra exist" (it does) — it's **"verify every shader `#define` is sourced from `shader_constants_data.rs`; flag any literal that bypasses it"**. (Lockstep risk is HIGH — see `feedback_shader_struct_sync.md`.)
-- GPU `#[repr(C)]` struct sizes are a lockstep regression surface: `GpuCamera` is pinned at 304 B (`crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs::gpu_camera_is_288_bytes` asserts 304 — the test NAME is stale, the asserted value is current) and `GpuInstance` is pinned at its std430 size by the layout test. Flag any inline size literal that should reference these tests, and any doc comment quoting an outdated byte size.
-- Frame-budget / ray-budget / cache-size numbers (e.g., `GLASS_RAY_BUDGET = 8192`, `MAX_TOTAL_BONES`, `MAX_MATERIALS = 4096`) — are they all in one tunable module, or scattered?
-- ESM record sub-record sizes hardcoded (e.g., `if data.len() == 24`) — should map to a named constant from the record struct
-- **Don't flag**: protocol-defined magic (4-char FourCC tags, BSA/NIF magic numbers, Vulkan format enums) — these are spec, not arbitrary
+**Discovery**: target subsystems with N>1 sibling files, then read for repeated scaffolding:
+```bash
+ls crates/nif/src/blocks/*.rs crates/plugin/src/esm/records/**/*.rs crates/renderer/src/vulkan/*.rs byroredux/src/cell_loader/*.rs
+```
+**Look for**:
+- Block-parser scaffolding repeated across `crates/nif/src/blocks/` (header read → field read → fixup) that should funnel through a shared helper/macro.
+- Texture-upload chains (BC1/BC3/BC5/RGBA) duplicated in `crates/renderer/src/vulkan/`.
+- The same image-layout barrier sequence repeated per render pass.
+- `vk::WriteDescriptorSet` builder boilerplate.
+- ESM sub-record parse loops repeated across `crates/plugin/src/esm/records/`.
+- Z-up → Y-up coordinate flips reimplemented outside the canonical homes
+  (`crates/nif/src/import/coord.rs`, `crates/nif/src/anim/coord.rs`) — any other
+  call site is a leak.
 
-**Output**: `/tmp/audit/tech-debt/dim_4.md`
-
-### Dimension 5: Stub & Placeholder Implementations
-**Entry points**: `crates/` (19 crates — the recent `crates/sfmaterial/src/` (Starfield CDB) and `crates/debug-ui/src/` (egui overlay) are the likeliest to carry first-pass stubs), `byroredux/`
-**Checklist**:
-- Every `unimplemented!()` and `todo!()` — is the call site reachable from a shipped CLI flag or smoke test?
-- `panic!("not yet")` / `panic!("not implemented")` — same reachability check
-- Functions that return `None` / `Vec::new()` / `Default::default()` with a comment like "// TODO: real impl" or "// stub"
-- Trait impls with empty method bodies that should do work (check against trait docs for required behavior)
-- ESM per-game record coverage in `crates/plugin/src/esm/records/` — which records are fully wired vs still stubbed per game? (The legacy crates/plugin/src/legacy/{tes3,tes4,tes5,fo4}.rs per-game stubs were removed under `#390`; coverage now lives in the unified records tree. Cross-check against ROADMAP.md per-game compat matrix.)
-- Console commands in `byroredux/src/commands.rs` that exist but are no-ops or print "TODO"
-
-**Output**: `/tmp/audit/tech-debt/dim_5.md`
-
-### Dimension 6: Test Hygiene
-**Entry points**: `**/*_tests.rs`, `**/tests/**`, `byroredux/tests/`
-**Checklist**:
-- Every `#[ignore]` test: is there a referenced issue? Is that issue still open?
-- Tests with **only** smoke assertions (`assert!(result.is_ok())` and nothing else) — should assert on returned values
-- Commented-out assertions inside otherwise-passing tests (`// assert_eq!(...)`)
-- `#[cfg(feature = "...")]`-gated tests where the feature is never enabled in CI
-- Tests that print rather than assert (`println!("got {x}")` with no follow-up `assert_eq!`)
-- Tests with `unwrap()` everywhere — are they testing the failure paths they need to?
-- Golden-frame tests (`byroredux/tests/golden_frames.rs`) marked `--ignored` — confirm they're still runnable and the golden image is current
-- **Cross-reference baseline notes** in audit skills (e.g., `audit-performance.md`'s "must not regress" lines) — is each mentioned regression test still present and not `#[ignore]`d?
-
-**Output**: `/tmp/audit/tech-debt/dim_6.md`
-
-### Dimension 7: Stale Documentation & Comments
-**Entry points**: `docs/`, `ROADMAP.md`, `HISTORY.md`, `README.md`, `CLAUDE.md`, `.claude/commands/audit-*.md`, doc comments in source
-**Checklist**:
-- Run `.claude/commands/_audit-validate.sh` first — it's the structural gate added under `#1114` / TD7-050 to catch audit-skill path drift on the commit that introduces it. If the script reports STALE refs, those are auto-eligible Dim 7 findings (effort: trivial).
-- Doc comments that reference renamed types (e.g., `// See OldStruct` where `OldStruct` was renamed)
-- "76-byte Vertex" -style numerical claims in doc comments that no longer match `Vertex::SIZE` (commit 1c388e5 fixed one batch of these — sweep for the rest)
-- ROADMAP.md milestones marked "in progress" but the underlying issues are all closed (or vice versa)
-- HISTORY.md entries that reference issues that were later reverted
-- README.md command examples that no longer work (`cargo run` flag changed, BSA path syntax changed)
-- `docs/legacy/` references to Gamebryo source paths that may have moved
-- Doc comments referencing the **deleted render-time `Material::classify_pbr`**: PBR resolution moved to the parse-time NIFAL boundary (`byroredux/src/material_translate.rs`) + the shared `classify_pbr_keyword` helper. `crates/core/src/ecs/components/material.rs` still carries several doc-comments naming the old `Material::classify_pbr` (e.g. ~lines 396/551/578/587/627/981) — confirm each correctly frames it as *deleted/historical*, not as a live entry point. (Covered in depth by Dimension 11.)
-- `crates/renderer/shaders/triangle.frag` doc comments quoting outdated GPU struct byte sizes (GpuCamera, GpuMaterial) — cross-check against the layout tests rather than trusting the prose.
-
-**Convention** (post-`#1114`): backticked path refs in audit-*.md claim
-"this path exists right now — find it." Forward-looking refs (a file
-that doesn't yet exist) or backwards-looking refs (a file that was
-deleted) must NOT use backticks. The validate script flags any
-backticked path that does not resolve.
-
-**Output**: `/tmp/audit/tech-debt/dim_7.md`
-
-### Dimension 8: Backwards-Compat Cruft
-**Entry points**: `crates/`, `byroredux/`, `Cargo.toml` files
-**Checklist**:
-- `_unused`-renamed parameters or fields that survived a refactor (CLAUDE.md is explicit: don't rename to `_var`, delete it)
-- `// removed: ...` comment markers (CLAUDE.md again: delete completely, no breadcrumbs)
-- Re-exports of deleted types kept "for compatibility" — but ByroRedux has no external consumers yet, so these are just rot
-- Feature flags in `Cargo.toml` for features that have only one branch (always-on or always-off) — remove the flag
-- Deprecated `#[deprecated]` items with no consumers — delete instead of deprecate
-- Cell-loader `nif_import_registry` legacy paths — given the post-Session-34 split, are any old call sites still on the deprecated route?
-
-**Output**: `/tmp/audit/tech-debt/dim_8.md`
-
-### Dimension 9: File / Function / Module Complexity
-**Entry points**: `crates/`, `byroredux/`
-**Checklist**:
-- List `.rs` files >2000 LOC (Session 34 split target was 2000):
+### Dimension 3: Stale Documentation & Comments
+Doc rot is high-impact debt because it misleads the *next* reader and the *next*
+audit. **Run the path gate first** (it is also Dim 9's input):
+```bash
+.claude/commands/_audit-validate.sh
+```
+Any STALE refs it prints are auto-eligible findings (effort: trivial). Then
+sweep for content rot the gate cannot see:
+- **Numeric claims in doc comments that drift from a pinned test.** The canonical
+  trap: `GpuCamera` / `GpuInstance` / `GpuMaterial` byte sizes and `Vertex::SIZE`.
+  Do NOT trust prose — cross-check against the layout test, whose value is
+  authoritative and whose *name* may itself be stale:
   ```bash
-  find crates byroredux -name '*.rs' -exec wc -l {} + | awk '$1 > 2000 && $2 != "total"' | sort -rn
+  grep -rn "fn gpu_camera_is\|fn gpu_instance_is\|assert_eq.*size_of" crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs
   ```
-  Historical baseline (do NOT trust as current — re-run the command above each audit): as of 2026-05-13 the oversized set was acceleration.rs (4200 LOC), dispatch_tests.rs (3667), cell/tests.rs (3329), draw.rs (2554), scene_buffer.rs (2367), context/mod.rs (2348), import/mesh.rs (2212), blocks/collision.rs (2162), nif/anim.rs (2101) — these pre-split paths were since split into submodules (Session 34/35/36 sweeps — #29e9f45/bd45caa/9c1f723/1fe5321/fe47706/014adc8/ca81c19), all 9 closed.
-  As of **2026-05-28** the >2000 LOC set is 5 files (membership changed entirely — the two Vulkan files grew rather than shrank, and three new `byroredux/` files crossed the threshold):
-  - `crates/renderer/src/vulkan/context/draw.rs` 3337 LOC — split axis: per-pass recording groups (geometry / RT / denoise / composite / overlay), Vulkan-recording-adjacent (see `feedback_speculative_vulkan_fixes.md`).
-  - `crates/renderer/src/vulkan/context/mod.rs` 3017 LOC — split axis: struct + new() vs Drop teardown vs accessor groups, also Vulkan-recording-adjacent.
-  - `byroredux/src/asset_provider.rs` 2561 LOC — split axis: BSA/BA2 archive resolution vs TextureProvider vs mesh extraction.
-  - `byroredux/src/main.rs` 2448 LOC — split axis: App/ApplicationHandler event loop vs system registration vs boot/config plumbing.
-  - `byroredux/src/commands.rs` 2115 LOC — split axis: console-command groups (stats / entities / systems / tex.* / scene) into a per-group module.
+- Doc comments naming renamed/deleted symbols. The recurring one: the **deleted
+  render-time `Material::classify_pbr`** (PBR resolution moved to the parse-time
+  NIFAL boundary). Several doc-comments in `crates/core/src/ecs/components/material.rs`
+  still name it — each must frame it as *deleted/historical*, never as a live
+  entry point. Enumerate and read each:
+  ```bash
+  grep -n "classify_pbr" crates/core/src/ecs/components/material.rs
+  ```
+  The surviving symbols are the free function `classify_pbr_keyword` and the
+  method `Material::resolve_pbr`; `metalness`/`roughness` are plain resolved `f32`.
+  (This overlaps Dim 8 — report material doc rot under Dim 3.)
+- ROADMAP.md milestones marked "in progress" whose issues are all closed (or vice versa) — cross-check `git log` / `gh issue`.
+- HISTORY.md entries referencing later-reverted work.
+- README.md command examples whose flags/paths changed.
+- `docs/legacy/` references to Gamebryo source paths that moved.
+- `crates/renderer/shaders/triangle.frag` doc comments quoting outdated GPU struct byte sizes — cross-check the layout test, not the prose.
 
-  For each, propose a split axis (by submodule responsibility, not by line count alone).
-- Functions >200 LOC — propose extraction
-- Match arms >50 cases (these usually want a lookup table)
-- Nesting depth >5 (often a state-machine extraction candidate)
-- Modules with >20 `pub use` re-exports (the module is doing two jobs)
-- `cargo +nightly clippy --all-targets -- -W clippy::cognitive_complexity` if available; otherwise visual inspection of the worst-offender list
+**Path convention (post-#1114)**: a backticked `.ext` path in any audit-*.md or
+this file asserts "exists right now". Forward-looking (not-yet-created) or
+backwards-looking (deleted) refs must NOT use backticks. The gate fails on any
+backticked path that does not resolve. (Note: the gate globs
+`.claude/commands/audit-*.md`, not `audit-*/SKILL.md` subdirs — paths in *this
+very file* are not gate-covered and must be hand-validated.)
 
-**Output**: `/tmp/audit/tech-debt/dim_9.md`
+### Dimension 4: Audit-Finding Rot
+The audit infrastructure decays like any other code, and stale baselines actively
+misdirect future audits.
+**Discovery**:
+```bash
+.claude/commands/_audit-validate.sh            # structural path gate (#1114)
+ls .claude/commands/audit-*.md docs/audits/
+```
+- STALE refs from the gate that live in *other* audit skills → Dim 4 findings (trivial).
+- Symbol-anchor refs the gate cannot verify (e.g. `crates/audio/src/lib.rs::drain_pending_oneshots`) — spot-check the symbol still exists.
+- "Existing: #NNN" callouts in skills where the issue is now CLOSED — reframe as a closed-state baseline.
+- Skill files quoting a dimension count ("all N dimensions") that no longer matches the live list.
+- `docs/audits/` reports >90 days old whose CRITICAL/HIGH findings are not all triaged on GitHub.
+- **Do NOT flag** `.claude/issues/<N>/ISSUE.md` "Status: Open" drift — dropped per
+  TD10-001 / #1156: local issue files are immutable snapshots; GitHub is
+  authoritative. Query `gh issue view <N> --json state` for live state.
 
-### Dimension 10: Audit-Finding Rot
-**Entry points**: `.claude/commands/audit-*.md`, `docs/audits/`, `.claude/issues/`
-**Checklist**:
-- Audit skill "must not regress" baselines — every backticked path in `audit-*.md` is now gated by `.claude/commands/_audit-validate.sh` (post-#1114). Run that gate first; any STALE refs it reports are auto-eligible Dim 10 findings (effort: trivial). For symbol-anchor refs that the gate can't verify (e.g., `crates/audio/src/lib.rs::drain_pending_oneshots`), spot-check that the function still exists.
-- "Existing: #NNN" callouts in skill files where the issue is now CLOSED — should the skill prose reference the closed-state baseline differently?
-- ~~`.claude/issues/<N>/ISSUE.md` entries where the upstream GitHub issue was closed but the local file still says "Status: Open"~~ — **dropped per TD10-001 / #1156**: local issue files are immutable snapshots of the issue as filed; state drift is expected and not a finding. GitHub is authoritative for current state. If you need live state during an audit, query `gh issue view <N> --json state` directly.
-- Audit reports in `docs/audits/` from >90 days ago whose CRITICAL/HIGH findings are not all triaged (open or closed) on GitHub
-- Skill files that reference dimension counts (e.g., "all 9 dimensions") that don't match the current dimension list
+### Dimension 5: Stale Markers (TODO / FIXME / HACK / XXX)
+**Discovery**:
+```bash
+grep -RInE '(TODO|FIXME|HACK|XXX)\b' crates byroredux
+grep -RInE '(TODO|HACK)' crates/renderer/shaders/
+```
+**Triage each** (skip markers <30 days old unless they name a closed issue):
+- `git blame` for age — anything >6 months gets reported.
+- Does it name an issue number? Is that issue still open? Closed issue + live marker → "marker outlived its driver" (delete or reopen).
+- Does it name a milestone (M21, M29, …) now complete per ROADMAP.md?
+- `// TODO: implement` on a path now reachable from a shipped CLI flag → promote (see severity table).
+- **False positives to exclude**: `XXXX` is the ESM extended-size sub-record tag
+  (`crates/plugin/src/esm/reader.rs`, `records/misc/magic.rs`) — protocol, not a
+  marker. `// FIXME note` referencing a *reference implementation's* FIXME (e.g.
+  `crates/bgsm/src/bgem.rs`) is documentation of upstream, not our debt.
+- **Must-not-delete**: the third-party attribution block atop
+  `crates/renderer/shaders/triangle.frag` (GLSL-PathTracer MIT notice + Burley
+  2012 citation, ~first 30 lines). Flag any edit that strips/truncates it — MIT
+  requires the notice travel with the code.
 
-**Output**: `/tmp/audit/tech-debt/dim_10.md`
+### Dimension 6: Stub & Placeholder Implementations
+**Discovery**:
+```bash
+grep -RInE 'unimplemented!|todo!\(\)|panic!\("not ' crates byroredux
+grep -RInE '// *(stub|TODO: real|placeholder|not yet)' crates byroredux
+```
+The first command currently returns **nothing** — the codebase prefers explicit
+fallbacks to panics, so any hit is genuinely notable. For each:
+- Reachable from a shipped CLI flag or smoke test? → promote to MEDIUM.
+- Functions returning `None` / `Vec::new()` / `Default::default()` with a "// stub"/"// TODO: real impl" comment.
+- Trait impls with empty bodies that the trait docs say should do work.
+- Per-game ESM record coverage in `crates/plugin/src/esm/records/` — fully wired
+  vs stubbed per game; cross-check ROADMAP.md per-game compat matrix. (The legacy
+  per-game stubs in `crates/plugin/src/legacy/` were removed under #390 — coverage
+  now lives in the unified records tree; do not re-file the removed stubs.)
+- Console commands in `byroredux/src/commands.rs` that exist but no-op / print "TODO".
 
-### Dimension 11: NIFAL Translation-Tier Debt
-**Entry points**: `byroredux/src/material_translate.rs`, `crates/core/src/ecs/components/material.rs`, `crates/nif/src/import/collision.rs`, `crates/nif/src/import/walk/mod.rs`, `crates/nif/src/blocks/particle.rs`, `byroredux/src/systems/particle.rs`. Spec: `docs/engine/nifal.md`.
+### Dimension 7: Magic Numbers & Hardcoded Constants
+**Discovery**: read the version-gate and budget sites; do not regex blindly (most
+literals are legitimate).
+- Bare numeric literals in `crates/nif/src/blocks/` compared against version codes → should be a `NifVersion` constant.
+- Vulkan `MAX_*`/`MIN_*` hardcoded inline → reference `vk::PhysicalDeviceLimits` or a named constant.
+- **Shader `#define` provenance**: every shader define is generated from one Rust
+  source — `crates/renderer/src/shader_constants_data.rs` is `include!`d by both
+  `crates/renderer/src/shader_constants.rs` and `crates/renderer/build.rs` (which
+  emits `shaders/include/shader_constants.glsl`). The generated-header infra
+  exists; the check is **"every shader `#define` is sourced from
+  `shader_constants_data.rs`; flag any literal that bypasses it"** (lockstep risk
+  HIGH — `feedback_shader_struct_sync.md`).
+- **GPU `#[repr(C)]` size literals**: `GpuCamera`, `GpuInstance`, `GpuMaterial`
+  sizes are pinned by `gpu_instance_layout_tests.rs`. Flag any inline size literal
+  that should reference those tests, and any doc comment quoting an outdated size
+  (overlaps Dim 3). Get the live values from the test, not from memory:
+  ```bash
+  grep -rn "fn gpu_camera_is\|fn gpu_instance_is\|size_of::<Gpu" crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs
+  ```
+- Frame/ray/cache budgets (`GLASS_RAY_BUDGET`, `MAX_TOTAL_BONES`, `MAX_MATERIALS`, …) scattered vs in one tunable module.
+- ESM sub-record sizes hardcoded (`if data.len() == 24`) → named constant from the record struct.
+- **Do NOT flag** protocol-defined magic: FourCC tags, BSA/NIF/BA2 magic, Vulkan format enums.
 
-NIFAL is the canonical translation tier: the single `ImportedMesh → Material` boundary lives at `byroredux/src/material_translate.rs::translate_material`. PBR resolution moved from a render-time path to parse time, so the old indirection left debt behind. This dimension scopes that tier for **debt only** (dead code, stale doc, leftover fallback breadcrumbs) — translation *correctness* is the domain of `/audit-nifal` (**see also `/audit-nifal`**).
+### Dimension 8: Dead Code & Backwards-Compat Cruft
+**Discovery**:
+```bash
+grep -RInE 'allow\(dead_code\)' crates byroredux
+grep -RInE '#\[deprecated\]|// *removed:|_unused|fn .*_unused' crates byroredux
+cargo machete 2>/dev/null || echo "cargo machete not installed — scan Cargo.toml deps vs use stmts"
+```
+- Each `#[allow(dead_code)]` — actually called now, or still dead? Delete if dead.
+- `pub fn` in a private module no one imports (`cargo +nightly rustc -- -W unused`).
+- `mod.rs`/`lib.rs` re-exports with no downstream consumer.
+- `_`-prefixed params that survived a refactor (CLAUDE.md: delete, don't rename to `_var`).
+- `// removed: …` breadcrumbs (CLAUDE.md: delete completely, no breadcrumbs).
+- Re-exports of deleted types kept "for compatibility" — ByroRedux has no external consumers yet, so these are pure rot.
+- `Cargo.toml` feature flags with only one branch (always-on/always-off) → remove the flag.
+- `#[deprecated]` items with no consumers → delete, don't deprecate.
+- **Do NOT flag**: `cfg(test)`/`cfg(debug_assertions)`-gated code, FFI boundary
+  functions, or public API of a workspace-internal crate a future binary will
+  consume (note such cases rather than deleting).
 
-**Checklist**:
-- **Deleted-`classify_pbr` doc rot**: `Material::metalness` / `Material::roughness` are now plain resolved `f32` (no `Option`, no render-time fallback) — `crates/core/src/ecs/components/material.rs:216,222`. The render-time `Material::classify_pbr` is gone; only the shared `classify_pbr_keyword` helper (`material.rs:432`) and `Material::resolve_pbr` (`material.rs:588`) remain. Sweep `material.rs` for doc-comments still naming `Material::classify_pbr` (e.g. ~lines 396/551/578/587/627/981) — each must read as *deleted/historical*, never as a live method. (Overlaps Dim 7; report under Dim 11.)
-- **NaN-sentinel breadcrumbs**: `translate_material` seeds `f32::NAN` into metalness/roughness when there's no authored override (`material_translate.rs:149-150`), relying on `resolve_pbr` to fill them. Confirm no leftover comment or dead branch implies a per-draw classify fallback still exists (`static_meshes.rs` documents "no per-draw keyword scan").
-- **Typed-particle-block cruft**: `NiPSysEmitter` / `NiPSysEmitterCtlr` / `NiPSysEmitterCtlrData` / `NiPSysGrowFadeModifier` are now TYPED structs in `crates/nif/src/blocks/particle.rs` feeding `extract_emitter_params` / `extract_emitter_rate` (`crates/nif/src/import/walk/mod.rs:670,713`) → `byroredux/src/systems/particle.rs::apply_emitter_params:29`. The opaque `NiPSysBlock` fallback (`particle.rs:151`, used at `walk/mod.rs:522,1184`) is still a *legitimate* path for legacy types with no modifier list — confirm it is still reachable, not orphaned dead code superseded by the typed blocks.
-- **Dropped-collision-shape breadcrumbs**: `BhkMultiSphereShape` and `BhkConvexListShape` now translate to `CollisionShape` (`crates/nif/src/import/collision.rs:301,397`) — they were previously dropped. Sweep for stale `// dropped` / `// unsupported` comments around the collision-translate arms that are now wrong.
-- Each finding here must propose a concrete deletion or doc fix; do NOT re-derive translation correctness (that is `/audit-nifal`'s job).
+### Dimension 9: Test Hygiene
+**Discovery**:
+```bash
+grep -RIn '#\[ignore\]' . | grep -v target/
+```
+Most `#[ignore]`s gate Vulkan/smoke tests that need a GPU or on-disk game data —
+those are **not** debt. Triage the rest:
+- Each `#[ignore]` test: referenced issue still open? If it guards a closed CRITICAL/HIGH fix → MEDIUM (severity table).
+- Tests with only smoke assertions (`assert!(result.is_ok())` and nothing else) — should assert on values.
+- Commented-out assertions inside otherwise-passing tests (`// assert_eq!(…)`).
+- `#[cfg(feature = "…")]`-gated tests where the feature is never enabled in CI.
+- Tests that `println!` without a follow-up assert.
+- `byroredux/tests/golden_frames.rs` (opts into `--ignored`) — still runnable, golden image current.
+- Cross-reference "must not regress" lines in other audit skills (e.g. `audit-performance`) — each named regression test still present and not `#[ignore]`d.
 
-**Output**: `/tmp/audit/tech-debt/dim_11.md`
+## Cross-Dimension Dedup
+
+A TODO inside a dead function reports under Dim 8 (Dead Code), not also Dim 5.
+Material doc rot reports under Dim 3, not also Dim 8. A stale GPU-size doc comment
+reports under Dim 3; a stale GPU-size *code literal* under Dim 7. NIFAL/material
+*translation correctness* is out of scope here — that is `/audit-nifal`. This
+audit only owns the *debt* around that tier (dead code, stale doc, leftover
+breadcrumbs).
 
 ## Phase 3: Merge
 
-1. Read all `/tmp/audit/tech-debt/dim_*.md` files
-2. Combine into `docs/audits/AUDIT_TECH_DEBT_<TODAY>.md` with structure:
-   - **Executive Summary** — Total findings by severity + delta vs `baseline.txt`
-   - **Baseline Snapshot** — counts captured in Phase 1, so the next audit can diff
-   - **Top 10 Quick Wins** — trivial / small effort, immediate readability or compile-time payoff
-   - **Top 5 Medium Investments** — file/function splits, duplication consolidations
-   - **Findings** — Grouped by severity (HIGH first, then MEDIUM, then LOW), then by dimension
-   - **Deferred** — Findings that depend on milestones still in progress; note the gating milestone
-3. Remove cross-dimension duplicates (e.g., a TODO inside a dead function reports under Dim 2, not also Dim 1)
+1. Read all `/tmp/audit/tech-debt/dim_*.md`.
+2. Combine into `docs/audits/AUDIT_TECH_DEBT_<TODAY>.md`:
+   - **Executive Summary** — findings by severity + delta vs `baseline.txt`.
+   - **Baseline Snapshot** — the Phase-1 counts, so the next audit can diff.
+   - **Top 10 Quick Wins** — trivial/small effort, immediate readability or compile-time payoff.
+   - **Top 5 Medium Investments** — file/function splits, duplication consolidations.
+   - **Findings** — by severity (HIGH → MEDIUM → LOW), then by dimension.
+   - **Deferred** — findings gated on an in-progress milestone; name the gating milestone.
+3. Remove cross-dimension duplicates per the rules above.
 
 ## Phase 4: Cleanup
 
-1. `rm -rf /tmp/audit/tech-debt`
-2. Inform user the report is ready
-3. Suggest: `/audit-publish docs/audits/AUDIT_TECH_DEBT_<TODAY>.md`
+1. `rm -rf /tmp/audit/tech-debt`.
+2. Tell the user the report is ready.
+3. Suggest: `/audit-publish docs/audits/AUDIT_TECH_DEBT_<TODAY>.md`.
 
 ## GitHub Label
 
-This audit publishes findings under the `tech-debt` label (in addition to the standard `<severity>` and `<domain>` labels). The label is registered in the repository — `/audit-publish` will apply it automatically when a finding's audit type is `TECH_DEBT`.
+Findings publish under the `tech-debt` label (plus the standard `<severity>` and
+`<domain>` labels). It is registered in the repo — `/audit-publish` applies it
+automatically when a finding's audit type is `TECH_DEBT`.


### PR DESCRIPTION
Re-verified every audit skill against the live tree and rewrote them for accuracy and effectiveness. 22 SKILL.md files + the two shared protocol files were drifting against months of module splits, milestone closures, and struct/enum churn.

Foundation:
- _audit-common.md: Project Layout map re-verified (render.rs -> render/, dropped removed Decal marker, added env_translate/ragdoll/cornell/ water_caustic/gpu_timers/import-precombine and the cell_loader LOD submodules, resolved the Caustics M?? placeholder to M22). Domain Labels reconciled against the real `gh label list` (removed nonexistent bsa/esm/platform/maintenance; added nif-parser/import-pipeline).
- _audit-validate.sh: fix the glob — skills migrated to audit-*/SKILL.md subdirs but the gate still globbed audit-*.md, so it was silently checking zero skills. Now inspects 776 refs across 24 files, passes clean.

Per-skill (deep rewrite): risk-reordered dimensions, recast resolved work as regression guards, replaced drifted line numbers with symbol anchors, swapped rotting bench/count literals for ROADMAP pointers. Notable factual corrections:
- ecs/concurrency: Stage enum is Early/Update/PostUpdate/Physics/Late (old ParallelUpdate/LateExclusive were fiction).
- skyrim: 9 ShaderTypeData variants (not 8); shader blocks in shader.rs.
- oblivion: dropped "ESM stubs" framing (#390); BSA v103/v104 folder records are both 16B.
- fo4: M49 CSG precombines landed (was described as blocked).
- starfield: removed "no ESM" — Cydonia interior is walkable.
- publish: reconciled applied labels to the real repo label set.
- renderer: ~57KB->38KB; GpuCamera 320->336B, GpuMaterial test 260->300.
- suite: remapped every --focus index to the renumbered target skills.