### PR TITLE
Fix #1652: map bhk motion_type via the full canonical Havok enum

### DIFF
--- a/crates/nif/src/import/collision.rs
+++ b/crates/nif/src/import/collision.rs
@@ -118,6 +118,41 @@ pub fn extract_collision(
     None
 }
 
+/// Map the raw Havok `hkMotionType` byte to the engine [`MotionType`].
+///
+/// Values per the canonical `hkMotionType` enum (`hkpMotion::MotionType`,
+/// nif.xml `<enum name="hkMotionType">`):
+///
+/// | Value | Havok | Engine |
+/// |-------|-------|--------|
+/// | 1 | DYNAMIC | Dynamic |
+/// | 2 | SPHERE_INERTIA | Dynamic |
+/// | 3 | SPHERE_STABILIZED | Dynamic |
+/// | 4 | BOX_INERTIA | Dynamic |
+/// | 5 | BOX_STABILIZED | Dynamic |
+/// | 6 | KEYFRAMED | Keyframed |
+/// | 7 | FIXED | Static |
+/// | 8 | THIN_BOX | Dynamic |
+/// | 9 | CHARACTER | CharacterKinematic |
+/// | 0 / other | INVALID | Static |
+///
+/// The pre-#1652 mapping collapsed `4 => Keyframed` and `_ => Static`,
+/// which froze the most common dynamic clutter (BOX_INERTIA 4 crates/
+/// debris) into a kinematic body with no animated transform and turned
+/// every KEYFRAMED (6) door/platform into immovable Static. This is the
+/// canonical translation boundary — the physics solver only ever sees
+/// the engine [`MotionType`], never the raw Havok byte.
+fn havok_motion_type(raw: u8) -> MotionType {
+    match raw {
+        1..=5 | 8 => MotionType::Dynamic,
+        6 => MotionType::Keyframed,
+        7 => MotionType::Static,
+        9 => MotionType::CharacterKinematic,
+        // 0 = MO_SYS_INVALID and any out-of-range value → Static.
+        _ => MotionType::Static,
+    }
+}
+
 /// Classic `BhkCollisionObject` → `BhkRigidBody` → shape-tree extractor.
 /// This is the dominant path for Oblivion / FO3 / FNV / Skyrim LE / SSE and
 /// still covers most FO4+ rigid bodies that author the legacy chain. Body of
@@ -152,11 +187,7 @@ fn extract_from_classic(
         };
     }
 
-    let motion_type = match body.motion_type {
-        1..=3 => MotionType::Dynamic,
-        4 => MotionType::Keyframed,
-        _ => MotionType::Static,
-    };
+    let motion_type = havok_motion_type(body.motion_type);
 
     let body_data = RigidBodyData {
         motion_type,
@@ -995,6 +1026,33 @@ mod dispatch_tests {
     };
     use crate::blocks::NiObject;
     use crate::types::BlockRef;
+
+    /// #1652 — `havok_motion_type` must map the full canonical
+    /// `hkMotionType` enum, not the pre-fix `4 => Keyframed / _ => Static`
+    /// collapse. Pins the four previously-wrong values (4, 5, 6, 8) plus
+    /// the correct edges (1, 7, 9, 0).
+    #[test]
+    fn havok_motion_type_maps_full_enum() {
+        // Dynamic family: DYNAMIC(1), SPHERE_INERTIA(2), SPHERE_STABILIZED(3),
+        // BOX_INERTIA(4), BOX_STABILIZED(5), THIN_BOX(8).
+        for v in [1u8, 2, 3, 4, 5, 8] {
+            assert_eq!(
+                havok_motion_type(v),
+                MotionType::Dynamic,
+                "hkMotionType {v} must be Dynamic"
+            );
+        }
+        assert_eq!(havok_motion_type(6), MotionType::Keyframed, "KEYFRAMED");
+        assert_eq!(havok_motion_type(7), MotionType::Static, "FIXED");
+        assert_eq!(
+            havok_motion_type(9),
+            MotionType::CharacterKinematic,
+            "CHARACTER"
+        );
+        // INVALID(0) and any out-of-range value fall back to Static.
+        assert_eq!(havok_motion_type(0), MotionType::Static, "INVALID");
+        assert_eq!(havok_motion_type(200), MotionType::Static, "out-of-range");
+    }
 
     fn empty_scene() -> NifScene {
         let mut scene = NifScene::default();


### PR DESCRIPTION
extract_from_classic collapsed the raw hkMotionType byte with `4 => Keyframed` / `_ => Static`, which contradicts the canonical hkMotionType enum (nif.xml <enum name="hkMotionType">):

  1..=5, 8  fully-simulated  -> Dynamic
  6         KEYFRAMED        -> Keyframed
  7         FIXED            -> Static
  9         CHARACTER        -> CharacterKinematic
  0/other   INVALID          -> Static

The collapse mis-typed the two most common dynamic-body cases: BOX_INERTIA (4) — box-shaped clutter (crates, ammo boxes, debris) — became Keyframed -> KinematicPositionBased, so a statically-placed crate froze in place with infinite mass instead of falling; and KEYFRAMED (6) doors/platforms fell into `_` -> Static -> Fixed, so scripted-moved doors became immovable. BOX_STABILIZED (5) and THIN_BOX (8) likewise became immovable Static.

Affects all Havok-content games (FNV/FO3/Oblivion/Skyrim share this extractor; FO4+ classic chain too). Static architecture (FIXED=7) was already correct, so walkable collision was unaffected — the bug was confined to the dynamic/keyframed body population.

Extract havok_motion_type(u8) at the NIF import->component boundary (the canonical translation seam — the physics solver only ever sees the engine MotionType, never the raw byte) and add a regression test pinning 1..=5/8 -> Dynamic, 6 -> Keyframed, 7 -> Static, 9 -> CharacterKinematic, 0/oob -> Static. SIBLING: the only motion_type decode in the crate; extract_from_np (FO4 NP blob) and extract_from_phantom (triggers) return None without building a body.