### PR TITLE
Fix #1603: discard cancelled screenshot straggler via capture generation

### DIFF
--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -1843,6 +1843,10 @@ impl ApplicationHandler for App {
                         owner: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(
                             byroredux_core::ecs::resources::SCREENSHOT_OWNER_NONE,
                         )),
+                        // #1603 — shared capture generation; the renderer
+                        // gates each readback's publish on it so a
+                        // cancelled-then-resumed straggler is discarded.
+                        generation: ss_handle.generation,
                     });
 
                 // Expose the GPU allocator to the ECS so the

--- a/crates/core/src/ecs/resources.rs
+++ b/crates/core/src/ecs/resources.rs
@@ -36,6 +36,18 @@ pub struct ScreenshotBridge {
     /// CAS'd from NONE → owner by `try_claim`, reset to NONE by
     /// successful `take_result_for` or by `cancel`.
     pub owner: std::sync::Arc<std::sync::atomic::AtomicU8>,
+    /// Monotonic capture generation, shared with the renderer (#1603).
+    ///
+    /// `owner` cannot distinguish a *cancelled* in-flight capture from a
+    /// fresh claim that reuses the same owner tag, so it can't gate the
+    /// renderer's private `screenshot_pending_readback` latch: a copy
+    /// recorded under owner X, cancelled mid-flight, then a new claim by
+    /// the same owner X, would let the straggler readback publish into
+    /// the new claimant's slot. This generation does: the renderer
+    /// captures it when it records the copy and only publishes the PNG if
+    /// it still matches at readback time. [`cancel`](Self::cancel) bumps
+    /// it, invalidating any capture recorded before the cancel.
+    pub generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// `ScreenshotBridge` is idle — neither CLI nor debug-server holds it.
@@ -151,7 +163,31 @@ impl ScreenshotBridge {
         // #1006 — release ownership so the next consumer can claim.
         self.owner
             .store(SCREENSHOT_OWNER_NONE, std::sync::atomic::Ordering::Release);
+        // #1603 — bump the capture generation so a copy already recorded
+        // into the renderer's staging buffer (but not yet read back) is
+        // rejected when its delayed readback completes, instead of
+        // publishing a stale PNG into the next claimant's result slot.
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         had_request || had_result
+    }
+
+    /// Current capture generation (#1603). The renderer captures this
+    /// when it records a screenshot copy and passes it back to
+    /// [`readback_is_current`](Self::readback_is_current) before
+    /// publishing the encoded PNG.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Whether a readback captured at `captured_generation` is still the
+    /// live capture — i.e. no [`cancel`](Self::cancel) has intervened
+    /// since the copy was recorded. The renderer gates its
+    /// `screenshot_result` write on this so a cancelled-then-resumed
+    /// straggler is discarded rather than served to a later claimant.
+    /// #1603.
+    pub fn readback_is_current(&self, captured_generation: u64) -> bool {
+        self.generation() == captured_generation
     }
 }
 
@@ -1622,7 +1658,46 @@ mod tests {
             requested: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             result: std::sync::Arc::new(std::sync::Mutex::new(None)),
             owner: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(SCREENSHOT_OWNER_NONE)),
+            generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
+    }
+
+    /// #1603 — a screenshot copy recorded into the renderer staging
+    /// buffer, then cancelled (client `recv_timeout` during an engine
+    /// stall), must NOT be published when its delayed readback finally
+    /// completes — even if a new request has since claimed the bridge
+    /// under the same owner tag. The renderer gates the
+    /// `screenshot_result` write on the capture generation; this pins
+    /// the generation discipline that makes that gate correct.
+    #[test]
+    fn screenshot_cancelled_readback_not_served_to_later_claimant() {
+        let bridge = idle_bridge();
+
+        // Claim A records a copy; the renderer captures the generation.
+        assert!(bridge.try_claim(SCREENSHOT_OWNER_DEBUG_SERVER));
+        let captured_gen = bridge.generation();
+        assert!(
+            bridge.readback_is_current(captured_gen),
+            "uncancelled in-flight capture is current"
+        );
+
+        // Client A times out → drain cancels.
+        bridge.cancel();
+
+        // A new request (claim B) reuses the same owner tag.
+        assert!(bridge.try_claim(SCREENSHOT_OWNER_DEBUG_SERVER));
+
+        // A's straggler readback finally completes. Despite owner being
+        // DEBUG_SERVER again (B's claim), the captured generation is
+        // stale → the renderer must NOT publish A's pixels.
+        assert!(
+            !bridge.readback_is_current(captured_gen),
+            "cancel() must invalidate the pre-cancel capture generation"
+        );
+
+        // B's own capture, recorded after the claim, IS current.
+        let b_gen = bridge.generation();
+        assert!(bridge.readback_is_current(b_gen), "B's fresh capture is current");
     }
 
     /// #1011 — `cancel()` must clear both the AtomicBool `requested`

--- a/crates/renderer/src/vulkan/context/mod.rs
+++ b/crates/renderer/src/vulkan/context/mod.rs
@@ -31,7 +31,7 @@ use ash::vk;
 use gpu_allocator::vulkan as vk_alloc;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 /// Maximum number of skinned-mesh `SkinSlot`s the per-skinned-entity
@@ -860,6 +860,11 @@ pub struct ScreenshotHandle {
     pub requested: Arc<AtomicBool>,
     /// After capture, the PNG bytes are placed here for retrieval.
     pub result: Arc<Mutex<Option<Vec<u8>>>>,
+    /// Monotonic capture generation, shared with `ScreenshotBridge`
+    /// (#1603). The renderer captures it at record time and only
+    /// publishes the PNG if it still matches at readback time, so a
+    /// cancelled-then-resumed straggler is discarded.
+    pub generation: Arc<AtomicU64>,
 }
 
 impl Default for ScreenshotHandle {
@@ -873,6 +878,7 @@ impl ScreenshotHandle {
         Self {
             requested: Arc::new(AtomicBool::new(false)),
             result: Arc::new(Mutex::new(None)),
+            generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -1067,12 +1073,19 @@ pub struct VulkanContext {
     // ── Screenshot capture ──────────────────────────────────────────
     screenshot_requested: Arc<AtomicBool>,
     screenshot_result: Arc<Mutex<Option<Vec<u8>>>>,
+    /// Monotonic capture generation, shared with `ScreenshotBridge` (#1603).
+    /// Captured into `screenshot_pending_readback` at record time; the
+    /// readback only publishes its PNG when this still matches, so a
+    /// capture cancelled mid-flight is not served to a later claimant.
+    screenshot_generation: Arc<AtomicU64>,
     /// Staging buffer for screenshot readback (allocated on first capture).
     screenshot_staging: Option<(vk::Buffer, vk_alloc::Allocation, vk::DeviceSize)>,
-    /// Extent captured at record time; `Some` while the staging buffer holds
-    /// data waiting for the fence.  Stored here (not re-derived from the live
-    /// swapchain) so a same-frame resize cannot corrupt the readback dimensions.
-    screenshot_pending_readback: Option<vk::Extent2D>,
+    /// Extent + capture generation recorded at copy time; `Some` while the
+    /// staging buffer holds data waiting for the fence.  The extent is stored
+    /// here (not re-derived from the live swapchain) so a same-frame resize
+    /// cannot corrupt the readback dimensions (#1448); the generation gates
+    /// publication against an intervening `cancel()` (#1603).
+    screenshot_pending_readback: Option<(vk::Extent2D, u64)>,
 
     frame_sync: FrameSync,
     command_buffers: Vec<vk::CommandBuffer>,
@@ -2406,6 +2419,7 @@ impl VulkanContext {
             skin_first_sight_builds_scratch: Vec::new(),
             screenshot_requested: Arc::new(AtomicBool::new(false)),
             screenshot_result: Arc::new(Mutex::new(None)),
+            screenshot_generation: Arc::new(AtomicU64::new(0)),
             screenshot_staging: None,
             screenshot_pending_readback: None,
         })
@@ -2520,6 +2534,7 @@ impl VulkanContext {
         ScreenshotHandle {
             requested: Arc::clone(&self.screenshot_requested),
             result: Arc::clone(&self.screenshot_result),
+            generation: Arc::clone(&self.screenshot_generation),
         }
     }
 

--- a/crates/renderer/src/vulkan/context/screenshot.rs
+++ b/crates/renderer/src/vulkan/context/screenshot.rs
@@ -20,7 +20,7 @@ impl VulkanContext {
         // record and readback would otherwise read the new dimensions against
         // the old staging copy → wrong size / OOB (SYNC-01). Do not replace
         // this with `self.swapchain_state.extent`.
-        let Some(extent) = self.screenshot_pending_readback.take() else {
+        let Some((extent, captured_generation)) = self.screenshot_pending_readback.take() else {
             return;
         };
 
@@ -58,6 +58,23 @@ impl VulkanContext {
                 log::warn!("Screenshot PNG encode failed: {e}");
                 return;
             }
+        }
+
+        // #1603 — discard a straggler whose claim was cancelled while the
+        // copy sat in the staging buffer. `cancel()` bumps the shared
+        // generation; if it no longer matches the value captured at record
+        // time, publishing these pixels would serve a cancelled capture to
+        // whatever claimant next reads `result` (the same-owner reuse race
+        // `owner` alone can't catch). Drop them; the latch is already
+        // cleared by the `.take()` above.
+        if self.screenshot_generation.load(Ordering::Acquire) != captured_generation {
+            log::debug!(
+                "Screenshot readback discarded (gen {} != captured {}): \
+                 capture was cancelled before readback completed",
+                self.screenshot_generation.load(Ordering::Acquire),
+                captured_generation,
+            );
+            return;
         }
 
         log::info!(
@@ -174,7 +191,14 @@ impl VulkanContext {
             &[barrier_to_present],
         );
 
-        self.screenshot_pending_readback = Some(vk::Extent2D { width, height });
+        // #1603 — tag the recorded copy with the capture generation at
+        // record time. If a `cancel()` bumps the shared generation before
+        // the readback completes (client timed out during an engine
+        // stall), `screenshot_finish_readback` sees the mismatch and
+        // discards the straggler instead of publishing it to a later
+        // claimant.
+        let generation = self.screenshot_generation.load(Ordering::Acquire);
+        self.screenshot_pending_readback = Some((vk::Extent2D { width, height }, generation));
     }
 
     /// Ensure a host-visible staging buffer exists for screenshot readback.


### PR DESCRIPTION
When a debug-server Screenshot request had its copy recorded into the staging buffer (screenshot_pending_readback = Some) but the engine stalled > 5 s before the next draw_frame ran the readback, the client's recv_timeout fired and the drain called ScreenshotBridge::cancel(). cancel() cleared `result` but had no handle on the renderer-private readback latch, so when the engine resumed, screenshot_finish_readback wrote the cancelled capture's PNG into the shared result slot unconditionally. A subsequent request that claimed the bridge then read those stale pixels.

The `owner` tag can't gate this: a new claim reuses the same owner value (DEBUG_SERVER), so an owner check would still publish A's straggler into B's slot. A boolean "discard next" flag is also unsound — if cancel fires when no readback is pending, the flag persists and wrongly kills the next legitimate capture.

Add a monotonic capture generation shared between the renderer (VulkanContext::screenshot_generation, exposed through ScreenshotHandle) and ScreenshotBridge. screenshot_record_copy stamps the current generation into screenshot_pending_readback; screenshot_finish_readback publishes the PNG only when the generation still matches. cancel() bumps the generation, so any capture recorded before the cancel is discarded while captures recorded after are unaffected — each is judged by its own stamp, sidestepping the stale-flag hazard.

Debug/diagnostic only, loopback-only operator surface; no crash or memory unsafety. SIBLING: cancel/owner discipline now spans requested/result/owner/generation consistently. Regression test screenshot_cancelled_readback_not_served_to_later_claimant pins that a cancelled-then-reclaimed capture's stamp is rejected while a fresh one is accepted. byroredux-core suite + full workspace green, zero warnings.