### PR TITLE
Fix #1606: capture the undocumented Starfield BSLightingShaderPropert…

### DIFF
--- a/crates/nif/src/blocks/mod.rs
+++ b/crates/nif/src/blocks/mod.rs
@@ -573,7 +573,9 @@ fn parse_block_inner(
         "TileShaderProperty" => Ok(Box::new(TileShaderProperty::parse(stream)?)),
         "BSShaderNoLightingProperty" => Ok(Box::new(BSShaderNoLightingProperty::parse(stream)?)),
         "BSShaderTextureSet" => Ok(Box::new(BSShaderTextureSet::parse(stream)?)),
-        "BSLightingShaderProperty" => Ok(Box::new(BSLightingShaderProperty::parse(stream)?)),
+        "BSLightingShaderProperty" => Ok(Box::new(BSLightingShaderProperty::parse_with_size(
+            stream, block_size,
+        )?)),
         "BSEffectShaderProperty" => Ok(Box::new(BSEffectShaderProperty::parse(stream)?)),
         "NiMaterialProperty" => Ok(Box::new(NiMaterialProperty::parse(stream)?)),
         "NiAlphaProperty" => Ok(Box::new(NiAlphaProperty::parse(stream)?)),

--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -733,6 +733,44 @@ pub struct BSLightingShaderProperty {
     pub texture_arrays: Vec<BSTextureArray>,
     /// Shader-type-specific trailing fields (env map, skin tint, eye cubemap, etc.).
     pub shader_type_data: ShaderTypeData,
+    /// #1606 — opaque Starfield trailing block. Starfield (bsver ≥ 172)
+    /// full-body `BSLightingShaderProperty` blocks carry a trailing field
+    /// the FO76+ parser doesn't decode: byte-audited over
+    /// `Starfield - LODMeshes.ba2` as **38 B = 9× f32 + 2 B**, byte-identical
+    /// across all 26 LOD instances (`[2.0, 3.0, 0.1, 0.0, 0.02, 0.0289,
+    /// 0.095, 0.003, 1.0, 0x00, 0x00]`), but **undocumented in nif.xml**
+    /// (every tail field there gates on `#FO4#`/`#F76#`). Rather than
+    /// fabricate field names/semantics, the bytes are captured opaquely up
+    /// to `block_size` so they're preserved for a future decoder and the
+    /// stream stays self-consistent. Empty for the 12-B material-reference
+    /// stub and for every non-Starfield variant.
+    pub starfield_tail: Vec<u8>,
+}
+
+/// #1606 — capture the trailing Starfield shader bytes between the
+/// parser's stop point and `block_size`, as an opaque tail. Returns empty
+/// for non-Starfield files, when `block_size` is unknown, or when the
+/// parser already consumed the whole block (no drift). Never over-reads:
+/// it consumes exactly `block_size - consumed`, whatever that is, so it is
+/// correct for any future tail length without assuming the LOD layout.
+fn read_starfield_tail(
+    stream: &mut NifStream,
+    block_start: u64,
+    block_size: Option<u32>,
+    bsver: u32,
+) -> io::Result<Vec<u8>> {
+    if bsver < crate::version::bsver::STARFIELD {
+        return Ok(Vec::new());
+    }
+    let Some(block_size) = block_size else {
+        return Ok(Vec::new());
+    };
+    let consumed = stream.position().saturating_sub(block_start);
+    let remaining = u64::from(block_size).saturating_sub(consumed);
+    if remaining == 0 {
+        return Ok(Vec::new());
+    }
+    stream.read_bytes(remaining as usize)
 }
 
 impl BSLightingShaderProperty {
@@ -780,6 +818,7 @@ impl BSLightingShaderProperty {
             translucency: None,
             texture_arrays: Vec::new(),
             shader_type_data: ShaderTypeData::None,
+            starfield_tail: Vec::new(),
         }
     }
 }
@@ -807,14 +846,29 @@ impl BSLightingShaderProperty {
     /// `m_kind%` / `metO%` fill-rates printed by the
     /// `translation_completeness --ignored` harness within ±2pp.
     pub fn parse(stream: &mut NifStream) -> io::Result<Self> {
+        Self::parse_with_size(stream, None)
+    }
+
+    /// As [`parse`](Self::parse), but with the block's declared
+    /// `block_size` so the Starfield trailing block (#1606) can be
+    /// captured opaquely up to the block boundary. The dispatcher passes
+    /// `Some(block_size)`; the legacy `parse(stream)` entry passes `None`
+    /// (no tail capture — drift recovery handles it as before).
+    pub fn parse_with_size(
+        stream: &mut NifStream,
+        block_size: Option<u32>,
+    ) -> io::Result<Self> {
+        let block_start = stream.position();
         let bsver = stream.bsver();
-        if bsver >= crate::version::bsver::FO76 {
-            Self::parse_fo76_plus(stream, bsver)
+        let mut me = if bsver >= crate::version::bsver::FO76 {
+            Self::parse_fo76_plus(stream, bsver)?
         } else if bsver >= crate::version::bsver::FALLOUT4 {
-            Self::parse_fo4(stream, bsver)
+            Self::parse_fo4(stream, bsver)?
         } else {
-            Self::parse_skyrim(stream, bsver)
-        }
+            Self::parse_skyrim(stream, bsver)?
+        };
+        me.starfield_tail = read_starfield_tail(stream, block_start, block_size, bsver)?;
+        Ok(me)
     }
 
     /// Skyrim LE/SE parser (BSVER 83-129).
@@ -888,6 +942,7 @@ impl BSLightingShaderProperty {
             translucency: None,
             texture_arrays: Vec::new(),
             shader_type_data,
+            starfield_tail: Vec::new(),
         })
     }
 
@@ -1014,6 +1069,7 @@ impl BSLightingShaderProperty {
             translucency: None,
             texture_arrays: Vec::new(),
             shader_type_data,
+            starfield_tail: Vec::new(),
         })
     }
 
@@ -1192,6 +1248,7 @@ impl BSLightingShaderProperty {
             translucency,
             texture_arrays,
             shader_type_data,
+            starfield_tail: Vec::new(),
         })
     }
 

--- a/crates/nif/src/blocks/shader_tests.rs
+++ b/crates/nif/src/blocks/shader_tests.rs
@@ -1565,6 +1565,64 @@ fn parse_bs_lighting_starfield_minimal_omits_fo76_only_tail() {
     assert!(matches!(prop.shader_type_data, ShaderTypeData::None));
 }
 
+/// #1606 — Starfield full-body `BSLightingShaderProperty` carries a
+/// trailing block (byte-audited as 38 B = 9× f32 + 2 B, constant across
+/// the 26 LODMeshes instances) that the FO76+ parser doesn't decode and
+/// nif.xml doesn't document. `parse_with_size` captures it opaquely up to
+/// `block_size` so the stream is self-consistent (no +38 drift) and the
+/// bytes survive for a future decoder.
+#[test]
+fn parse_bs_lighting_starfield_captures_trailing_tail() {
+    let header = make_starfield_header(""); // empty name → full-body path
+    let body = build_starfield_bs_lighting_minimal();
+    // Real layout is 9 f32 + 2 B; pin an arbitrary-but-distinct 38 B so we
+    // assert capture without asserting (unknown) semantics.
+    let tail: Vec<u8> = (0u8..38).collect();
+    let mut data = body.clone();
+    data.extend_from_slice(&tail);
+    let block_size = data.len() as u32;
+
+    let mut stream = NifStream::new(&data, &header);
+    let prop = BSLightingShaderProperty::parse_with_size(&mut stream, Some(block_size))
+        .expect("Starfield full body + tail must parse");
+    assert_eq!(
+        prop.starfield_tail, tail,
+        "the trailing block_size bytes are captured opaquely",
+    );
+    assert_eq!(
+        stream.position(),
+        data.len() as u64,
+        "tail capture consumes exactly to block_size — no drift",
+    );
+    // Body fields still decode unchanged.
+    assert!(prop.wetness.is_some());
+    assert!(matches!(prop.shader_type_data, ShaderTypeData::None));
+}
+
+/// #1606 — the tail is captured ONLY when a `block_size` is supplied and
+/// there are trailing bytes. The legacy `parse(stream)` entry (no size)
+/// and a block that consumed exactly to its boundary both yield an empty
+/// tail — drift recovery continues to handle the no-size case as before.
+#[test]
+fn parse_bs_lighting_starfield_tail_empty_without_size_or_drift() {
+    let header = make_starfield_header("");
+    let body = build_starfield_bs_lighting_minimal();
+
+    // (a) legacy parse(stream): no block_size → no tail capture.
+    let mut s1 = NifStream::new(&body, &header);
+    let p1 = BSLightingShaderProperty::parse(&mut s1).unwrap();
+    assert!(p1.starfield_tail.is_empty(), "no block_size → no tail capture");
+
+    // (b) parse_with_size with the exact body size (no trailing bytes).
+    let mut s2 = NifStream::new(&body, &header);
+    let p2 =
+        BSLightingShaderProperty::parse_with_size(&mut s2, Some(body.len() as u32)).unwrap();
+    assert!(
+        p2.starfield_tail.is_empty(),
+        "consumed == block_size → empty tail",
+    );
+}
+
 /// #1510 — Starfield material references are content-hash paths with NO
 /// `.mat`/`.bgsm` suffix, so `is_material_reference` misses them. For
 /// BSVER >= STARFIELD a non-empty Name means a reference (full bodies

--- a/crates/nif/src/import/material/double_sided_tests.rs
+++ b/crates/nif/src/import/material/double_sided_tests.rs
@@ -111,6 +111,7 @@ fn make_bs_lighting_with_flags(flags1: u32, flags2: u32) -> BSLightingShaderProp
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/material/emissive_source_tests.rs
+++ b/crates/nif/src/import/material/emissive_source_tests.rs
@@ -116,6 +116,7 @@ fn minimal_bslighting() -> BSLightingShaderProperty {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/material/lighting_shader_mat_tests.rs
+++ b/crates/nif/src/import/material/lighting_shader_mat_tests.rs
@@ -61,6 +61,7 @@ fn lighting_shader_with_name(name: &str) -> BSLightingShaderProperty {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/material/lighting_shader_pbr_tests.rs
+++ b/crates/nif/src/import/material/lighting_shader_pbr_tests.rs
@@ -85,6 +85,7 @@ fn bslsp_with_pbr_scalars(
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/material/texture_slot_3_4_5_tests.rs
+++ b/crates/nif/src/import/material/texture_slot_3_4_5_tests.rs
@@ -286,6 +286,7 @@ fn bs_lighting_shader_populates_parallax_env_slots() {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     };
     let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(shader), Box::new(tex_set)];
     let scene = NifScene {
@@ -472,6 +473,7 @@ fn bs_lighting_shader_uv_transform_blocks_later_ni_texturing_property() {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     };
     let tex = NiTexturingProperty {
         net: empty_net(),
@@ -722,6 +724,7 @@ fn skin_tint_lighting_shader() -> BSLightingShaderProperty {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 
@@ -918,6 +921,7 @@ fn lighting_shader_with_type_and_texset(
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/material/vertex_color_precedence_tests.rs
+++ b/crates/nif/src/import/material/vertex_color_precedence_tests.rs
@@ -74,6 +74,7 @@ fn lighting_shader() -> BSLightingShaderProperty {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/mesh/material_path_capture_tests.rs
+++ b/crates/nif/src/import/mesh/material_path_capture_tests.rs
@@ -56,6 +56,7 @@ fn minimal_lighting_shader_named(name: &str) -> BSLightingShaderProperty {
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
     }
 }
 

--- a/crates/nif/src/import/mesh/shader_type_fields_tests.rs
+++ b/crates/nif/src/import/mesh/shader_type_fields_tests.rs
@@ -53,6 +53,7 @@ fn lighting_shader_with(shader_type: u32, data: ShaderTypeData) -> BSLightingSha
         translucency: None,
         texture_arrays: Vec::new(),
         shader_type_data: data,
+        starfield_tail: Vec::new(),
     }
 }
 


### PR DESCRIPTION
…y tail

Starfield (bsver >= 172) full-body BSLightingShaderProperty blocks carry a trailing field the FO76+ parser doesn't decode: 26 LOD instances under-read their block_size by 38 bytes, absorbed by block_size drift recovery (0 NiUnknown) but silently dropped.

Byte-audited over the live `Starfield - LODMeshes.ba2` (bsver 173): the tail is exactly 38 B = 9x f32 + 2 B and is byte-IDENTICAL across all 26 instances ([2.0, 3.0, 0.1, 0.0, 0.02, 0.0289, 0.095, 0.003, 1.0, 00 00]). The reference nif.xml does NOT document any Starfield tail here — every BSLightingShaderProperty/BSSPWetnessParams trailing field gates on #FO4#/#F76#. The 12-byte "stripped" variant (48,877 instances) is the material-reference stub (CDB material); only the empty-name full-body form carries the tail, and it appears LOD-baked (none found sampling the main Meshes02 archive).

Rather than fabricate field names/semantics for an undocumented block, capture it OPAQUELY: add `BSLightingShaderProperty::parse_with_size` (the dispatcher passes the declared block_size; the legacy `parse` entry passes None and is unchanged) which, after the existing per-bsver parse, reads `block_size - consumed` trailing bytes into a new `starfield_tail: Vec<u8>` — gated on `bsver >= STARFIELD`. Reading to block_size (not a hardcoded 38) is correct for any future tail length and can't over-read. The bytes are preserved for a future decoder and the stream becomes self-consistent: drift on LODMeshes drops from +38x26 to zero (verified against live data).

SIBLING: the same sweep confirmed BSEffectShaderProperty under-reads +32x48 on the same archive — same pattern, left for a focused follow-up (this change is scoped to the BSLightingShaderProperty of the issue).

Tests: parse_bs_lighting_starfield_captures_trailing_tail pins opaque capture + exact-to-block_size consumption; ..._tail_empty_without_size_ or_drift pins that the legacy no-size path and a no-trailing-bytes block both yield an empty tail. Full byroredux-nif suite + workspace green, zero warnings.