### PR TITLE
Fix #1619: serialise audit-runtime; document per-game debug port for …

### DIFF
--- a/.claude/commands/audit-runtime/SKILL.md
+++ b/.claude/commands/audit-runtime/SKILL.md
@@ -134,7 +134,18 @@ For each selected `(game, cell)`:
 
 6. Tear down: `kill -INT $PID; sleep 2; kill -9 $PID; wait $PID`.
 
-Up to 4 games run in parallel (Xvfb auto-display lets them coexist).
+Run games **serially** — one engine + `byro-dbg` capture at a time. The
+debug server binds a single fixed TCP port (`BYRO_DEBUG_PORT`, default
+`9876`) with **no rebind/retry** (`crates/debug-server/src/listener.rs`), so
+two engines launched in parallel collide: the second logs `failed to bind
+port 9876: Address already in use`, its telemetry is unreachable for the
+whole run, and the capture silently mis-attributes the first game's numbers
+to the second (RT-1 / #1619). Serial is the contract this audit assumes.
+
+To parallelise anyway, give **each** concurrent game a distinct port —
+export `BYRO_DEBUG_PORT=$((9876 + i))` for **both** the engine launch and
+its `byro-dbg` capture (both honour the env var). Without that per-game
+offset, do not run them concurrently.
 
 > **Where each metric lives.** The bench scalars (`wall_fps`, `draws=N/Mb/Kc`,
 > `entities=`) are on the single `bench:` line printed at `--bench-frames` exit


### PR DESCRIPTION
…parallel

The audit-runtime skill told operators "Up to 4 games run in parallel (Xvfb auto-display lets them coexist)", but the debug server binds a single fixed TCP port (BYRO_DEBUG_PORT, default 9876) with no rebind or retry (crates/debug-server/src/listener.rs). Two engines launched in parallel collide: the second logs "failed to bind port 9876: Address already in use", its byro-dbg telemetry is unreachable for the whole run, and the capture silently attributes the first game's numbers to the second (the 2026-06-01 mis-attribution failure mode).

Replace the parallel claim with the serial-run contract this audit assumes, and document the safe way to parallelise: export BYRO_DEBUG_PORT=$((9876 + i)) for both the engine launch and its byro-dbg capture (both already honour the env var) so each concurrent game gets a distinct port.

SIBLING: the debug server is the only fixed-port bind in the tree; the engine (main.rs) and byro-dbg both read BYRO_DEBUG_PORT, so the per-game offset is the complete fix with no engine code change. TESTS: the serial-run contract is now pinned in the skill text.