### PR TITLE
Fix #1592: consume FO4 NIF model-space-normals + alpha-test shader flags

### DIFF
--- a/crates/nif/src/import/material/fo4_shader_flag_tests.rs
+++ b/crates/nif/src/import/material/fo4_shader_flag_tests.rs
@@ -1,0 +1,159 @@
+//! #1592 (FO4-D5-MEDIUM-01) — FO4 `BSLightingShaderProperty` shader-flag
+//! bits OR'd into `MaterialInfo` at import.
+//!
+//! For an FO4 (BSVER >= 130) `BSLightingShaderProperty` the walker now
+//! consumes `F4SF1::Model_Space_Normals` and `F4SF2::Alpha_Test` (plus the
+//! FO76+ `MODELSPACENORMALS` CRC) when no companion BGSM overrides them.
+//! The capture is gated on the FO4 BSVER so a Skyrim property — same block,
+//! different flag vocabulary — isn't read with FO4 semantics (`F4SF2` bit
+//! 25 is not alpha-test on Skyrim, which routes that via `NiAlphaProperty`).
+
+use super::*;
+use crate::blocks::base::{NiAVObjectData, NiObjectNETData};
+use crate::blocks::shader::{BSLightingShaderProperty, ShaderTypeData};
+use crate::blocks::tri_shape::NiTriShape;
+use crate::blocks::NiObject;
+use crate::shader_flags::{bs_shader_crc32, fo4_slsf1, fo4_slsf2};
+use crate::types::{BlockRef, NiTransform};
+use crate::version::bsver;
+use byroredux_core::string::StringPool;
+
+fn empty_net() -> NiObjectNETData {
+    NiObjectNETData {
+        name: None,
+        extra_data_refs: Vec::new(),
+        controller_ref: BlockRef::NULL,
+    }
+}
+
+fn make_bslsp(flags1: u32, flags2: u32, sf1_crcs: Vec<u32>) -> BSLightingShaderProperty {
+    BSLightingShaderProperty {
+        shader_type: 0,
+        net: empty_net(),
+        material_reference: false,
+        shader_flags_1: flags1,
+        shader_flags_2: flags2,
+        sf1_crcs,
+        sf2_crcs: Vec::new(),
+        uv_offset: [0.0, 0.0],
+        uv_scale: [1.0, 1.0],
+        texture_set_ref: BlockRef::NULL,
+        emissive_color: [0.0; 3],
+        emissive_multiple: 1.0,
+        root_material_path: None,
+        texture_clamp_mode: 0,
+        alpha: 1.0,
+        refraction_strength: 0.0,
+        glossiness: 80.0,
+        specular_color: [1.0; 3],
+        specular_strength: 1.0,
+        lighting_effect_1: 0.0,
+        lighting_effect_2: 0.0,
+        subsurface_rolloff: 0.0,
+        rimlight_power: 0.0,
+        backlight_power: 0.0,
+        grayscale_to_palette_scale: 0.0,
+        fresnel_power: 0.0,
+        wetness: None,
+        luminance: None,
+        do_translucency: false,
+        translucency: None,
+        texture_arrays: Vec::new(),
+        shader_type_data: ShaderTypeData::None,
+        starfield_tail: Vec::new(),
+    }
+}
+
+/// Shape carrying the shader via `shader_property_ref` (the Skyrim+/FO4
+/// attach path), not the inherited `properties` list.
+fn shape_with_shader_ref(ref_idx: u32) -> NiTriShape {
+    NiTriShape {
+        av: NiAVObjectData {
+            net: empty_net(),
+            flags: 0,
+            transform: NiTransform::default(),
+            properties: Vec::new(),
+            collision_ref: BlockRef::NULL,
+        },
+        data_ref: BlockRef::NULL,
+        skin_instance_ref: BlockRef::NULL,
+        shader_property_ref: BlockRef(ref_idx),
+        alpha_property_ref: BlockRef::NULL,
+        num_materials: 0,
+        active_material_index: 0,
+    }
+}
+
+fn extract(shader: BSLightingShaderProperty, bsver_val: u32) -> MaterialInfo {
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(shader)];
+    let scene = NifScene {
+        blocks,
+        bsver: bsver_val,
+        ..NifScene::default()
+    };
+    let shape = shape_with_shader_ref(0);
+    let mut pool = StringPool::new();
+    extract_material_info(&scene, &shape, &[], &mut pool)
+}
+
+/// FO4 BSVER + `F4SF1::Model_Space_Normals` → `model_space_normals`.
+/// Pre-fix the bit was parsed but never consumed (BGSM-only path).
+#[test]
+fn fo4_model_space_normals_flag_sets_field() {
+    let shader = make_bslsp(fo4_slsf1::MODEL_SPACE_NORMALS, 0, Vec::new());
+    let info = extract(shader, bsver::FALLOUT4);
+    assert!(
+        info.model_space_normals,
+        "FO4 F4SF1 bit 12 must OR model_space_normals into MaterialInfo (#1592)"
+    );
+    assert!(!info.alpha_test, "alpha-test bit was not set");
+}
+
+/// FO4 BSVER + `F4SF2::Alpha_Test` → `alpha_test`. The NiAlphaProperty
+/// path is absent here, so the shader flag is the only signal.
+#[test]
+fn fo4_alpha_test_flag_sets_field() {
+    let shader = make_bslsp(0, fo4_slsf2::ALPHA_TEST, Vec::new());
+    let info = extract(shader, bsver::FALLOUT4);
+    assert!(
+        info.alpha_test,
+        "FO4 F4SF2 bit 25 must OR alpha_test into MaterialInfo (#1592)"
+    );
+    assert!(!info.model_space_normals, "MSN bit was not set");
+}
+
+/// The gate is exclusive: a Skyrim (BSVER 100) property with the SAME
+/// numeric bits set must NOT pick up FO4 semantics. On Skyrim F4SF2 bit 25
+/// is not alpha-test (routed via NiAlphaProperty) — reading it here would
+/// spuriously cut out opaque Skyrim meshes.
+#[test]
+fn skyrim_bsver_does_not_read_fo4_f2_alpha_test() {
+    let shader = make_bslsp(0, fo4_slsf2::ALPHA_TEST, Vec::new());
+    let info = extract(shader, bsver::SKYRIM_SE);
+    assert!(
+        !info.alpha_test,
+        "Skyrim BSVER must not read F4SF2 bit 25 as alpha-test (#1592 gate)"
+    );
+}
+
+/// FO4 BSVER with no shader flags set leaves both at their defaults — the
+/// capture is additive, never fabricated.
+#[test]
+fn fo4_no_flags_leaves_defaults() {
+    let info = extract(make_bslsp(0, 0, Vec::new()), bsver::FALLOUT4);
+    assert!(!info.model_space_normals);
+    assert!(!info.alpha_test);
+}
+
+/// FO76 / Starfield (BSVER >= 132) store the typed flag words as zero and
+/// carry the identifiers in the CRC arrays instead. The MODELSPACENORMALS
+/// CRC on `sf1_crcs` must still set `model_space_normals`.
+#[test]
+fn fo76_crc_model_space_normals_sets_field() {
+    let shader = make_bslsp(0, 0, vec![bs_shader_crc32::MODELSPACENORMALS]);
+    let info = extract(shader, bsver::FO76);
+    assert!(
+        info.model_space_normals,
+        "FO76+ MODELSPACENORMALS CRC must OR model_space_normals (#1592)"
+    );
+}

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -499,6 +499,14 @@ pub(super) struct MaterialInfo {
     pub alpha_property_consumed: bool,
     pub two_sided: bool,
     pub is_decal: bool,
+    /// Object/model-space normal map (vs the default tangent-space). Set
+    /// from the FO4 `F4SF1::Model_Space_Normals` shader-flag bit (or the
+    /// FO76+ CRC) on `BSLightingShaderProperty` when no BGSM overrides it —
+    /// vanilla FO4 sources this from the `.bgsm` (authoritative), so this
+    /// only fires for inline / modded NIFs with no material file. Flows to
+    /// `ImportedMesh::model_space_normals`, where the BGSM merge can still
+    /// upgrade it (OR semantics). See #1592 / FO4-D5-MEDIUM-01.
+    pub model_space_normals: bool,
     pub emissive_color: [f32; 3],
     pub emissive_mult: f32,
     /// Provenance of `emissive_mult` — disambiguates the three NIF
@@ -946,6 +954,7 @@ impl Default for MaterialInfo {
             alpha_property_consumed: false,
             two_sided: false,
             is_decal: false,
+            model_space_normals: false,
             emissive_color: [0.0, 0.0, 0.0],
             emissive_mult: 0.0,
             emissive_source: byroredux_core::ecs::components::material::EmissiveSource::None,
@@ -1176,6 +1185,12 @@ mod texture_slot_3_4_5_tests;
 /// unaffected.
 #[cfg(test)]
 mod double_sided_tests;
+
+/// Regression tests for #1592 (FO4-D5-MEDIUM-01) — FO4 `BSLightingShaderProperty`
+/// shader-flag bits (model-space-normals / alpha-test) OR'd into MaterialInfo,
+/// gated on the FO4 BSVER so a Skyrim property isn't read with FO4 semantics.
+#[cfg(test)]
+mod fo4_shader_flag_tests;
 
 /// Regression tests for #337 (D4-NEW-01) — `NiStencilProperty` test
 /// state must round-trip into `MaterialInfo.stencil_state` so the

--- a/crates/nif/src/import/material/walker.rs
+++ b/crates/nif/src/import/material/walker.rs
@@ -304,6 +304,40 @@ pub(crate) fn extract_material_info_from_refs(
             ) {
                 info.is_decal = true;
             }
+            // #1592 — FO4 NIF shader-flag bits the BGSM merge can't see on
+            // inline / modded content. `BSLightingShaderProperty` is shared
+            // with Skyrim under a *different* bit vocabulary, so gate on
+            // `bsver >= FALLOUT4`: F4SF2 bit 25 (`Alpha_Test`) and bit 6
+            // (`Glow_Map`) mean other things on Skyrim, which routes
+            // alpha-test through `NiAlphaProperty` instead. These are a
+            // LOWER-priority source than the BGSM merge — vanilla FO4 leaves
+            // them unset and sources the same attributes from the `.bgsm`
+            // (authoritative); `asset_provider`'s BGSM merge OR-upgrades, so
+            // vanilla content is unchanged. See FO4-D5-MEDIUM-01.
+            if scene.bsver >= crate::version::bsver::FALLOUT4 {
+                use crate::shader_flags::bs_shader_crc32::{contains_any, MODELSPACENORMALS};
+                // Model-space normals — F4SF1 bit 12 (same position on
+                // Skyrim, but kept FO4-gated to leave the validated Skyrim
+                // path untouched) OR the FO76/Starfield CRC. Drives the MSN
+                // normal-decode branch via `ImportedMesh::model_space_normals`.
+                if shader.shader_flags_1 & crate::shader_flags::fo4_slsf1::MODEL_SPACE_NORMALS
+                    != 0
+                    || contains_any(&shader.sf1_crcs, &[MODELSPACENORMALS])
+                    || contains_any(&shader.sf2_crcs, &[MODELSPACENORMALS])
+                {
+                    info.model_space_normals = true;
+                }
+                // Alpha-test cutout — F4SF2 bit 25 (FO4-only; nif.xml lists
+                // no CRC identifier, and the typed field is zero on
+                // BSVER >= 132, so this is a no-op for FO76+). The
+                // `NiAlphaProperty` path already covers meshes that ship one
+                // (it sets the threshold/func); this catches inline FO4 NIFs
+                // that signal cutout via the shader flag alone, where the
+                // GREATEREQUAL/default threshold stands in.
+                if shader.shader_flags_2 & crate::shader_flags::fo4_slsf2::ALPHA_TEST != 0 {
+                    info.alpha_test = true;
+                }
+            }
             // Capture rich material data.
             info.emissive_color = shader.emissive_color;
             info.emissive_mult = shader.emissive_multiple;

--- a/crates/nif/src/import/mesh/bs_geometry.rs
+++ b/crates/nif/src/import/mesh/bs_geometry.rs
@@ -246,7 +246,10 @@ pub fn extract_bs_geometry(
         // downstream by `merge_bgsm_into_mesh` from BgsmFile.
         is_pbr: false,
         has_translucency: false,
-        model_space_normals: false,
+        // #1592 — now also sourced from the FO4 `F4SF1::Model_Space_Normals`
+        // shader flag in the material walker; `merge_bgsm_into_mesh` still
+        // OR-upgrades it from the `.bgsm` (authoritative for vanilla).
+        model_space_normals: mat.model_space_normals,
         from_bgsm: false,
         bgem_glass: false,
         // Stage 2 — legacy PBR translation; BGSM merge overwrites

--- a/crates/nif/src/import/mesh/bs_tri_shape.rs
+++ b/crates/nif/src/import/mesh/bs_tri_shape.rs
@@ -239,7 +239,10 @@ pub fn extract_bs_tri_shape(
         // downstream by `merge_bgsm_into_mesh` from BgsmFile.
         is_pbr: false,
         has_translucency: false,
-        model_space_normals: false,
+        // #1592 — now also sourced from the FO4 `F4SF1::Model_Space_Normals`
+        // shader flag in the material walker; `merge_bgsm_into_mesh` still
+        // OR-upgrades it from the `.bgsm` (authoritative for vanilla).
+        model_space_normals: mat.model_space_normals,
         from_bgsm: false,
         bgem_glass: false,
         // Stage 2 — legacy PBR translation. BGSM merge overwrites for

--- a/crates/nif/src/import/mesh/ni_tri_shape.rs
+++ b/crates/nif/src/import/mesh/ni_tri_shape.rs
@@ -238,7 +238,10 @@ pub fn extract_mesh(
         // downstream by `merge_bgsm_into_mesh` from BgsmFile.
         is_pbr: false,
         has_translucency: false,
-        model_space_normals: false,
+        // #1592 — now also sourced from the FO4 `F4SF1::Model_Space_Normals`
+        // shader flag in the material walker; `merge_bgsm_into_mesh` still
+        // OR-upgrades it from the `.bgsm` (authoritative for vanilla).
+        model_space_normals: mat.model_space_normals,
         from_bgsm: false,
         bgem_glass: false,
         // Stage 2 — legacy PBR translation. BGSM merge overwrites for

--- a/crates/nif/src/lib.rs
+++ b/crates/nif/src/lib.rs
@@ -764,6 +764,7 @@ pub fn parse_nif_with_options(data: &[u8], options: &ParseOptions) -> io::Result
         drift_histogram: scene_drift_histogram,
         stubbed_drift_histogram: scene_stubbed_drift_histogram,
         havok_scale: havok_scale_for(&header),
+        bsver: header.user_version_2,
     };
     // Opt-in dangling-ref walk (#892). Off by default; debug builds,
     // `nif_stats`, and integration sweeps flip

--- a/crates/nif/src/scene.rs
+++ b/crates/nif/src/scene.rs
@@ -112,6 +112,16 @@ pub struct NifScene {
     /// surfaced this as "character falls forever, KCC never finds a
     /// floor."
     pub havok_scale: f32,
+    /// The file's `BSVER` (`NifHeader.user_version_2`), retained so
+    /// post-parse consumers can make game-era decisions the raw block data
+    /// no longer carries. `BSLightingShaderProperty` is shared between
+    /// Skyrim (bsver 83/100) and FO4 (130/131) with *different* shader-flag
+    /// bit vocabularies, so the material walker gates FO4-only F4SF2 bits
+    /// (alpha-test, glow) on `bsver >= bsver::FALLOUT4` — without this it
+    /// would read a Skyrim property with FO4 semantics. See #1592 /
+    /// FO4-D5-MEDIUM-01. `0` for `NifScene::default()` (no header) — below
+    /// every real game's bsver, so flag-gating defaults to off in fixtures.
+    pub bsver: u32,
 }
 
 impl Default for NifScene {
@@ -130,6 +140,10 @@ impl Default for NifScene {
             // pre-#1230 behaviour, so any test that didn't care about
             // the scale before continues to not care.
             havok_scale: 7.0,
+            // No header → bsver 0, below every real game's bsver, so the
+            // FO4 shader-flag gate in the material walker stays off for
+            // header-less test fixtures.
+            bsver: 0,
         }
     }
 }
@@ -363,6 +377,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         assert!(scene.validate_refs().is_empty());
     }
@@ -384,6 +399,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         assert!(scene.validate_refs().is_empty());
     }
@@ -402,6 +418,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         let errs = scene.validate_refs();
         assert_eq!(errs.len(), 1);
@@ -428,6 +445,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         let errs = scene.validate_refs();
         assert_eq!(errs.len(), 2);
@@ -452,6 +470,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         let errs = scene.validate_refs();
         assert_eq!(errs.len(), 1);
@@ -472,6 +491,7 @@ mod validate_refs_tests {
             drift_histogram: BTreeMap::new(),
             stubbed_drift_histogram: BTreeMap::new(),
             havok_scale: 7.0,
+            bsver: 0,
         };
         let errs = scene.validate_refs();
         assert_eq!(errs.len(), 1);

--- a/crates/nif/src/tests.rs
+++ b/crates/nif/src/tests.rs
@@ -119,6 +119,7 @@ fn nif_scene_struct_carries_truncated_field() {
         drift_histogram: std::collections::BTreeMap::new(),
         stubbed_drift_histogram: std::collections::BTreeMap::new(),
         havok_scale: 7.0,
+        bsver: 0,
     };
     assert!(scene.truncated);
     assert_eq!(scene.dropped_block_count, 3);


### PR DESCRIPTION
For an FO4 BSLightingShaderProperty the parser reads the full F4SF1/F4SF2 pair, but the material walker only consumed decal/two-sided/effect bits. Three render-affecting FO4 bits were parsed-but-dropped: Model_Space_Normals (F4SF1 bit 12), Alpha_Test (F4SF2 bit 25), Glow_Map (F4SF2 bit 6). Vanilla FO4 is BGSM-backed (authoritative), so this only bites inline / loose / modded FO4 NIFs that set the bits and ship no BGSM — an object-space normal map decoded as tangent-space, or an inline cutout rendering opaque.

The walker now ORs Model_Space_Normals and Alpha_Test into MaterialInfo (plus the FO76+ MODELSPACENORMALS CRC for bsver >= 132). Because the NIF import runs before the BGSM merge — which OR-upgrades these fields (asset_provider) — the NIF flag is a strictly lower-priority source: vanilla BGSM-backed content is unchanged.

Critically the capture is gated on the FO4 BSVER. BSLightingShaderProperty is shared with Skyrim under a different flag vocabulary: F4SF2 bit 25 is not alpha-test on Skyrim (which routes that through NiAlphaProperty) and bit 6 is not its glow signal. Reading a Skyrim property with FO4 semantics would spuriously cut out opaque meshes, so the gate (bsver >= FALLOUT4) keeps the validated Skyrim path untouched. To carry the era past parse, NifScene now retains the file's bsver (user_version_2).

Glow_Map is intentionally not wired: the glow texture is already captured from texture-set slot 2 and emissive_source is already Lighting for every BSLightingShaderProperty, so the flag has no orthogonal field in the current material model — wiring it would be dead state.

model_space_normals gains a MaterialInfo field routed into all three mesh builders (BSTriShape / BSGeometry / NiTriShape); alpha_test was already plumbed. Five regression tests pin the FO4 capture, the Skyrim exclusion, the FO76 CRC path, and the no-fabrication default.