### PR TITLE
fix(renderer): correct AS-build-input + composite loadOp sync hazards

### DIFF
--- a/crates/renderer/src/vulkan/acceleration/tlas.rs
+++ b/crates/renderer/src/vulkan/acceleration/tlas.rs
@@ -708,10 +708,16 @@ impl AccelerationManager {
                 &[copy_region],
             );
 
-            // Barrier 2: transfer write → AS build read on the device-local buffer.
+            // Barrier 2: transfer write → AS build INPUT read on the
+            // device-local buffer. AS-build input buffers (instance data here,
+            // and vertex/index elsewhere) are read with SHADER_READ at the
+            // AS_BUILD stage per the Vulkan spec — NOT ACCELERATION_STRUCTURE_
+            // READ_KHR, which is for reading an acceleration STRUCTURE itself.
+            // Synchronization validation flags the latter as a copy→build RAW
+            // hazard on the instance buffer. #1436.
             let transfer_to_as = vk::BufferMemoryBarrier::default()
                 .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
-                .dst_access_mask(vk::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ)
                 .buffer(tlas.instance_buffer_device.buffer)
                 .offset(0)
                 .size(copy_size);

--- a/crates/renderer/src/vulkan/composite.rs
+++ b/crates/renderer/src/vulkan/composite.rs
@@ -443,7 +443,20 @@ impl CompositePipeline {
             .src_access_mask(
                 vk::AccessFlags::COLOR_ATTACHMENT_WRITE | vk::AccessFlags::SHADER_WRITE,
             )
-            .dst_stage_mask(vk::PipelineStageFlags::FRAGMENT_SHADER)
+            // FRAGMENT_SHADER covers composite.frag's input sampling;
+            // COLOR_ATTACHMENT_OUTPUT covers the attachment loadOp itself.
+            // The colour attachment is `initial_layout = UNDEFINED` +
+            // `LOAD_OP_DONT_CARE`, so this EXTERNAL→0 dependency is what
+            // synchronizes the swapchain image's UNDEFINED→COLOR_ATTACHMENT
+            // layout transition. A DONT_CARE loadOp is itself a
+            // COLOR_ATTACHMENT_WRITE at COLOR_ATTACHMENT_OUTPUT; without that
+            // stage/access in the dst scope, the loadOp write races the
+            // layout transition this dependency drives — the sync-val
+            // WRITE_AFTER_WRITE flagged on the composite swapchain image.
+            .dst_stage_mask(
+                vk::PipelineStageFlags::FRAGMENT_SHADER
+                    | vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+            )
             // #963 / REN-D10-NEW-06 — enumerate UNIFORM_READ alongside
             // SHADER_READ so the render-pass dep documents (and
             // independently covers) composite.frag's read of the
@@ -454,9 +467,14 @@ impl CompositePipeline {
             // defence-in-depth so the dep accurately reflects the
             // consumer access pattern and a future #909
             // revert/restructure can't silently strand the
-            // dependency. Purely additive — widens the access mask,
-            // never narrows.
-            .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::UNIFORM_READ);
+            // dependency. COLOR_ATTACHMENT_WRITE orders the DONT_CARE
+            // loadOp after the layout transition. Purely additive —
+            // widens the access mask, never narrows.
+            .dst_access_mask(
+                vk::AccessFlags::SHADER_READ
+                    | vk::AccessFlags::UNIFORM_READ
+                    | vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+            );
 
         // Outgoing dependency: ensure swapchain write finishes before present.
         //

--- a/crates/renderer/src/vulkan/context/draw.rs
+++ b/crates/renderer/src/vulkan/context/draw.rs
@@ -1165,15 +1165,16 @@ impl VulkanContext {
         //     Final AS_BUILD_WRITE → AS_BUILD_INPUT_READ barrier hands
         //     fresh BLAS to TLAS below.
         //
-        // #661 / SY-4 / #1436 (VKC-007): the COMPUTE→AS_BUILD barriers
-        // below use `ACCELERATION_STRUCTURE_READ_KHR` because that is
-        // what sync1 (`cmd_pipeline_barrier`) exposes. The semantically
-        // correct flag for "read vertex/index data as AS build inputs" is
-        // `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR`; on every
-        // shipping driver today the two are aliased so the sync1 form is
-        // equivalent. When the renderer migrates to sync2 / `cmd_pipeline_
-        // barrier2` (#bench-gate TBD), every COMPUTE→AS_BUILD dst_access
-        // should switch to the more-specific flag (#1436).
+        // #661 / SY-4 / #1436 (VKC-007): AS-build INPUT reads (the skinned
+        // vertex output fed to the BLAS build) use `SHADER_READ` at the
+        // AS_BUILD stage — the access the Vulkan spec assigns to build inputs.
+        // Reading an acceleration STRUCTURE — a BLAS during the TLAS build, or
+        // the TLAS during a ray query — is the separate
+        // `ACCELERATION_STRUCTURE_READ_KHR`, retained on those barriers.
+        // The earlier `ACCELERATION_STRUCTURE_READ_KHR`-for-inputs form was a
+        // sync1 shortcut on the assumption the two flags were aliased;
+        // synchronization validation disproved it (a compute/copy→build RAW
+        // hazard on the input buffer), so input barriers now carry SHADER_READ.
         //
         // Skips entirely when `skin_compute` / `accel_manager` are None
         // (no RT) or no draws are skinned.
@@ -1486,14 +1487,17 @@ impl VulkanContext {
                             // and the refit loop further down — both
                             // read the freshly-written output buffers
                             // as BLAS-build vertex input.
-                            // COMPUTE_SHADER → ACCELERATION_STRUCTURE_BUILD_KHR
+                            // COMPUTE_SHADER → ACCELERATION_STRUCTURE_BUILD_KHR.
+                            // Skinned vertex output is a BLAS-build INPUT, so the
+                            // dst access is SHADER_READ (the spec's build-input
+                            // access), NOT ACCELERATION_STRUCTURE_READ. #1436.
                             memory_barrier(
                                 &self.device,
                                 cmd,
                                 vk::PipelineStageFlags::COMPUTE_SHADER,
                                 vk::AccessFlags::SHADER_WRITE,
                                 vk::PipelineStageFlags::ACCELERATION_STRUCTURE_BUILD_KHR,
-                                vk::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR,
+                                vk::AccessFlags::SHADER_READ,
                             );
                             // #911 — first-sight BLAS BUILDs piggyback
                             // on the per-frame `cmd` rather than each


### PR DESCRIPTION
Synchronization validation reported 40 hazards/frame on the --cornell harness (two distinct kinds). Both are spec-correctness bugs in pre-existing barriers, surfaced by the recent release-mode-validation / BLAS-eviction work — not specific to any scene.

1. AS-build INPUT reads used the wrong access flag (#1436). The Vulkan spec reads vertex/index/instance build inputs with SHADER_READ at the ACCELERATION_STRUCTURE_BUILD stage; the code used ACCELERATION_STRUCTURE_READ_KHR (which is for reading an acceleration STRUCTURE itself), on the assumption the two were aliased. sync-val disproves that with a copy/compute->build RAW hazard on the input buffer. Fixed the two input barriers: - tlas.rs: instance-buffer copy -> TLAS build (Cornell-exercised). - draw.rs: skinned-vertex compute-write -> BLAS build (skinned path, not exercised by --cornell; verify via docs/smoke-tests/m41-equip.sh). Left the three legitimate ACCELERATION_STRUCTURE_READ barriers that read an AS as an AS (BLAS compaction-size query, TLAS build reading BLAS, ray query reading TLAS).

2. Composite render pass loadOp raced its own layout transition. The composite colour attachment is initial_layout=UNDEFINED + LOAD_OP_DONT_CARE, so the EXTERNAL->0 subpass dependency (composite_dep_in) drives the swapchain UNDEFINED->COLOR_ATTACHMENT transition. Its dst scope covered only FRAGMENT_SHADER/SHADER_READ (composite.frag input sampling), but a DONT_CARE loadOp is a COLOR_ATTACHMENT_WRITE at COLOR_ATTACHMENT_OUTPUT, unordered against the transition -> WRITE_AFTER_WRITE. Widened the dep's dst scope additively to include COLOR_ATTACHMENT_OUTPUT/COLOR_ATTACHMENT_WRITE.

Verified: --cornell debug bench hazard count 40 -> 0 (no hazards of any kind, no validation errors, clean teardown); 334/334 renderer tests pass.