### PR TITLE
fix: Starfield PDCL conscious skip (#1568) + CDB tag-abort diagnosability (#1569)

### DIFF
--- a/crates/plugin/src/esm/records/index.rs
+++ b/crates/plugin/src/esm/records/index.rs
@@ -338,6 +338,19 @@ pub struct EsmIndex {
     /// soul. FO3 / FNV drop the record (no soul magic in the
     /// Wasteland) so the map is empty there. See #966.
     pub soul_gems: HashMap<u32, SlgmRecord>,
+    // ── Skip telemetry (#1568 / SF-D4-02) ───────────────────────────
+    /// Top-level GRUP labels the walker consciously skipped because no
+    /// consumer exists for them yet — recorded once per label per parse
+    /// (warned-once, no per-record spam). Unlike the anonymous catch-all
+    /// (`_ => skip_group`), these are *named* here so the skip is visible
+    /// to telemetry / tests instead of silently inflating the unresolved
+    /// bucket. Currently only `PDCL` (Starfield `BGSProjectedDecal`):
+    /// decals are projected onto surrounding geometry and have no MODL,
+    /// so they can't ride the `statics` path even if dispatched — a real
+    /// decal-projection system is needed before they have a consumer.
+    /// Not a record category (carries no count), so it stays out of
+    /// [`categories`](EsmIndex::categories) / [`total`](EsmIndex::total).
+    pub skipped_unconsumed_groups: Vec<[u8; 4]>,
 }
 
 impl EsmIndex {
@@ -638,6 +651,11 @@ impl EsmIndex {
         self.apparatuses.extend(other.apparatuses);
         self.sigil_stones.extend(other.sigil_stones);
         self.soul_gems.extend(other.soul_gems);
+
+        // #1568 — skip telemetry accumulates across the plugin stack so a
+        // master + DLC that both ship PDCL each surface their skip.
+        self.skipped_unconsumed_groups
+            .extend(other.skipped_unconsumed_groups);
     }
 }
 

--- a/crates/plugin/src/esm/records/mod.rs
+++ b/crates/plugin/src/esm/records/mod.rs
@@ -198,6 +198,7 @@ pub fn parse_esm_with_load_order(data: &[u8], remap: Option<FormIdRemap>) -> Res
     let mut warned_pkin = false;
     let mut warned_movs = false;
     let mut warned_mswp = false;
+    let mut warned_pdcl = false;
 
     // Walk top-level groups and dispatch by record-type label.
     while reader.remaining() > 0 {
@@ -291,6 +292,34 @@ pub fn parse_esm_with_load_order(data: &[u8], remap: Option<FormIdRemap>) -> Res
                          (HEDR {:.2}); MSWP is FO4+ only — skipping. \
                          Cross-game plugin risk: material-swap references \
                          won't resolve.",
+                        game,
+                        file_header.hedr_version,
+                    );
+                }
+                reader.skip_group(&group);
+            }
+            // PDCL (Starfield BGSProjectedDecal, #1568 / SF-D4-02) — the
+            // single most frequent unresolved base type in Cydonia
+            // (1846 REFRs / 67 forms). Decals are projected onto the
+            // surrounding geometry and carry no MODL, so they could never
+            // ride the `statics` path even if dispatched; a real
+            // decal-projection consumer has to land before they mean
+            // anything. Until then, skip consciously — name the skip in
+            // telemetry (`skipped_unconsumed_groups`) so it stops
+            // vanishing into the anonymous catch-all and warn once so a
+            // Starfield load gets a single visible signal. Do NOT route
+            // into `statics`.
+            b"PDCL" => {
+                if !warned_pdcl {
+                    warned_pdcl = true;
+                    index.skipped_unconsumed_groups.push(*b"PDCL");
+                    log::warn!(
+                        "ESM: PDCL GRUP encountered (Starfield \
+                         BGSProjectedDecal, GameKind::{:?}, HEDR {:.2}); \
+                         no decal-projection consumer exists yet — \
+                         skipping. Placed decal REFRs won't resolve at \
+                         cell-load time (cosmetic only: no collision or \
+                         structural geometry is lost).",
                         game,
                         file_header.hedr_version,
                     );

--- a/crates/plugin/src/esm/records/tests.rs
+++ b/crates/plugin/src/esm/records/tests.rs
@@ -561,6 +561,46 @@ fn avif_group_dispatches_to_actor_values_map() {
     assert!(avif.skill_scaling.is_some());
 }
 
+/// Regression: #1568 / SF-D4-02 — a top-level `PDCL` GRUP (Starfield
+/// `BGSProjectedDecal`) has no consumer yet. It must be CONSCIOUSLY
+/// skipped: named in the `skipped_unconsumed_groups` telemetry (not lost
+/// in the anonymous `_ => skip_group` catch-all) and never routed into
+/// `cells.statics` (decals carry no MODL). Pre-fix the whole group fell
+/// through the catch-all and the 1846 Cydonia decal REFRs dangled with
+/// zero signal.
+#[test]
+fn pdcl_group_consciously_skipped_and_counted() {
+    let pdcl: [u8; 4] = *b"PDCL";
+    let subs: Vec<(&[u8; 4], Vec<u8>)> = vec![(b"EDID", b"DecalGrime01\0".to_vec())];
+    let record = build_record(b"PDCL", 0xBEEF_00DE, &subs);
+    let group = wrap_group(b"PDCL", &record);
+    let mut tes4 = build_record(b"TES4", 0, &[]);
+    tes4.extend_from_slice(&group);
+    let index = parse_esm(&tes4).unwrap();
+
+    // Counted in telemetry — named, not silently dropped.
+    assert!(
+        index.skipped_unconsumed_groups.contains(&pdcl),
+        "PDCL must be recorded in skip telemetry, not lost to the catch-all"
+    );
+    // Warned-once: a single PDCL group records exactly one entry, no
+    // per-record spam (matches the warned_scol / warned_movs contract).
+    assert_eq!(
+        index
+            .skipped_unconsumed_groups
+            .iter()
+            .filter(|&&l| l == pdcl)
+            .count(),
+        1,
+        "PDCL skip must be recorded once per parse, not per record"
+    );
+    // Never routed into statics — decals have no MODL.
+    assert!(
+        !index.cells.statics.contains_key(&0xBEEF_00DE),
+        "PDCL must not leak into cells.statics"
+    );
+}
+
 /// Regression: #442 — a top-level `CREA` GRUP must dispatch to
 /// `parse_npc` (schema is NPC_-shaped) and land in
 /// `EsmIndex.creatures`. Pre-fix the whole group fell through to

--- a/crates/sfmaterial/src/error.rs
+++ b/crates/sfmaterial/src/error.rs
@@ -44,8 +44,20 @@ pub enum Error {
     #[error("TYPE chunk must be exactly 4 bytes, got {got}")]
     BadTypeChunkSize { got: usize },
 
-    #[error("CLAS chunk has unknown class flags {raw:#06x} (known: IsUser | IsStruct)")]
-    UnknownClassFlags { raw: u16 },
+    #[error(
+        "CLAS chunk #{class_index} ({class_name:?}) has unknown class flags \
+         {raw:#06x} (known: IsUser | IsStruct)"
+    )]
+    UnknownClassFlags {
+        raw: u16,
+        /// 0-based index of the offending class within the TYPE block —
+        /// names *which* class aborted the parse (#1569), instead of just
+        /// the raw flag value with no positional anchor.
+        class_index: usize,
+        /// Editor name of the offending class, resolved from the string
+        /// table before the flag check.
+        class_name: String,
+    },
 
     #[error("class chunk had {leftover} trailing bytes after fields")]
     ClassTrailingBytes { leftover: usize },

--- a/crates/sfmaterial/src/reader.rs
+++ b/crates/sfmaterial/src/reader.rs
@@ -53,8 +53,8 @@ impl ComponentDatabaseFile {
         }
         let type_count = read_u32_le(type_chunk, 0)?;
 
-        for _ in 0..type_count {
-            let class = parse_class(&mut state)?;
+        for class_index in 0..type_count as usize {
+            let class = parse_class(&mut state, class_index)?;
             let idx = state.classes.len();
             state.class_by_name_offset.insert(class.name_offset, idx);
             state.classes.push(class);
@@ -239,7 +239,7 @@ impl<'a> State<'a> {
     }
 }
 
-fn parse_class(state: &mut State) -> Result<Class> {
+fn parse_class(state: &mut State, class_index: usize) -> Result<Class> {
     let payload = state.consume_chunk(ChunkType::Clas)?;
     let mut cur = Cursor::new(payload);
 
@@ -251,7 +251,16 @@ fn parse_class(state: &mut State) -> Result<Class> {
 
     let unknown = flags_raw & !ClassFlags::KNOWN;
     if unknown != 0 {
-        return Err(Error::UnknownClassFlags { raw: flags_raw });
+        // #1569 — name the offending class (index + editor name) instead
+        // of just the raw flag value, so a future patch/DLC CDB that adds
+        // a reflection class-flag bit is diagnosable from the single warn
+        // line rather than leaving the operator guessing which of 1.44M
+        // materials' classes aborted the whole load.
+        return Err(Error::UnknownClassFlags {
+            raw: flags_raw,
+            class_index,
+            class_name: name,
+        });
     }
 
     let mut fields = Vec::with_capacity(field_count);
@@ -600,4 +609,143 @@ fn read_u32_le(bytes: &[u8], pos: usize) -> Result<u32> {
         bytes[pos + 2],
         bytes[pos + 3],
     ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #1569 baseline — the CDB is a flat chunk stream with no
+    /// per-instance recovery: a single unrecognised chunk FourCC aborts
+    /// the whole 1.44M-material parse (`?` on every dispatch). Pin the
+    /// recognised chunk-type set so a future format tag becomes a
+    /// deliberate baseline edit here, not a silent runtime drop — and
+    /// confirm an unknown FourCC fails loud and diagnosable (raw + index).
+    #[test]
+    fn chunk_type_recognized_set_is_pinned() {
+        let known: &[(u32, ChunkType)] = &[
+            (0x54525453, ChunkType::Strt),
+            (0x45505954, ChunkType::Type),
+            (0x53414C43, ChunkType::Clas),
+            (0x544A424F, ChunkType::Objt),
+            (0x46464944, ChunkType::Diff),
+            (0x52455355, ChunkType::User),
+            (0x44525355, ChunkType::Usrd),
+            (0x4350414D, ChunkType::Mapc),
+            (0x5453494C, ChunkType::List),
+        ];
+        for (raw, want) in known {
+            assert_eq!(
+                ChunkType::from_raw(*raw, 0).unwrap(),
+                *want,
+                "chunk FourCC {raw:#010x} must decode"
+            );
+        }
+        match ChunkType::from_raw(0xDEAD_BEEF, 7) {
+            Err(Error::UnknownChunkType { raw, index }) => {
+                assert_eq!(raw, 0xDEAD_BEEF);
+                assert_eq!(index, 7, "the failing chunk index must be carried for diagnostics");
+            }
+            other => panic!("expected UnknownChunkType, got {other:?}"),
+        }
+    }
+
+    /// #1569 baseline — same all-or-nothing brittleness for the
+    /// `BuiltinType` low-byte tag. Pin the recognised primitive set; an
+    /// undocumented tag must fail with `UnsupportedBuiltin` (carries raw).
+    #[test]
+    fn builtin_type_recognized_set_is_pinned() {
+        let known: &[u32] = &[
+            0xFFFFFF01, 0xFFFFFF02, 0xFFFFFF03, 0xFFFFFF04, 0xFFFFFF05, 0xFFFFFF08, 0xFFFFFF09,
+            0xFFFFFF0A, 0xFFFFFF0B, 0xFFFFFF0C, 0xFFFFFF0D, 0xFFFFFF0E, 0xFFFFFF0F, 0xFFFFFF10,
+            0xFFFFFF11, 0xFFFFFF12,
+        ];
+        for raw in known {
+            assert!(
+                BuiltinType::from_u32(*raw).is_ok(),
+                "builtin tag {raw:#010x} must decode"
+            );
+        }
+        // 0xFFFFFF07 sits in the gap between Ref (…05) and Int8 (…08).
+        match BuiltinType::from_u32(0xFFFF_FF07) {
+            Err(Error::UnsupportedBuiltin { raw }) => assert_eq!(raw, 0xFFFF_FF07),
+            other => panic!("expected UnsupportedBuiltin, got {other:?}"),
+        }
+    }
+
+    /// #1569 baseline — only `IsUser | IsStruct` are recognised
+    /// class-flag bits; any other bit aborts the whole parse. Pin the
+    /// mask so a new reflection flag is a conscious edit.
+    #[test]
+    fn class_flags_known_mask_is_pinned() {
+        assert_eq!(ClassFlags::IS_USER, 1 << 2);
+        assert_eq!(ClassFlags::IS_STRUCT, 1 << 3);
+        assert_eq!(ClassFlags::KNOWN, 0b1100);
+        // A bit outside the mask is detected as unknown by parse_class.
+        assert_ne!(0x0001u16 & !ClassFlags::KNOWN, 0);
+    }
+
+    /// Build a minimal valid CDB whose single CLAS carries `flags`.
+    /// Layout: BETH header + STRT ("TestClass") + TYPE (count=1) + CLAS
+    /// (name_offset=0, type_id=0, flags, 0 fields). `chunkCount` includes
+    /// the BETH header, so BETH + STRT + TYPE + CLAS = 4.
+    fn synthetic_cdb_with_class_flags(flags: u16) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&SIGNATURE_BETH.to_le_bytes());
+        bytes.extend_from_slice(&HEADER_SIZE.to_le_bytes());
+        bytes.extend_from_slice(&FILE_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&4u32.to_le_bytes()); // chunkCount incl. BETH
+
+        let strt: &[u8] = b"TestClass\0";
+        bytes.extend_from_slice(&(ChunkType::Strt as u32).to_le_bytes());
+        bytes.extend_from_slice(&(strt.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(strt);
+
+        bytes.extend_from_slice(&(ChunkType::Type as u32).to_le_bytes());
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // type_count
+
+        let mut clas = Vec::new();
+        clas.extend_from_slice(&0i32.to_le_bytes()); // name_offset → "TestClass"
+        clas.extend_from_slice(&0u32.to_le_bytes()); // type_id
+        clas.extend_from_slice(&flags.to_le_bytes()); // flags
+        clas.extend_from_slice(&0u16.to_le_bytes()); // field_count
+        bytes.extend_from_slice(&(ChunkType::Clas as u32).to_le_bytes());
+        bytes.extend_from_slice(&(clas.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&clas);
+
+        bytes
+    }
+
+    /// #1569 — an unknown class flag must abort with a diagnostic that
+    /// NAMES the offending class (index + editor name), not just the raw
+    /// flag value. Pre-fix the operator got "unknown class flags 0xNNNN"
+    /// with no anchor into the 1.44M-material set.
+    #[test]
+    fn unknown_class_flag_names_offending_class() {
+        let cdb = synthetic_cdb_with_class_flags(0x0001);
+        match ComponentDatabaseFile::parse(&cdb) {
+            Err(Error::UnknownClassFlags {
+                raw,
+                class_index,
+                class_name,
+            }) => {
+                assert_eq!(raw, 0x0001);
+                assert_eq!(class_index, 0);
+                assert_eq!(class_name, "TestClass");
+            }
+            other => panic!("expected UnknownClassFlags naming the class, got {other:?}"),
+        }
+    }
+
+    /// Sanity: the SAME synthetic CDB with a valid flag (IsStruct) parses
+    /// cleanly — proves the failure above is the flag check, not a
+    /// malformed fixture.
+    #[test]
+    fn synthetic_cdb_with_valid_flag_parses() {
+        let cdb = synthetic_cdb_with_class_flags(ClassFlags::IS_STRUCT);
+        let parsed = ComponentDatabaseFile::parse(&cdb).expect("valid-flag CDB parses");
+        assert_eq!(parsed.classes.len(), 1);
+        assert_eq!(parsed.classes[0].name, "TestClass");
+    }
 }


### PR DESCRIPTION
Two independent Starfield audit fixes (AUDIT_STARFIELD_2026-06-14), one commit each.

## #1568 — PDCL silently dropped (MEDIUM, esm)
`PDCL` (Starfield `BGSProjectedDecal`) is the single most frequent unresolved base type in Cydonia (1846 REFRs / 67 forms) yet had no dispatch arm — it fell into the anonymous `_ => skip_group` catch-all with zero signal. Decals are projected onto surrounding geometry and carry **no MODL**, so they can't ride the `statics` path even if dispatched; a real decal-projection consumer must land first.

Added a warned-once skip arm matching the `warned_scol` / `warned_movs` pattern, plus a new `EsmIndex.skipped_unconsumed_groups` telemetry vec so the skip is **named and observable** instead of vanishing into the silent-skip bucket. PDCL is *not* routed into statics.

- **SIBLING** ✓ warned-once, one entry per parse (no per-record spam)
- **TESTS** ✓ `pdcl_group_consciously_skipped_and_counted`: parse succeeds, PDCL recorded once in telemetry, never leaks into `cells.statics`

## #1569 — Monolithic CDB aborts on first unknown tag (MEDIUM, sfmaterial)
The CDB is a flat chunk stream with no per-instance recovery: one unknown chunk FourCC / `BuiltinType` tag / out-of-mask class-flag bit propagates the first `Err` via `?` and drops all 1.44M materials to the keyword-guessed Lambert fallback. Per-instance skip is unsafe (positional instances desync on a wrong skip), so this keeps the all-or-nothing parse but makes the abort **diagnosable** and pins the recognised tag set.

`UnknownClassFlags` carried only the raw flag value — *"nothing names the offending class"*. Now threads the class index + editor name (already resolved before the flag check) so the single `load_starfield_cdb` warn line names which class aborted. The call-site already surfaces `{e}`, and `UnknownChunkType`/`UnsupportedBuiltin` already carry `index`/`raw`.

- **CANONICAL-BOUNDARY** ✓ recovery stays at the parse boundary; no partial-set silent substitution added — the all-or-nothing Lambert fallback is unchanged, just diagnosable
- **TESTS** ✓ baseline pins the recognised chunk-type / builtin / class-flag set (a new tag → deliberate baseline edit + loud runtime error); a synthetic-CDB test proves the enriched `UnknownClassFlags` names the class end-to-end
- Follow-up noted: `UnsupportedBuiltin` still carries only `raw` (naming its class/field needs deeper `read_value` threading)

## Tests
Full workspace suite green (63 binaries, 0 failures). New: 5 sfmaterial baseline/diagnostic tests + 1 esm PDCL skip test.

Fixes #1568
Fixes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)