### PR TITLE
fix: wire .STRINGS loader (#1553) + decode ESL 0x0200 light-master FormIDs (#1554)

### DIFF
--- a/byroredux/src/cell_loader/load_order.rs
+++ b/byroredux/src/cell_loader/load_order.rs
@@ -10,6 +10,7 @@
 //! See M46.0 / #561 / #445 for the multi-plugin landing.
 
 use byroredux_plugin::esm;
+use std::path::Path;
 
 /// Lowercase basename of a plugin path. Used as the global load-order
 /// key (case-insensitive on Bethesda content).
@@ -76,6 +77,30 @@ pub(super) fn build_remap_for_plugin(
     })
 }
 
+/// #1553 / SK-D4-02 — load a Localized-flagged plugin's companion
+/// `.STRINGS` / `.DLSTRINGS` / `.ILSTRINGS` tables and install them into
+/// the thread-local string table for the duration of the returned guard.
+///
+/// Returns `None` (identity behaviour — placeholders survive) for a
+/// non-localized plugin or an unreadable header. The loader + RAII guard
+/// already existed (`esm::strings_table`); this is the missing wiring
+/// that turns `<lstring 0xNNNNNNNN>` placeholders into authored names.
+/// All three table kinds are covered by `StringTableSet::load`. The
+/// guard MUST be held by the caller across the record walk so
+/// `resolve_lstring` sees the tables, then dropped before the next plugin.
+fn install_strings_guard(
+    plugin_path: &str,
+    plugin_data: &[u8],
+    language: &str,
+) -> Option<esm::StringsTableGuard> {
+    let mut reader = esm::reader::EsmReader::new(plugin_data);
+    if !reader.read_file_header().ok()?.localized {
+        return None;
+    }
+    let tables = esm::StringTableSet::load(Path::new(plugin_path), language);
+    Some(esm::StringsTableGuard::new(tables))
+}
+
 /// Parse a sequence of plugins in load order (masters first, main
 /// plugin last) and return a single merged [`esm::records::EsmIndex`]
 /// plus the lowercased load-order list.
@@ -106,6 +131,12 @@ pub(super) fn parse_record_indexes_in_load_order(
             }
         }
     }
+    // #1553 — companion `.STRINGS` language. Vanilla ships `english`;
+    // a localized install (french / german / …) can override it. Read
+    // once outside the loop.
+    let strings_language =
+        std::env::var("BYRO_STRINGS_LANG").unwrap_or_else(|_| "english".to_string());
+
     let mut merged = esm::records::EsmIndex::default();
     for (idx, path) in plugin_paths.iter().enumerate() {
         let bytes = std::fs::read(path)
@@ -119,6 +150,12 @@ pub(super) fn parse_record_indexes_in_load_order(
             idx,
         );
         let remap = build_remap_for_plugin(path, &bytes, idx, &load_order)?;
+        // #1553 — install this plugin's companion string tables for the
+        // record walk so localized FULL/DESC/etc. lstring indices resolve
+        // to authored names instead of `<lstring 0xNNNNNNNN>`. RAII guard:
+        // alive across the parse, dropped before the next plugin so each
+        // plugin sees only its own tables.
+        let _strings_guard = install_strings_guard(path, &bytes, &strings_language);
         let plugin_records = esm::records::parse_esm_with_load_order(&bytes, Some(remap))
             .unwrap_or_else(|e| {
                 log::warn!("Record parse failed for '{}': {}", path, e);
@@ -127,4 +164,149 @@ pub(super) fn parse_record_indexes_in_load_order(
         merged.merge_from(plugin_records);
     }
     Ok((merged, load_order))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// FO3+/TES5 24-byte-header record: `type + size + flags + form_id +
+    /// 8-byte trailer`, then `[subtype, u16 len, data]` sub-records.
+    fn build_record(typ: &[u8; 4], form_id: u32, subs: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
+        let mut sub_data = Vec::new();
+        for (st, data) in subs {
+            sub_data.extend_from_slice(*st);
+            sub_data.extend_from_slice(&(data.len() as u16).to_le_bytes());
+            sub_data.extend_from_slice(data);
+        }
+        let mut buf = Vec::new();
+        buf.extend_from_slice(typ);
+        buf.extend_from_slice(&(sub_data.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes()); // flags
+        buf.extend_from_slice(&form_id.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 8]); // trailer
+        buf.extend_from_slice(&sub_data);
+        buf
+    }
+
+    fn wrap_group(label: &[u8; 4], record: &[u8]) -> Vec<u8> {
+        let total = 24 + record.len();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GRUP");
+        buf.extend_from_slice(&(total as u32).to_le_bytes());
+        buf.extend_from_slice(label);
+        buf.extend_from_slice(&0u32.to_le_bytes()); // group_type = top
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(record);
+        buf
+    }
+
+    /// TES4 with the Localized flag (0x80) + a Skyrim HEDR version.
+    fn build_localized_tes4() -> Vec<u8> {
+        let mut hedr = Vec::new();
+        hedr.extend_from_slice(b"HEDR");
+        hedr.extend_from_slice(&12u16.to_le_bytes());
+        hedr.extend_from_slice(&1.7f32.to_le_bytes()); // Skyrim
+        hedr.extend_from_slice(&0u32.to_le_bytes());
+        hedr.extend_from_slice(&0u32.to_le_bytes());
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"TES4");
+        buf.extend_from_slice(&(hedr.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&0x80u32.to_le_bytes()); // Localized
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 8]);
+        buf.extend_from_slice(&hedr);
+        buf
+    }
+
+    /// Synthetic `.STRINGS`: `[count][data_size][id,offset…][blob]` with
+    /// bare null-terminated strings (no length prefix).
+    fn build_strings_file(entries: &[(u32, &str)]) -> Vec<u8> {
+        let mut blob = Vec::new();
+        let mut offsets = Vec::new();
+        for (_, s) in entries {
+            offsets.push(blob.len() as u32);
+            blob.extend_from_slice(s.as_bytes());
+            blob.push(0);
+        }
+        let mut out = Vec::new();
+        out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        out.extend_from_slice(&(blob.len() as u32).to_le_bytes());
+        for (i, (id, _)) in entries.iter().enumerate() {
+            out.extend_from_slice(&id.to_le_bytes());
+            out.extend_from_slice(&offsets[i].to_le_bytes());
+        }
+        out.extend_from_slice(&blob);
+        out
+    }
+
+    /// Localized WEAP (FULL = lstring id 0x0001) wrapped in a TES4-headed
+    /// plugin written to `dir/<stem>.esm`. Returns the path.
+    fn write_localized_weap_plugin(dir: &Path, stem: &str) -> std::path::PathBuf {
+        let mut weap_subs = Vec::<(&[u8; 4], Vec<u8>)>::new();
+        weap_subs.push((b"EDID", b"TestBlade\0".to_vec()));
+        weap_subs.push((b"FULL", 0x0001u32.to_le_bytes().to_vec()));
+        weap_subs.push((b"DATA", {
+            let mut d = Vec::new();
+            d.extend_from_slice(&100u32.to_le_bytes()); // value
+            d.extend_from_slice(&0u32.to_le_bytes()); // health
+            d.extend_from_slice(&1.5f32.to_le_bytes()); // weight
+            d.extend_from_slice(&15u16.to_le_bytes()); // damage
+            d.push(0);
+            d.push(0);
+            d
+        }));
+        let weap = build_record(b"WEAP", 0xBEEF, &weap_subs);
+        let group = wrap_group(b"WEAP", &weap);
+        let mut esm_bytes = build_localized_tes4();
+        esm_bytes.extend_from_slice(&group);
+        let path = dir.join(format!("{stem}.esm"));
+        fs::write(&path, &esm_bytes).unwrap();
+        path
+    }
+
+    /// #1553 / SK-D4-02 — end-to-end wiring: a Localized plugin on disk
+    /// with a sibling `Strings/<stem>_english.STRINGS` must resolve its
+    /// FULL lstring indices to authored names through
+    /// `parse_record_indexes_in_load_order`. Pre-fix the loader + guard
+    /// existed but were never wired, so every localized name stayed a
+    /// `<lstring 0x…>` placeholder.
+    #[test]
+    fn localized_plugin_resolves_names_through_load_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let stem = "TestPlugin";
+        let esm_path = write_localized_weap_plugin(dir.path(), stem);
+
+        let strings_dir = dir.path().join("Strings");
+        fs::create_dir(&strings_dir).unwrap();
+        fs::write(
+            strings_dir.join(format!("{stem}_english.STRINGS")),
+            build_strings_file(&[(0x0001, "Iron Sword")]),
+        )
+        .unwrap();
+
+        let path_str = esm_path.to_str().unwrap();
+        let (index, _order) = parse_record_indexes_in_load_order(&[path_str]).unwrap();
+        let item = index.items.get(&0xBEEF).expect("WEAP indexed");
+        assert_eq!(
+            item.common.full_name, "Iron Sword",
+            "the load-order wiring must install the .STRINGS guard so the \
+             FULL lstring resolves (not the <lstring 0x…> placeholder)"
+        );
+    }
+
+    /// Control: the SAME Localized plugin WITHOUT the companion file keeps
+    /// the placeholder — proving the resolution above came from the wired
+    /// guard reading the on-disk table, not some other path.
+    #[test]
+    fn localized_plugin_without_strings_keeps_placeholder() {
+        let dir = tempfile::tempdir().unwrap();
+        let esm_path = write_localized_weap_plugin(dir.path(), "NoStrings");
+
+        let path_str = esm_path.to_str().unwrap();
+        let (index, _order) = parse_record_indexes_in_load_order(&[path_str]).unwrap();
+        let item = index.items.get(&0xBEEF).expect("WEAP indexed");
+        assert_eq!(item.common.full_name, "<lstring 0x00000001>");
+    }
 }

--- a/byroredux/src/cell_loader/load_order.rs
+++ b/byroredux/src/cell_loader/load_order.rs
@@ -33,29 +33,30 @@ pub(super) fn plugin_for_form_id(form_id: u32, load_order: &[String]) -> Option<
 
 /// Build the [`FormIdRemap`] that turns this plugin's local FormIDs
 /// (top byte = mod-index in its own MASTERS list) into globally
-/// load-order-indexed FormIDs (top byte = position in the load order
-/// passed to the cell loader).
+/// load-order-resolved FormIDs.
+///
+/// `plugin_slot` is this plugin's already-assigned global slot;
+/// `slots` holds every plugin's slot indexed by load-order position, so
+/// each master resolves to its own [`GlobalSlot`] — regular or ESL
+/// (#1554). Masters always precede their dependents, so their slots are
+/// assigned before this call.
 ///
 /// Returns `Err` when the plugin declares a master that isn't in the
-/// global load order — that's a load-order misconfiguration the caller
-/// must fix (every declared master must be present and earlier).
+/// global load order (or loads after it) — a load-order misconfiguration
+/// the caller must fix (every declared master must be present and earlier).
 pub(super) fn build_remap_for_plugin(
     plugin_path: &str,
-    plugin_data: &[u8],
-    plugin_index: usize,
+    header: &esm::reader::FileHeader,
+    plugin_slot: esm::reader::GlobalSlot,
     load_order: &[String],
+    slots: &[esm::reader::GlobalSlot],
 ) -> anyhow::Result<esm::reader::FormIdRemap> {
-    let mut reader = esm::reader::EsmReader::new(plugin_data);
-    let header = reader
-        .read_file_header()
-        .map_err(|e| anyhow::anyhow!("Failed to read TES4 header for '{}': {}", plugin_path, e))?;
-
-    let master_indices: Vec<u8> = header
+    let master_slots: Vec<esm::reader::GlobalSlot> = header
         .master_files
         .iter()
         .map(|m| {
             let m_lc = m.to_ascii_lowercase();
-            load_order
+            let pos = load_order
                 .iter()
                 .position(|name| name == &m_lc)
                 .ok_or_else(|| {
@@ -66,35 +67,45 @@ pub(super) fn build_remap_for_plugin(
                         m,
                         m,
                     )
-                })
-                .map(|i| i as u8)
+                })?;
+            // Masters load before their dependents, so the slot is already
+            // assigned. A master listed AFTER this plugin is a misordered
+            // load order — fail loudly rather than index unassigned slots.
+            slots.get(pos).copied().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Plugin '{}' declares master '{}' which loads after it — \
+                     masters must come first in the load order",
+                    plugin_path,
+                    m,
+                )
+            })
         })
-        .collect::<anyhow::Result<Vec<u8>>>()?;
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(esm::reader::FormIdRemap {
-        plugin_index: plugin_index as u8,
-        master_indices,
+        plugin_slot,
+        master_slots,
     })
 }
 
-/// #1553 / SK-D4-02 — load a Localized-flagged plugin's companion
-/// `.STRINGS` / `.DLSTRINGS` / `.ILSTRINGS` tables and install them into
-/// the thread-local string table for the duration of the returned guard.
+/// #1553 / SK-D4-02 — load a Localized plugin's companion `.STRINGS` /
+/// `.DLSTRINGS` / `.ILSTRINGS` tables and install them into the
+/// thread-local string table for the duration of the returned guard.
 ///
-/// Returns `None` (identity behaviour — placeholders survive) for a
-/// non-localized plugin or an unreadable header. The loader + RAII guard
-/// already existed (`esm::strings_table`); this is the missing wiring
-/// that turns `<lstring 0xNNNNNNNN>` placeholders into authored names.
-/// All three table kinds are covered by `StringTableSet::load`. The
-/// guard MUST be held by the caller across the record walk so
-/// `resolve_lstring` sees the tables, then dropped before the next plugin.
+/// `localized` is the caller's already-read TES4 `0x80` flag. Returns
+/// `None` (identity behaviour — placeholders survive) for a non-localized
+/// plugin. The loader + RAII guard already existed (`esm::strings_table`);
+/// this is the missing wiring that turns `<lstring 0xNNNNNNNN>`
+/// placeholders into authored names. All three table kinds are covered by
+/// `StringTableSet::load`. The guard MUST be held by the caller across the
+/// record walk so `resolve_lstring` sees the tables, then dropped before
+/// the next plugin.
 fn install_strings_guard(
+    localized: bool,
     plugin_path: &str,
-    plugin_data: &[u8],
     language: &str,
 ) -> Option<esm::StringsTableGuard> {
-    let mut reader = esm::reader::EsmReader::new(plugin_data);
-    if !reader.read_file_header().ok()?.localized {
+    if !localized {
         return None;
     }
     let tables = esm::StringTableSet::load(Path::new(plugin_path), language);
@@ -138,6 +149,15 @@ pub(super) fn parse_record_indexes_in_load_order(
         std::env::var("BYRO_STRINGS_LANG").unwrap_or_else(|_| "english".to_string());
 
     let mut merged = esm::records::EsmIndex::default();
+    // #1554 — global-slot assignment. Regular plugins consume a full
+    // top-byte slot (0x00–0xFD); ESL / light-master plugins (TES4 0x0200)
+    // share the 0xFE byte via a 12-bit sub-index. Masters precede their
+    // dependents, so a single forward pass assigns every slot before it's
+    // referenced.
+    let mut slots: Vec<esm::reader::GlobalSlot> = Vec::with_capacity(plugin_paths.len());
+    let mut next_regular: u8 = 0;
+    let mut next_light: u16 = 0;
+
     for (idx, path) in plugin_paths.iter().enumerate() {
         let bytes = std::fs::read(path)
             .map_err(|e| anyhow::anyhow!("Failed to read ESM '{}': {}", path, e))?;
@@ -149,13 +169,35 @@ pub(super) fn parse_record_indexes_in_load_order(
             bytes.len() as f64 / 1_048_576.0,
             idx,
         );
-        let remap = build_remap_for_plugin(path, &bytes, idx, &load_order)?;
+
+        // Read the TES4 header once: masters (for the remap), the ESL
+        // flag (slot assignment, #1554), and the Localized flag (the
+        // .STRINGS guard, #1553).
+        let header = {
+            let mut reader = esm::reader::EsmReader::new(&bytes);
+            reader.read_file_header().map_err(|e| {
+                anyhow::anyhow!("Failed to read TES4 header for '{}': {}", path, e)
+            })?
+        };
+
+        let plugin_slot = if header.light_master {
+            let slot = esm::reader::GlobalSlot::Light(next_light);
+            next_light += 1;
+            slot
+        } else {
+            let slot = esm::reader::GlobalSlot::Regular(next_regular);
+            next_regular += 1;
+            slot
+        };
+        slots.push(plugin_slot);
+
+        let remap = build_remap_for_plugin(path, &header, plugin_slot, &load_order, &slots)?;
         // #1553 — install this plugin's companion string tables for the
         // record walk so localized FULL/DESC/etc. lstring indices resolve
         // to authored names instead of `<lstring 0xNNNNNNNN>`. RAII guard:
         // alive across the parse, dropped before the next plugin so each
         // plugin sees only its own tables.
-        let _strings_guard = install_strings_guard(path, &bytes, &strings_language);
+        let _strings_guard = install_strings_guard(header.localized, path, &strings_language);
         let plugin_records = esm::records::parse_esm_with_load_order(&bytes, Some(remap))
             .unwrap_or_else(|e| {
                 log::warn!("Record parse failed for '{}': {}", path, e);
@@ -202,8 +244,9 @@ mod tests {
         buf
     }
 
-    /// TES4 with the Localized flag (0x80) + a Skyrim HEDR version.
-    fn build_localized_tes4() -> Vec<u8> {
+    /// TES4 with explicit record `flags` (0x80 = Localized, 0x0200 = ESL)
+    /// + a Skyrim HEDR version.
+    fn build_tes4(flags: u32) -> Vec<u8> {
         let mut hedr = Vec::new();
         hedr.extend_from_slice(b"HEDR");
         hedr.extend_from_slice(&12u16.to_le_bytes());
@@ -213,7 +256,7 @@ mod tests {
         let mut buf = Vec::new();
         buf.extend_from_slice(b"TES4");
         buf.extend_from_slice(&(hedr.len() as u32).to_le_bytes());
-        buf.extend_from_slice(&0x80u32.to_le_bytes()); // Localized
+        buf.extend_from_slice(&flags.to_le_bytes());
         buf.extend_from_slice(&0u32.to_le_bytes());
         buf.extend_from_slice(&[0u8; 8]);
         buf.extend_from_slice(&hedr);
@@ -241,9 +284,10 @@ mod tests {
         out
     }
 
-    /// Localized WEAP (FULL = lstring id 0x0001) wrapped in a TES4-headed
-    /// plugin written to `dir/<stem>.esm`. Returns the path.
-    fn write_localized_weap_plugin(dir: &Path, stem: &str) -> std::path::PathBuf {
+    /// A single-WEAP plugin (FULL = lstring id 0x0001) with TES4 `flags`
+    /// and the WEAP at raw `weap_form_id`, written to `dir/<stem>.esm`.
+    /// Returns the path.
+    fn write_weap_plugin(dir: &Path, stem: &str, flags: u32, weap_form_id: u32) -> std::path::PathBuf {
         let mut weap_subs = Vec::<(&[u8; 4], Vec<u8>)>::new();
         weap_subs.push((b"EDID", b"TestBlade\0".to_vec()));
         weap_subs.push((b"FULL", 0x0001u32.to_le_bytes().to_vec()));
@@ -257,9 +301,9 @@ mod tests {
             d.push(0);
             d
         }));
-        let weap = build_record(b"WEAP", 0xBEEF, &weap_subs);
+        let weap = build_record(b"WEAP", weap_form_id, &weap_subs);
         let group = wrap_group(b"WEAP", &weap);
-        let mut esm_bytes = build_localized_tes4();
+        let mut esm_bytes = build_tes4(flags);
         esm_bytes.extend_from_slice(&group);
         let path = dir.join(format!("{stem}.esm"));
         fs::write(&path, &esm_bytes).unwrap();
@@ -276,7 +320,7 @@ mod tests {
     fn localized_plugin_resolves_names_through_load_order() {
         let dir = tempfile::tempdir().unwrap();
         let stem = "TestPlugin";
-        let esm_path = write_localized_weap_plugin(dir.path(), stem);
+        let esm_path = write_weap_plugin(dir.path(), stem, 0x80, 0xBEEF);
 
         let strings_dir = dir.path().join("Strings");
         fs::create_dir(&strings_dir).unwrap();
@@ -302,11 +346,37 @@ mod tests {
     #[test]
     fn localized_plugin_without_strings_keeps_placeholder() {
         let dir = tempfile::tempdir().unwrap();
-        let esm_path = write_localized_weap_plugin(dir.path(), "NoStrings");
+        let esm_path = write_weap_plugin(dir.path(), "NoStrings", 0x80, 0xBEEF);
 
         let path_str = esm_path.to_str().unwrap();
         let (index, _order) = parse_record_indexes_in_load_order(&[path_str]).unwrap();
         let item = index.items.get(&0xBEEF).expect("WEAP indexed");
         assert_eq!(item.common.full_name, "<lstring 0x00000001>");
+    }
+
+    /// #1554 / SK-D4-03 — end-to-end: an ESL-flagged (TES4 0x0200) plugin's
+    /// own forms must land in the 0xFE light space through the load-order
+    /// path, NOT at a flat top-byte index. The single ESL with no masters
+    /// gets light sub-index 0, so a self-ref WEAP at raw 0x0000_0800
+    /// resolves to 0xFE00_0800 in the merged index. Pre-fix the 0x0200
+    /// flag was never read and the form kept its raw 0x0000_0800 id.
+    #[test]
+    fn esl_plugin_own_forms_land_in_light_space() {
+        let dir = tempfile::tempdir().unwrap();
+        // Self-ref object id 0x800 (within the 12-bit ESL object range).
+        let esm_path = write_weap_plugin(dir.path(), "EslMod", 0x0200, 0x0000_0800);
+
+        let path_str = esm_path.to_str().unwrap();
+        let (index, _order) = parse_record_indexes_in_load_order(&[path_str]).unwrap();
+        assert!(
+            index.items.contains_key(&0xFE00_0800),
+            "ESL self-ref form must remap into the 0xFE light space (sub-index 0), \
+             got keys: {:?}",
+            index.items.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !index.items.contains_key(&0x0000_0800),
+            "the raw pre-remap id must not survive — that's the #1554 bug"
+        );
     }
 }

--- a/crates/plugin/src/esm/reader.rs
+++ b/crates/plugin/src/esm/reader.rs
@@ -238,31 +238,74 @@ pub struct EsmReader<'a> {
 /// Pitt / Zeta all use 0x01 for their own new forms).
 #[derive(Debug, Clone)]
 pub struct FormIdRemap {
-    /// This plugin's index in the global load order (0-based).
-    pub plugin_index: u8,
-    /// For each entry in this plugin's MASTERS list, the global
-    /// load-order index of that master. `master_indices[N]` is
-    /// where a FormID with mod-index `N` actually lives.
-    pub master_indices: Vec<u8>,
+    /// This plugin's slot in the global load order.
+    pub plugin_slot: GlobalSlot,
+    /// For each entry in this plugin's MASTERS list, the global slot of
+    /// that master. `master_slots[N]` is where a FormID with mod-index
+    /// `N` actually lives.
+    pub master_slots: Vec<GlobalSlot>,
+}
+
+/// A plugin's resolved position in the global load order.
+///
+/// Regular plugins occupy a full top-byte slot (`0x00`–`0xFD`) with a
+/// 24-bit object-id space. ESL / light-master plugins (TES4 flag `0x0200`)
+/// all share the `0xFE` top byte and are distinguished by a 12-bit
+/// load-order sub-index, leaving only a 12-bit (`0x000`–`0xFFF`) object-id
+/// space. Modelling the slot as a sum type lets [`FormIdRemap::remap`]
+/// decode both kinds — and references *to* an ESL master — uniformly.
+/// See the Creation Engine light-master spec / SK-D4-03 / #1554.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalSlot {
+    /// Full-byte load-order index (`0x00`–`0xFD`).
+    Regular(u8),
+    /// `0xFE` light-master space; the `u16` is the 12-bit sub-index.
+    Light(u16),
+}
+
+impl GlobalSlot {
+    /// Compose this slot with a raw plugin-local FormID into a global
+    /// FormID.
+    ///
+    /// `Regular` keeps the bottom 24 bits as the object id and writes the
+    /// byte index into the top byte. `Light` packs the 12-bit sub-index
+    /// into the `0xFE` space and keeps only the bottom 12 bits — the ESL
+    /// object-id range — because an ESL's object space is 12 bits, not 24.
+    pub fn compose(self, raw: u32) -> u32 {
+        match self {
+            GlobalSlot::Regular(byte) => ((byte as u32) << 24) | (raw & 0x00FF_FFFF),
+            GlobalSlot::Light(sub) => {
+                0xFE00_0000 | (((sub as u32) & 0x0FFF) << 12) | (raw & 0x0000_0FFF)
+            }
+        }
+    }
 }
 
 impl FormIdRemap {
+    /// All-regular convenience constructor (no ESL in the load order) —
+    /// every slot is a full-byte index. Used by the multi-plugin tests.
+    #[cfg(test)]
+    pub fn regular(plugin_index: u8, master_indices: Vec<u8>) -> Self {
+        Self {
+            plugin_slot: GlobalSlot::Regular(plugin_index),
+            master_slots: master_indices.into_iter().map(GlobalSlot::Regular).collect(),
+        }
+    }
+
     /// Apply this remap to a raw plugin-local FormID.
     ///
-    /// `raw & 0xFFFFFF` (the bottom 24 bits) is preserved unchanged —
-    /// it's the plugin's internal unique-id. The top byte is replaced
-    /// with the global load-order index of whichever plugin owns this
-    /// form.
+    /// The object-id bits (bottom 24 for regular, bottom 12 for ESL) are
+    /// preserved; the load-order portion is rewritten to the global slot
+    /// of whichever plugin owns this form. See [`GlobalSlot::compose`].
     pub fn remap(&self, raw: u32) -> u32 {
-        let mod_index = (raw >> 24) as u8;
-        let local = raw & 0x00FF_FFFF;
-        let global_index = if mod_index as usize == self.master_indices.len() {
+        let mod_index = (raw >> 24) as usize;
+        let slot = if mod_index == self.master_slots.len() {
             // Self-reference — top byte equals master count per the
             // Bethesda ESM spec.
-            self.plugin_index
-        } else if (mod_index as usize) < self.master_indices.len() {
-            self.master_indices[mod_index as usize]
-        } else if self.master_indices.is_empty() {
+            self.plugin_slot
+        } else if mod_index < self.master_slots.len() {
+            self.master_slots[mod_index]
+        } else if self.master_slots.is_empty() {
             // Standalone / single-plugin load (no masters) with a top byte
             // past index 0 — the known Bethesda authoring artifact: vanilla
             // Oblivion.esm (and a few FO3/FNV masters) ship a handful of
@@ -282,18 +325,18 @@ impl FormIdRemap {
                 "standalone FormID {raw:08x} (mod_index {mod_index}, no masters) \
                  passed through — Bethesda index-{mod_index:02x} artifact"
             );
-            mod_index
+            return raw;
         } else {
             // Multi-plugin load with an out-of-range index — genuinely
             // suspicious (malformed file or an in-memory injected form).
             // Keep this at warn; it is rare and worth surfacing.
             log::warn!(
                 "FormID {raw:08x} has mod_index {mod_index} but plugin has {} masters",
-                self.master_indices.len()
+                self.master_slots.len()
             );
-            mod_index
+            return raw;
         };
-        ((global_index as u32) << 24) | local
+        slot.compose(raw)
     }
 }
 
@@ -339,6 +382,16 @@ pub struct FileHeader {
     /// 4-byte payload becomes a `"<lstring 0xNNNNNNNN>"` placeholder
     /// instead of 3-character UTF-8 garbage. See audit S6-03 / #348.
     pub localized: bool,
+    /// TES4 record flag bit `0x0200` (Light Master / ESL). When set, this
+    /// plugin shares the `0xFE` top-byte load-order space with every other
+    /// ESL: its forms are addressed as `0xFE` + a 12-bit load-order
+    /// sub-index + a 12-bit object id, rather than a full-byte mod-index +
+    /// 24-bit object id. The load-order builder turns this into a
+    /// [`GlobalSlot::Light`] so [`FormIdRemap`] decodes the plugin's forms
+    /// (and references to ESL masters) correctly. No vanilla Skyrim SE /
+    /// FO4 / Starfield master is ESL-flagged; this is for third-party ESL
+    /// mods and ESL-flagged CC content. See SK-D4-03 / #1554.
+    pub light_master: bool,
 }
 
 impl<'a> EsmReader<'a> {
@@ -624,6 +677,10 @@ impl<'a> EsmReader<'a> {
         // route string decoding through the lstring helper. See
         // audit S6-03 / #348.
         let localized = header.flags & 0x80 != 0;
+        // Bit 0x0200 is the Light Master (ESL) flag — see
+        // `FileHeader::light_master`. Captured here so the load-order
+        // builder can place the plugin in the 0xFE light space (#1554).
+        let light_master = header.flags & 0x0200 != 0;
 
         let subs = self.read_sub_records(&header)?;
         let mut masters = Vec::new();
@@ -652,6 +709,7 @@ impl<'a> EsmReader<'a> {
             record_count,
             hedr_version,
             localized,
+            light_master,
         })
     }
 
@@ -749,10 +807,7 @@ mod tests {
     /// and every existing consumer keep seeing the same u32 FormIDs.
     #[test]
     fn form_id_remap_single_plugin_is_identity() {
-        let remap = FormIdRemap {
-            plugin_index: 0,
-            master_indices: Vec::new(),
-        };
+        let remap = FormIdRemap::regular(0, Vec::new());
         // Self-references (top byte = 0 = master_count) pass through.
         assert_eq!(remap.remap(0x0001_2345), 0x0001_2345);
         assert_eq!(remap.remap(0x00CA_FEBA), 0x00CA_FEBA);
@@ -767,10 +822,7 @@ mod tests {
     /// contract so a future "clamp" refactor can't land silently.
     #[test]
     fn form_id_remap_standalone_out_of_range_passes_through() {
-        let remap = FormIdRemap {
-            plugin_index: 0,
-            master_indices: Vec::new(),
-        };
+        let remap = FormIdRemap::regular(0, Vec::new());
         // mod_index 0x01 with no masters — the Oblivion artifact. Verbatim
         // pass-through, not clamped to 0x00.
         assert_eq!(remap.remap(0x0100_0ABC), 0x0100_0ABC);
@@ -788,10 +840,7 @@ mod tests {
     #[test]
     fn form_id_remap_dlc_on_base_routes_self_and_master_correctly() {
         // Anchorage.esm loaded at plugin_index=1 with Fallout3.esm as master 0.
-        let remap = FormIdRemap {
-            plugin_index: 1,
-            master_indices: vec![0],
-        };
+        let remap = FormIdRemap::regular(1, vec![0]);
         // Reference to Fallout3 (mod_index=0, master_indices[0]=0) → unchanged.
         assert_eq!(remap.remap(0x0001_2345), 0x0001_2345);
         // Self-reference (mod_index=1 == master count) → plugin_index=1.
@@ -804,15 +853,9 @@ mod tests {
     #[test]
     fn form_id_remap_two_dlcs_resolve_collision() {
         // Anchorage.esm loaded at plugin_index=1, masters=[0 (Fallout3)].
-        let anchorage = FormIdRemap {
-            plugin_index: 1,
-            master_indices: vec![0],
-        };
+        let anchorage = FormIdRemap::regular(1, vec![0]);
         // BrokenSteel.esm loaded at plugin_index=2, masters=[0 (Fallout3)].
-        let broken_steel = FormIdRemap {
-            plugin_index: 2,
-            master_indices: vec![0],
-        };
+        let broken_steel = FormIdRemap::regular(2, vec![0]);
 
         // Both files ship their own 0x01_012345 — the audit's canonical
         // example. Under remap they land in distinct global slots.
@@ -837,10 +880,7 @@ mod tests {
     /// the load-order index.
     #[test]
     fn form_id_remap_rewrites_self_ref_to_load_order_index() {
-        let remap = FormIdRemap {
-            plugin_index: 3,
-            master_indices: vec![0],
-        };
+        let remap = FormIdRemap::regular(3, vec![0]);
         // mod_index 1 == num_masters → self → plugin_index=3.
         assert_eq!(remap.remap(0x0112_3456), 0x0312_3456);
     }
@@ -851,10 +891,7 @@ mod tests {
     fn read_record_header_applies_installed_remap() {
         let data = build_record(b"STAT", 0x0112_3456, &[]);
         let mut reader = EsmReader::with_variant(&data, EsmVariant::Tes5Plus);
-        reader.set_form_id_remap(FormIdRemap {
-            plugin_index: 2,
-            master_indices: vec![0],
-        });
+        reader.set_form_id_remap(FormIdRemap::regular(2, vec![0]));
         let header = reader.read_record_header().unwrap();
         assert_eq!(
             header.form_id, 0x0212_3456,
@@ -866,14 +903,99 @@ mod tests {
     /// the mod-index byte changes.
     #[test]
     fn form_id_remap_preserves_local_24_bits() {
-        let remap = FormIdRemap {
-            plugin_index: 5,
-            master_indices: vec![0, 1],
-        };
+        let remap = FormIdRemap::regular(5, vec![0, 1]);
         let local = 0x00AB_CDEF;
         assert_eq!(remap.remap(local) & 0x00FF_FFFF, local);
         assert_eq!(remap.remap(0x01CD_EF12) & 0x00FF_FFFF, 0x00CD_EF12);
         assert_eq!(remap.remap(0x02CD_EF12) & 0x00FF_FFFF, 0x00CD_EF12);
+    }
+
+    /// #1554 — `GlobalSlot::compose` decode. Regular slots keep the
+    /// 24-bit object id; Light (ESL) slots pack a 12-bit sub-index into
+    /// the 0xFE space and keep only the 12-bit ESL object id.
+    #[test]
+    fn global_slot_compose_decodes_regular_and_light() {
+        // Regular: byte index in the top byte, 24-bit object id preserved.
+        assert_eq!(GlobalSlot::Regular(3).compose(0x00AB_CDEF), 0x03AB_CDEF);
+        // Light: 0xFE | (sub << 12) | (object & 0xFFF).
+        assert_eq!(GlobalSlot::Light(5).compose(0x0000_0ABC), 0xFE00_5ABC);
+        // ESL object space is 12 bits — anything above 0xFFF is masked off
+        // (the higher bits belong to the 12-bit sub-index window).
+        assert_eq!(GlobalSlot::Light(0).compose(0x0000_1FFF), 0xFE00_0FFF);
+        // Max sub-index (0xFFF) and max object id (0xFFF) fill the space.
+        assert_eq!(GlobalSlot::Light(0xFFF).compose(0x0000_0FFF), 0xFEFF_FFFF);
+    }
+
+    /// #1554 / SK-D4-03 — an ESL plugin's OWN forms (self-reference,
+    /// mod_index == master count) decode into the 0xFE light space at the
+    /// plugin's 12-bit sub-index, NOT a flat top-byte index. References to
+    /// the ESL's regular masters are unaffected.
+    #[test]
+    fn form_id_remap_esl_plugin_own_forms_decode_into_light_space() {
+        // An ESL at light sub-index 2 with one regular master (byte 0).
+        let remap = FormIdRemap {
+            plugin_slot: GlobalSlot::Light(2),
+            master_slots: vec![GlobalSlot::Regular(0)],
+        };
+        // Self-ref (mod_index 1 == master count): raw 0x0100_0800 →
+        // 0xFE | sub 2 | object 0x800.
+        assert_eq!(remap.remap(0x0100_0800), 0xFE00_2800);
+        // Reference to the regular master (mod_index 0) stays a byte-0 form.
+        assert_eq!(remap.remap(0x0001_2345), 0x0001_2345);
+    }
+
+    /// #1554 / SK-D4-03 — a reference FROM any plugin TO an ESL master
+    /// decodes into that master's 0xFE light sub-index. This is the
+    /// per-master half the flat-top-byte remap got wrong.
+    #[test]
+    fn form_id_remap_reference_to_esl_master_decodes_into_light_space() {
+        // A regular plugin (byte 1) whose master[0] is an ESL at sub 5.
+        let remap = FormIdRemap {
+            plugin_slot: GlobalSlot::Regular(1),
+            master_slots: vec![GlobalSlot::Light(5)],
+        };
+        // Reference to the ESL master (mod_index 0) → 0xFE | sub 5 | 0xABC.
+        assert_eq!(remap.remap(0x0000_0ABC), 0xFE00_5ABC);
+        // Self-ref (mod_index 1 == master count) → regular byte 1.
+        assert_eq!(remap.remap(0x0112_3456), 0x0112_3456);
+    }
+
+    /// #1554 — `read_file_header` decodes both the Localized (0x80) and
+    /// Light-Master (0x0200) TES4 flags independently.
+    #[test]
+    fn read_file_header_reads_localized_and_light_master_flags() {
+        // Minimal TES4 (Tes5Plus 24-byte header) carrying `flags` + HEDR.
+        fn tes4_with_flags(flags: u32) -> Vec<u8> {
+            let mut hedr = Vec::new();
+            hedr.extend_from_slice(&1.7f32.to_le_bytes()); // version
+            hedr.extend_from_slice(&0u32.to_le_bytes()); // record_count
+            hedr.extend_from_slice(&0u32.to_le_bytes()); // next_object_id
+            let mut subs = Vec::new();
+            subs.extend_from_slice(b"HEDR");
+            subs.extend_from_slice(&(hedr.len() as u16).to_le_bytes());
+            subs.extend_from_slice(&hedr);
+            let mut buf = Vec::new();
+            buf.extend_from_slice(b"TES4");
+            buf.extend_from_slice(&(subs.len() as u32).to_le_bytes());
+            buf.extend_from_slice(&flags.to_le_bytes());
+            buf.extend_from_slice(&0u32.to_le_bytes()); // form_id
+            buf.extend_from_slice(&[0u8; 8]); // trailer
+            buf.extend_from_slice(&subs);
+            buf
+        }
+        let read = |flags: u32| {
+            EsmReader::with_variant(&tes4_with_flags(flags), EsmVariant::Tes5Plus)
+                .read_file_header()
+                .unwrap()
+        };
+        let plain = read(0x0000);
+        assert!(!plain.localized && !plain.light_master);
+        let localized = read(0x0080);
+        assert!(localized.localized && !localized.light_master);
+        let esl = read(0x0200);
+        assert!(!esl.localized && esl.light_master);
+        let both = read(0x0280);
+        assert!(both.localized && both.light_master);
     }
 
     #[test]

--- a/crates/plugin/src/esm/records/misc/ai.rs
+++ b/crates/plugin/src/esm/records/misc/ai.rs
@@ -928,10 +928,8 @@ mod tests {
         use crate::esm::reader::FormIdRemap;
         // PNAM (previous_info) and TCLT (topic_links) and ANAM (actor)
         // should be remapped when a remap is provided.
-        let remap = FormIdRemap {
-            plugin_index: 1,         // This plugin is at index 1
-            master_indices: vec![0], // Master is at index 0
-        };
+        // This plugin at index 1, master at index 0 (all regular, no ESL).
+        let remap = FormIdRemap::regular(1, vec![0]);
         let subs = vec![
             sub(b"PNAM", &0x00_050000u32.to_le_bytes()), // plugin 0 (master), form 0x050000
             sub(b"TCLT", &0x01_030000u32.to_le_bytes()), // plugin 1 (this), form 0x030000

--- a/crates/plugin/src/esm/records/mod.rs
+++ b/crates/plugin/src/esm/records/mod.rs
@@ -105,7 +105,7 @@ pub fn parse_esm(data: &[u8]) -> Result<EsmIndex> {
 /// `remap` rewrites every record's FormID top byte into the global
 /// load order so maps in [`EsmIndex`] stay collision-free across
 /// plugins. Pass `None` for single-plugin loads (the default today);
-/// pass `Some(FormIdRemap { plugin_index, master_indices })` when
+/// pass `Some(FormIdRemap { plugin_slot, master_slots })` when
 /// loading a DLC or mod in a multi-plugin stack so Anchorage's new
 /// form 0x01012345 doesn't collide with BrokenSteel's 0x01012345 in
 /// the same map. See #445.

--- a/crates/plugin/src/esm/records/tests.rs
+++ b/crates/plugin/src/esm/records/tests.rs
@@ -477,10 +477,7 @@ fn parse_esm_with_load_order_remaps_self_form_ids() {
 
     // Load this synthetic "DLC" at plugin_index=2 with Fallout3
     // (plugin_index=0) as its single master.
-    let remap = super::super::reader::FormIdRemap {
-        plugin_index: 2,
-        master_indices: vec![0],
-    };
+    let remap = super::super::reader::FormIdRemap::regular(2, vec![0]);
     let index = parse_esm_with_load_order(&tes4, Some(remap)).unwrap();
     assert_eq!(index.items.len(), 1);
     let remapped_key = 0x0200_BEEFu32;


### PR DESCRIPTION
Two Skyrim multi-master / cell-load fixes from AUDIT_SKYRIM_2026-06-14, one commit each.

## #1553 — .STRINGS loader written + tested but never wired (LOW, esm)
The `.STRINGS` / `.DLSTRINGS` / `.ILSTRINGS` loader and its RAII `StringsTableGuard` existed and were unit-tested, but had **no production call site** — so `resolve_lstring` always returned `None` and every localized name on the seven Localized-flagged Skyrim SE masters rendered as `<lstring 0xNNNNNNNN>`.

Wires the guard into `parse_record_indexes_in_load_order`: when the TES4 Localized (0x80) flag is set, load the plugin's companion tables (all three kinds via `StringTableSet::load`) and hold the guard across the record walk, dropped before the next plugin. Language defaults to `english`, overridable via `BYRO_STRINGS_LANG`.

- **SIBLING** ✓ all three table kinds via `StringTableSet::load`
- **TESTS** ✓ on-disk integration test (temp ESM + sibling `Strings/<stem>_english.STRINGS`) resolves the FULL lstring to the authored name through the load-order path; a no-companion-file control keeps the placeholder

## #1554 — ESL 0x0200 light-master flag undecoded (LOW, esm)
`FormIdRemap` treated the FormID top byte as a flat mod-index, so an ESL plugin's forms — `0xFE` + 12-bit load-order sub-index + 12-bit object id — were remapped as if `0xFE` were a regular slot, resolving to wrong records. The header parser never read the `0x0200` flag.

Per the chosen **full** approach, models a plugin's global position as `GlobalSlot { Regular(u8) | Light(u16) }` and composes FormIDs through it (`Regular` → 24-bit object id under a byte index; `Light` → 12-bit sub-index in the `0xFE` space + 12-bit object id). `read_file_header` decodes `0x0200` into `FileHeader.light_master`; the load-order builder assigns each plugin a slot in a single forward pass, so both a plugin's **own** forms and references to **ESL masters** decode correctly.

- **SIBLING** ✓ all remapping funnels through `FormIdRemap::remap`, so cell + record paths are covered by the one chokepoint. (The global-form→plugin *lookup* helpers `plugin_for_form_id` / `resolve_precombine_owner` still assume a flat top byte and fall back for `0xFE` forms — they resolve an already-global id, not a remap, so they're a noted follow-up, not in scope.)
- **TESTS** ✓ `GlobalSlot` compose decode, ESL self-form + ESL-master-reference remap, the `0x80`/`0x0200` flag reads, and an end-to-end load-order test that an ESL self-ref form lands at `0xFE00_0800`

All-regular load orders are **byte-identical** to before (a regular plugin's slot index equals its old flat load-order index). No vanilla Skyrim SE / FO4 / Starfield master is ESL-flagged — this is forward-looking for third-party ESL mods + ESL CC content.

## Tests
Full workspace suite green (63 binaries, 0 failures). New: 2 binary-crate `.STRINGS` wiring tests + 1 ESL load-order test + 4 plugin-crate ESL/flag unit tests; the ~11 `FormIdRemap` literal sites migrated to a `FormIdRemap::regular(..)` test constructor.

Fixes #1553
Fixes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)