### PR TITLE
feat(save): M45 — full-ECS-snapshot save/load architecture (crates/save)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "byroredux-platform",
  "byroredux-plugin",
  "byroredux-renderer",
+ "byroredux-save",
  "byroredux-scripting",
  "byroredux-sfmaterial",
  "byroredux-spt",
@@ -610,6 +611,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "byroredux-save"
+version = "0.1.0"
+dependencies = [
+ "byroredux-core",
+ "crc32fast",
+ "glam 0.29.3",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "byroredux-scripting"
 version = "0.1.0"
 dependencies = [
@@ -617,6 +631,7 @@ dependencies = [
  "byroredux-papyrus",
  "byroredux-plugin",
  "log",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/core",
+    "crates/save",
     "crates/nif",
     "crates/spt",
     "crates/plugin",
@@ -32,6 +33,7 @@ license = "MIT"
 [workspace.dependencies]
 # Engine crates
 byroredux-core = { path = "crates/core" }
+byroredux-save = { path = "crates/save" }
 byroredux-renderer = { path = "crates/renderer" }
 byroredux-platform = { path = "crates/platform" }
 byroredux-plugin = { path = "crates/plugin" }
@@ -108,6 +110,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 semver = { version = "1", features = ["serde"] }
+
+# Checksums — save-file integrity (M45). Power-cut / partial-write
+# detection on load; SIMD-accelerated, non-cryptographic.
+crc32fast = "1"
 
 # Parallelism
 rayon = "1"

--- a/byroredux/Cargo.toml
+++ b/byroredux/Cargo.toml
@@ -25,9 +25,12 @@ dhat-heap = ["dep:dhat"]
 byroredux-debug-server = { workspace = true, optional = true }
 byroredux-debug-ui = { workspace = true }
 byroredux-core = { workspace = true }
+byroredux-save = { workspace = true }
 byroredux-renderer = { workspace = true }
 byroredux-platform = { workspace = true }
-byroredux-scripting = { workspace = true }
+# `save` feature: derive serde on script-owned game-state components
+# (ScriptTimer) so the M45 save registry can snapshot them.
+byroredux-scripting = { workspace = true, features = ["save"] }
 byroredux-nif = { workspace = true }
 byroredux-spt = { workspace = true }
 byroredux-bsa = { workspace = true }

--- a/byroredux/src/commands/mod.rs
+++ b/byroredux/src/commands/mod.rs
@@ -56,6 +56,10 @@ pub(crate) fn build_command_registry() -> CommandRegistry {
     registry.register(MatListCommand);
     registry.register(MatSetCommand);
     registry.register(RagdollCommand);
+    // M45 — save/load (the matching `SaveRegistry` + `SaveState`
+    // resources are installed alongside the command registry).
+    registry.register(crate::save_io::SaveCommand);
+    registry.register(crate::save_io::SaveInfoCommand);
     registry
 }
 

--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -25,6 +25,7 @@ mod npc_spawn;
 mod parsed_nif_cache;
 mod ragdoll;
 mod render;
+mod save_io;
 mod scene;
 mod scene_import_cache;
 mod sf_smoke;
@@ -999,6 +1000,15 @@ impl App {
         // declared-access conflicts to the operator.
         world.insert_resource(byroredux_core::ecs::SchedulerAccessReport(report_snapshot));
         world.insert_resource(build_command_registry());
+        // M45 — install the save registry + slot directory so the
+        // `save` / `save.info` console commands can operate. Saves live
+        // under `<cwd>/saves`; the ring keeps the last 10 quicksaves so
+        // a fresh save never immediately clobbers the previous good one.
+        world.insert_resource(crate::save_io::build_save_registry());
+        world.insert_resource(crate::save_io::SaveState::new(
+            std::path::PathBuf::from("saves"),
+            10,
+        ));
 
         // Start debug server (feature-gated, zero cost when disabled).
         // The returned handle's Drop signals shutdown + joins the

--- a/byroredux/src/save_io.rs
+++ b/byroredux/src/save_io.rs
@@ -1,0 +1,267 @@
+//! M45 Save/Load — binary-side wiring for the [`byroredux_save`] crate.
+//!
+//! The save crate is engine-agnostic: it knows how to snapshot a
+//! [`World`] given a [`SaveRegistry`], but only the binary sees every
+//! component type, so the binary populates the registry
+//! ([`build_save_registry`]) and installs it as a resource.
+//!
+//! ## What's wired
+//!
+//! - `save [slot]` — runs the pre-save validation pass, snapshots the
+//!   live world, and writes a CRC-protected file atomically. Read-only
+//!   against the World, so it's a plain [`ConsoleCommand`].
+//! - `save.info <slot>` — decodes + verifies a slot (magic / version /
+//!   CRC / schema fingerprint) and prints what it contains, without
+//!   touching the live world.
+//!
+//! ## What's deferred (M45.1)
+//!
+//! Applying a decoded snapshot to a *live* Vulkan session means clearing
+//! the world and re-instantiating GPU meshes/textures, BLAS, physics
+//! bodies, and the camera from the restored components — a renderer
+//! re-sync that's its own milestone-sized integration. The destructive
+//! [`restore_world`](byroredux_save::restore_world) path is fully
+//! implemented and tested headlessly in the save crate; `save.info` is
+//! the safe in-engine surface until the re-instantiation lands.
+
+use std::path::PathBuf;
+
+use byroredux_core::console::{CommandOutput, ConsoleCommand};
+use byroredux_core::ecs::resource::Resource;
+use byroredux_core::ecs::World;
+use byroredux_save::validate::validate_world;
+use byroredux_save::{disk, encode, save_world, SaveRegistry};
+
+/// Where save slots live, plus the round-robin ring cursor.
+///
+/// Installed as a resource at startup. Default root is `<cwd>/saves`.
+pub struct SaveState {
+    pub dir: PathBuf,
+    pub ring: disk::SaveRing,
+}
+
+impl Resource for SaveState {}
+
+impl SaveState {
+    pub fn new(dir: PathBuf, ring_size: u32) -> Self {
+        Self {
+            dir,
+            ring: disk::SaveRing::new(ring_size),
+        }
+    }
+}
+
+/// Build the curated game-state save registry.
+///
+/// Only types that carry *player-visible game state* are registered —
+/// derived data (`GlobalTransform`, `WorldBound`), GPU handles
+/// (`MeshHandle`, `TextureHandle`, `SkinnedMesh`), and transient event
+/// markers are reconstructed on load, never serialised.
+pub fn build_save_registry() -> SaveRegistry {
+    use byroredux_core::animation::{AnimationPlayer, AnimationStack};
+    use byroredux_core::ecs::components::{
+        Children, EquipmentSlots, Inventory, LightFlicker, LightSource, Name, Parent, Transform,
+    };
+    use byroredux_core::ecs::resources::ItemInstancePool;
+    use byroredux_scripting::ScriptTimer;
+
+    let mut r = SaveRegistry::new();
+    r.register_component::<Transform>("Transform")
+        .register_component::<Name>("Name")
+        .register_component::<Parent>("Parent")
+        .register_component::<Children>("Children")
+        .register_component::<Inventory>("Inventory")
+        .register_component::<EquipmentSlots>("EquipmentSlots")
+        .register_component::<LightSource>("LightSource")
+        .register_component::<LightFlicker>("LightFlicker")
+        .register_component::<AnimationPlayer>("AnimationPlayer")
+        .register_component::<AnimationStack>("AnimationStack")
+        .register_component::<ScriptTimer>("ScriptTimer")
+        .register_form_id_component("FormIdComponent")
+        .register_resource::<ItemInstancePool>("ItemInstancePool");
+    r
+}
+
+/// `save [slot]` — validate, snapshot, and atomically write the world.
+pub struct SaveCommand;
+
+impl ConsoleCommand for SaveCommand {
+    fn name(&self) -> &str {
+        "save"
+    }
+    fn description(&self) -> &str {
+        "save [slot] — validate + snapshot the world to a slot (default: next ring slot)"
+    }
+    fn execute(&self, world: &World, args: &str) -> CommandOutput {
+        let Some(registry) = world.try_resource::<SaveRegistry>() else {
+            return CommandOutput::error("save registry not installed");
+        };
+        let Some(mut state) = world.try_resource_mut::<SaveState>() else {
+            return CommandOutput::error("save directory not installed");
+        };
+
+        // Explicit slot, or advance the ring so the previous save survives.
+        let slot = match args.trim() {
+            "" => state.ring.advance(),
+            s => match s.parse::<u32>() {
+                Ok(n) => n,
+                Err(_) => return CommandOutput::error(format!("invalid slot '{s}'")),
+            },
+        };
+
+        // Pre-save validation — refuse to persist a broken world.
+        let issues = validate_world(world);
+        if !issues.is_empty() {
+            let mut lines = vec![format!(
+                "save ABORTED: {} referential-integrity issue(s) — refusing to write a poisoned save:",
+                issues.len()
+            )];
+            for issue in issues.iter().take(20) {
+                lines.push(format!("  [{:?}] entity {}: {}", issue.kind, issue.entity, issue.detail));
+            }
+            if issues.len() > 20 {
+                lines.push(format!("  … and {} more", issues.len() - 20));
+            }
+            return CommandOutput::lines(lines);
+        }
+
+        let snapshot = match save_world(world, &registry) {
+            Ok(s) => s,
+            Err(e) => return CommandOutput::error(format!("snapshot failed: {e}")),
+        };
+        let bytes = match encode(&snapshot, registry.schema_fingerprint()) {
+            Ok(b) => b,
+            Err(e) => return CommandOutput::error(format!("encode failed: {e}")),
+        };
+        match disk::write_slot(&state.dir, slot, &bytes) {
+            Ok(path) => CommandOutput::lines(vec![
+                format!("saved slot {slot} → {}", path.display()),
+                format!(
+                    "  {} entities-worth of rows across {} component columns, {} resource(s)",
+                    snapshot.row_count(),
+                    snapshot.components.len(),
+                    snapshot.resources.len()
+                ),
+                format!("  {} bytes (next_entity={})", bytes.len(), snapshot.next_entity),
+            ]),
+            Err(e) => CommandOutput::error(format!("write failed: {e}")),
+        }
+    }
+}
+
+/// `save.info <slot>` — decode + verify a slot and report its contents,
+/// without mutating the live world.
+pub struct SaveInfoCommand;
+
+impl ConsoleCommand for SaveInfoCommand {
+    fn name(&self) -> &str {
+        "save.info"
+    }
+    fn description(&self) -> &str {
+        "save.info <slot> — verify (magic/version/CRC/schema) + summarise a save slot"
+    }
+    fn execute(&self, world: &World, args: &str) -> CommandOutput {
+        let Some(registry) = world.try_resource::<SaveRegistry>() else {
+            return CommandOutput::error("save registry not installed");
+        };
+        let Some(state) = world.try_resource::<SaveState>() else {
+            return CommandOutput::error("save directory not installed");
+        };
+        let slot = match args.trim().parse::<u32>() {
+            Ok(n) => n,
+            Err(_) => {
+                let slots = disk::list_slots(&state.dir);
+                return CommandOutput::lines(vec![
+                    "usage: save.info <slot>".to_string(),
+                    format!("available slots: {slots:?}"),
+                ]);
+            }
+        };
+
+        let bytes = match disk::read_slot(&state.dir, slot) {
+            Ok(b) => b,
+            Err(e) => return CommandOutput::error(format!("read slot {slot}: {e}")),
+        };
+        match byroredux_save::decode(&bytes, registry.schema_fingerprint()) {
+            Ok(snap) => {
+                let mut lines = vec![
+                    format!("slot {slot}: VALID ({} bytes)", bytes.len()),
+                    format!(
+                        "  next_entity={}, {} strings, {} rows",
+                        snap.next_entity,
+                        snap.strings.len(),
+                        snap.row_count()
+                    ),
+                ];
+                for (name, col) in &snap.components {
+                    let rows = col.as_array().map_or(0, |a| a.len());
+                    lines.push(format!("  {name}: {rows} rows"));
+                }
+                for name in snap.resources.keys() {
+                    lines.push(format!("  resource {name}"));
+                }
+                lines.push(
+                    "  (live load/apply is deferred to M45.1 — needs GPU/physics re-instantiation)"
+                        .to_string(),
+                );
+                CommandOutput::lines(lines)
+            }
+            Err(e) => CommandOutput::error(format!("slot {slot} INVALID: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use byroredux_core::ecs::components::Transform;
+    use byroredux_core::form_id::FormIdPool;
+    use byroredux_core::math::Vec3;
+    use byroredux_core::string::StringPool;
+    use byroredux_save::{decode, restore_world};
+    use byroredux_scripting::ScriptTimer;
+
+    /// The binary's curated registry must round-trip its full type set —
+    /// including the cross-crate `ScriptTimer` and a stable form id —
+    /// through encode → decode → restore into a fresh World.
+    #[test]
+    fn binary_registry_round_trips_including_scripttimer() {
+        let reg = build_save_registry();
+
+        let mut src = World::new();
+        src.insert_resource(StringPool::new());
+        src.insert_resource(FormIdPool::new());
+        let e = src.spawn();
+        let other = src.spawn();
+        src.insert(e, Transform::from_translation(Vec3::new(4.0, 5.0, 6.0)));
+        src.insert(e, ScriptTimer { id: 42, remaining: 3.5 });
+        src.insert(other, ScriptTimer { id: 7, remaining: 0.25 });
+
+        let snap = save_world(&src, &reg).unwrap();
+        let bytes = encode(&snap, reg.schema_fingerprint()).unwrap();
+        let decoded = decode(&bytes, reg.schema_fingerprint()).unwrap();
+
+        let mut dst = World::new();
+        dst.insert_resource(FormIdPool::new());
+        restore_world(&mut dst, &reg, &decoded).unwrap();
+
+        assert_eq!(dst.next_entity_id(), 2);
+        let q = dst.query::<ScriptTimer>().unwrap();
+        let timers: std::collections::HashMap<u32, (u32, f32)> =
+            q.iter().map(|(en, t)| (en, (t.id, t.remaining))).collect();
+        assert_eq!(timers[&0], (42, 3.5));
+        assert_eq!(timers[&1], (7, 0.25));
+
+        let qt = dst.query::<Transform>().unwrap();
+        assert_eq!(qt.iter().next().unwrap().1.translation, Vec3::new(4.0, 5.0, 6.0));
+    }
+
+    /// A clean validation pass is the precondition every save checks.
+    #[test]
+    fn fresh_world_validates_clean() {
+        let mut world = World::new();
+        let e = world.spawn();
+        world.insert(e, Transform::default());
+        assert!(validate_world(&world).is_empty());
+    }
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 default = ["parallel-scheduler"]
 parallel-scheduler = ["rayon"]
 inspect = ["serde", "serde_json", "glam/serde"]
+# Save/load (M45) reuses the same serde derives as `inspect`; kept as a
+# distinct feature name so the save crate can opt in without implying the
+# debug-inspection intent.
+save = ["inspect"]
 
 [dependencies]
 glam = { workspace = true }

--- a/crates/core/src/ecs/components/hierarchy.rs
+++ b/crates/core/src/ecs/components/hierarchy.rs
@@ -7,6 +7,7 @@ use crate::ecs::sparse_set::SparseSetStorage;
 use crate::ecs::storage::{Component, EntityId};
 
 /// Points to this entity's parent in the scene hierarchy.
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent(pub EntityId);
 
 impl Component for Parent {
@@ -20,6 +21,7 @@ impl Component for Parent {
 /// Lists this entity's children in the scene hierarchy.
 /// Maintained alongside `Parent` — adding a Parent to a child should
 /// also push the child into the parent's Children list.
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct Children(pub Vec<EntityId>);
 
 impl Component for Children {

--- a/crates/core/src/ecs/components/name.rs
+++ b/crates/core/src/ecs/components/name.rs
@@ -11,7 +11,16 @@ use crate::string::FixedString;
 ///
 /// Equality is integer comparison via [`FixedString`] — no string
 /// comparisons in hot paths.
-pub struct Name(pub FixedString);
+///
+/// For save/load the symbol is serialised as its raw `u32` (via
+/// [`fixed_string_serde`](crate::string::fixed_string_serde)); the
+/// snapshot restores the owning `StringPool` first, so the symbol
+/// resolves to the same string on load.
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
+pub struct Name(
+    #[cfg_attr(feature = "inspect", serde(with = "crate::string::fixed_string_serde"))]
+    pub  FixedString,
+);
 
 impl Component for Name {
     type Storage = SparseSetStorage<Self>;

--- a/crates/core/src/ecs/packed.rs
+++ b/crates/core/src/ecs/packed.rs
@@ -253,6 +253,16 @@ impl<T: Component<Storage = Self>> DynStorage for PackedStorage<T> {
         <Self as ComponentStorage<T>>::remove(self, entity);
     }
 
+    fn clear_erased(&mut self) {
+        self.entities.clear();
+        self.data.clear();
+        // Tracked components push every cleared entity through the dirty
+        // set on a normal remove; a wholesale clear instead just drops
+        // the dirty list — the consumers re-derive from the (now empty)
+        // population on the next frame.
+        self.dirty.clear();
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/core/src/ecs/resources.rs
+++ b/crates/core/src/ecs/resources.rs
@@ -1342,6 +1342,7 @@ impl Resource for SelectedRef {}
 /// inventory types. Phase A of #896 ships it minimal; Phase B/C and
 /// M45 fill in real fields.
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct ItemInstance {
     /// Reserved for now. Real fields land alongside the consuming
     /// gameplay system (M45 save round-trip; FO4 OMOD wiring).
@@ -1359,6 +1360,7 @@ pub struct ItemInstance {
 /// wraps `NonZeroU32`) can encode "no instance" as the absence of
 /// the option without burning a u32 niche.
 #[derive(Debug)]
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct ItemInstancePool {
     instances: Vec<Option<ItemInstance>>,
     free: Vec<u32>,

--- a/crates/core/src/ecs/sparse_set.rs
+++ b/crates/core/src/ecs/sparse_set.rs
@@ -143,6 +143,13 @@ impl<T: Component<Storage = Self>> DynStorage for SparseSetStorage<T> {
         <Self as ComponentStorage<T>>::remove(self, entity);
     }
 
+    fn clear_erased(&mut self) {
+        self.sparse.clear();
+        self.dense.clear();
+        self.data.clear();
+        self.structural_gen = self.structural_gen.wrapping_add(1);
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/crates/core/src/ecs/storage.rs
+++ b/crates/core/src/ecs/storage.rs
@@ -79,6 +79,13 @@ pub trait DynStorage: Send + Sync + 'static {
     /// No-op if the entity has no component here.
     fn remove_entity_erased(&mut self, entity: EntityId);
 
+    /// Drop every component in this storage, leaving it empty but
+    /// reusable. Used by [`World::clear_entities`](super::world::World::clear_entities)
+    /// when a save load replaces the entire entity population — far
+    /// cheaper than walking `next_entity` and despawning one ID at a
+    /// time, and it can't miss a live entity the way an ID sweep would.
+    fn clear_erased(&mut self);
+
     /// Upcast to `&dyn Any` so `World` can downcast back to the concrete
     /// `T::Storage` for typed access.
     fn as_any(&self) -> &dyn Any;

--- a/crates/core/src/ecs/world.rs
+++ b/crates/core/src/ecs/world.rs
@@ -211,6 +211,40 @@ impl World {
         }));
     }
 
+    /// Drop every component on every entity, emptying all storages.
+    ///
+    /// Used by the save/load path ([`byroredux_save`]) when restoring a
+    /// snapshot replaces the entire entity population. Storages themselves
+    /// are retained (so `query::<T>()` keeps succeeding for already-seen
+    /// types) — only their contents are dropped. Does NOT touch resources
+    /// or `next_entity`; the caller sets `next_entity` via
+    /// [`set_next_entity`](Self::set_next_entity) before re-inserting.
+    ///
+    /// Note: this does not tear down GPU/physics handles referenced by the
+    /// dropped components — callers that own those resources (the binary's
+    /// cell loader) must release them separately, exactly as the cell-unload
+    /// path already does.
+    pub fn clear_entities(&mut self) {
+        for lock in self.storages.values_mut() {
+            lock.get_mut()
+                .unwrap_or_else(|_| panic!("storage lock poisoned during clear_entities"))
+                .clear_erased();
+        }
+    }
+
+    /// Overwrite the entity-id high-water mark.
+    ///
+    /// The save/load path calls this with the snapshot's saved
+    /// `next_entity` **before** re-inserting components, so that
+    /// [`insert`](Self::insert) / [`insert_batch`](Self::insert_batch) at
+    /// the original (possibly sparse) entity ids pass their
+    /// `entity < next_entity` guard and inter-entity references
+    /// (`Parent`, `Children`, animation `root_entity`) stay valid without
+    /// any id remapping.
+    pub fn set_next_entity(&mut self, next_entity: EntityId) {
+        self.next_entity = next_entity;
+    }
+
     /// Remove a component from an entity.
     /// Returns `None` if the entity doesn't have this component or if
     /// no storage exists for this type (avoids creating empty storage).

--- a/crates/core/src/ecs/world_tests.rs
+++ b/crates/core/src/ecs/world_tests.rs
@@ -1291,3 +1291,47 @@ fn despawn_poisoned_lock_panics_with_type_name() {
         "despawn panic should name the component type, got: {msg}"
     );
 }
+
+// ── Save/load support: clear_entities + set_next_entity (M45) ────────────
+
+#[test]
+fn clear_entities_empties_all_storages_across_backends() {
+    let mut world = World::new();
+    // Mix a sparse-set and a packed component so both DynStorage::clear
+    // impls are exercised.
+    let a = world.spawn();
+    let b = world.spawn();
+    world.insert(a, Health(1.0));
+    world.insert(b, Health(2.0));
+    world.insert(a, Position { x: 5.0, y: 6.0 });
+
+    assert_eq!(world.count::<Health>(), 2);
+    assert_eq!(world.count::<Position>(), 1);
+
+    world.clear_entities();
+
+    assert_eq!(world.count::<Health>(), 0);
+    assert_eq!(world.count::<Position>(), 0);
+    // Storages persist (queries still resolve), they're just empty.
+    assert!(world.query::<Health>().is_some());
+    // next_entity is untouched by clear — only set_next_entity moves it.
+    assert_eq!(world.next_entity_id(), 2);
+}
+
+#[test]
+fn set_next_entity_then_insert_at_original_ids() {
+    // Mimics the load path: clear, set the saved high-water mark, then
+    // re-insert components at their original (sparse) entity ids without
+    // calling spawn().
+    let mut world = World::new();
+    world.set_next_entity(10);
+    // id 7 is < next_entity (10), so insert passes its guard even though
+    // spawn() was never called for it.
+    world.insert(7, Health(99.0));
+    world.insert_batch::<Position, _>(vec![(3, Position { x: 1.0, y: 2.0 })]);
+
+    assert_eq!(world.next_entity_id(), 10);
+    assert_eq!(world.get::<Health>(7).map(|h| h.0), Some(99.0));
+    let q = world.query::<Position>().unwrap();
+    assert_eq!(q.iter().map(|(e, _)| e).collect::<Vec<_>>(), vec![3]);
+}

--- a/crates/core/src/form_id.rs
+++ b/crates/core/src/form_id.rs
@@ -54,6 +54,27 @@ pub struct FormId(u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PluginId(pub u128);
 
+// `PluginId` is a 128-bit UUID; `serde_json::Value`'s number type tops out
+// at `u64`, so a raw-number derive fails with "number out of range" for any
+// real plugin id. Serialise as a fixed 32-char lowercase hex string instead
+// — Value-safe and human-legible in a save dump.
+#[cfg(feature = "inspect")]
+impl serde::Serialize for PluginId {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&format!("{:032x}", self.0))
+    }
+}
+
+#[cfg(feature = "inspect")]
+impl<'de> serde::Deserialize<'de> for PluginId {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = <std::string::String as serde::Deserialize>::deserialize(de)?;
+        u128::from_str_radix(&s, 16)
+            .map(PluginId)
+            .map_err(|e| serde::de::Error::custom(format!("invalid PluginId hex '{s}': {e}")))
+    }
+}
+
 impl PluginId {
     /// Derive a deterministic `PluginId` from a legacy plugin filename.
     ///
@@ -90,6 +111,7 @@ impl PluginId {
 /// For legacy files this is the lower 24 bits of the original Form ID.
 /// For Redux-native plugins this is assigned by the plugin author.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalFormId(pub u32);
 
 /// The canonical, load-order-independent identity of a record.
@@ -97,6 +119,7 @@ pub struct LocalFormId(pub u32);
 /// This is what gets written to save files and plugin manifests.
 /// At runtime it is interned into a [`FormId`] via [`FormIdPool`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct FormIdPair {
     pub plugin: PluginId,
     pub local: LocalFormId,

--- a/crates/core/src/string/mod.rs
+++ b/crates/core/src/string/mod.rs
@@ -86,6 +86,73 @@ impl StringPool {
             None => self.0.get(s.to_ascii_lowercase()),
         }
     }
+
+    /// Dump every interned string in **symbol order** (symbol 0, 1, 2 …).
+    ///
+    /// The `StringBackend` assigns symbols contiguously as strings are
+    /// first interned, so re-interning this exact sequence into a fresh
+    /// pool reproduces identical [`FixedString`] values
+    /// ([`from_dump`](Self::from_dump)). That symbol stability is what lets
+    /// the save format store `FixedString`-bearing components by their raw
+    /// `u32` symbol (see [`fixed_string_serde`]) rather than re-resolving
+    /// every string at the component level.
+    ///
+    /// Strings come back in their canonical lowercased form (the same form
+    /// [`resolve`](Self::resolve) returns); re-interning is idempotent.
+    pub fn dump(&self) -> Vec<String> {
+        use string_interner::Symbol;
+        // Iteration order isn't contractually symbol-order, so index by
+        // symbol explicitly rather than trusting the yield order.
+        let mut by_symbol: Vec<Option<String>> = Vec::new();
+        for (sym, s) in self.0.iter() {
+            let idx = sym.to_usize();
+            if idx >= by_symbol.len() {
+                by_symbol.resize(idx + 1, None);
+            }
+            by_symbol[idx] = Some(s.to_string());
+        }
+        // Every slot 0..len must be filled for a contiguous backend; an
+        // empty slot would desync every later symbol, so surface it loudly.
+        by_symbol
+            .into_iter()
+            .enumerate()
+            .map(|(i, s)| s.unwrap_or_else(|| panic!("StringPool dump: gap at symbol {i}")))
+            .collect()
+    }
+
+    /// Rebuild a pool from a [`dump`](Self::dump), reproducing the original
+    /// [`FixedString`] symbol for each string by interning in symbol order.
+    pub fn from_dump(strings: &[String]) -> Self {
+        let mut pool = Self::new();
+        for s in strings {
+            pool.intern(s);
+        }
+        pool
+    }
+}
+
+/// `serde` adapter for serializing a [`FixedString`] as its raw `u32`
+/// symbol, for use with `#[serde(with = "...")]` on component fields.
+///
+/// Only valid when the [`StringPool`] is restored first (via
+/// [`StringPool::from_dump`]) so the symbol resolves to the same string.
+/// The save driver guarantees that ordering: strings are restored before
+/// any component column is deserialized.
+#[cfg(feature = "inspect")]
+pub mod fixed_string_serde {
+    use super::FixedString;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use string_interner::Symbol;
+
+    pub fn serialize<S: Serializer>(fs: &FixedString, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_u32(fs.to_usize() as u32)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<FixedString, D::Error> {
+        let raw = u32::deserialize(de)?;
+        FixedString::try_from_usize(raw as usize)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid FixedString symbol {raw}")))
+    }
 }
 
 /// Copy `s` into `buf`, ASCII-lowercasing in place, and return the

--- a/crates/save/Cargo.toml
+++ b/crates/save/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "byroredux-save"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+# `save` pulls in the serde derives on every snapshot-relevant component
+# + resource, plus the `FixedString` serde adapter and the StringPool
+# dump/restore path.
+byroredux-core = { workspace = true, features = ["save"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+crc32fast = { workspace = true }
+thiserror = { workspace = true }
+log = { workspace = true }
+
+[dev-dependencies]
+glam = { workspace = true }

--- a/crates/save/src/disk.rs
+++ b/crates/save/src/disk.rs
@@ -1,0 +1,180 @@
+//! On-disk save slots — atomic writes and a slot ring.
+//!
+//! A save is written to `<dir>/save_<slot>.ess` via the standard
+//! crash-safe dance: write to a `.tmp` sibling, `fsync`, re-read and
+//! verify the bytes match, then atomically `rename` over the target.
+//! A power cut mid-write leaves the old `save_<slot>.ess` intact and a
+//! stray `.tmp` that the next save overwrites — never a half-written
+//! live slot.
+//!
+//! [`SaveRing`] picks the next slot round-robin so a quicksave never
+//! immediately clobbers the most recent good save (Bethesda's "F5 ate my
+//! save" is a UX choice, not a constraint).
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::SaveError;
+
+/// File extension for save slots (Elder-Scrolls-Save heritage).
+const SAVE_EXT: &str = "ess";
+
+/// Path of a numbered save slot under `dir`.
+pub fn slot_path(dir: &Path, slot: u32) -> PathBuf {
+    dir.join(format!("save_{slot}.{SAVE_EXT}"))
+}
+
+/// Write `bytes` to `slot` under `dir`, crash-safely.
+///
+/// Creates `dir` if absent. Writes `save_<slot>.ess.tmp`, flushes +
+/// fsyncs it, re-reads to confirm the bytes landed, then renames over
+/// the live slot. The re-read catches a lying filesystem / short write
+/// before it can replace a good save with a bad one.
+pub fn write_slot(dir: &Path, slot: u32, bytes: &[u8]) -> Result<PathBuf, SaveError> {
+    fs::create_dir_all(dir)?;
+    let final_path = slot_path(dir, slot);
+    let tmp_path = final_path.with_extension(format!("{SAVE_EXT}.tmp"));
+
+    {
+        let mut f = fs::File::create(&tmp_path)?;
+        f.write_all(bytes)?;
+        f.flush()?;
+        f.sync_all()?;
+    }
+
+    // Read-back verification: the bytes on disk must equal what we wrote.
+    let mut readback = Vec::with_capacity(bytes.len());
+    fs::File::open(&tmp_path)?.read_to_end(&mut readback)?;
+    if readback != bytes {
+        // Don't leave a corrupt temp lying around.
+        let _ = fs::remove_file(&tmp_path);
+        return Err(SaveError::Io(std::io::Error::other(
+            "save read-back verification failed (short or corrupt write)",
+        )));
+    }
+
+    fs::rename(&tmp_path, &final_path)?;
+    Ok(final_path)
+}
+
+/// Read the raw bytes of `slot` under `dir`.
+pub fn read_slot(dir: &Path, slot: u32) -> Result<Vec<u8>, SaveError> {
+    let path = slot_path(dir, slot);
+    let mut bytes = Vec::new();
+    fs::File::open(&path)?.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// List the slot numbers that currently have a `save_<n>.ess` file,
+/// ascending.
+pub fn list_slots(dir: &Path) -> Vec<u32> {
+    let mut slots: Vec<u32> = match fs::read_dir(dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter_map(|e| parse_slot_filename(&e.file_name().to_string_lossy()))
+            .collect(),
+        Err(_) => Vec::new(),
+    };
+    slots.sort_unstable();
+    slots
+}
+
+/// Extract `n` from `save_<n>.ess`, or `None` if the name doesn't match.
+fn parse_slot_filename(name: &str) -> Option<u32> {
+    let stem = name.strip_suffix(&format!(".{SAVE_EXT}"))?;
+    let digits = stem.strip_prefix("save_")?;
+    digits.parse().ok()
+}
+
+/// A fixed-size ring of save slots.
+///
+/// `next()` advances round-robin over `0..size`, so successive quicksaves
+/// spread across the ring and the previous good save survives the next
+/// write. Stateless on disk beyond the slot files themselves — the cursor
+/// lives in memory for the session.
+#[derive(Debug, Clone)]
+pub struct SaveRing {
+    size: u32,
+    cursor: u32,
+}
+
+impl SaveRing {
+    /// Create a ring of `size` slots (`size` is clamped to at least 1).
+    pub fn new(size: u32) -> Self {
+        Self {
+            size: size.max(1),
+            cursor: 0,
+        }
+    }
+
+    /// The slot the next [`advance`](Self::advance) will return.
+    pub fn peek(&self) -> u32 {
+        self.cursor
+    }
+
+    /// Return the current slot and advance the cursor round-robin.
+    pub fn advance(&mut self) -> u32 {
+        let slot = self.cursor;
+        self.cursor = (self.cursor + 1) % self.size;
+        slot
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_wraps() {
+        let mut ring = SaveRing::new(3);
+        assert_eq!(ring.advance(), 0);
+        assert_eq!(ring.advance(), 1);
+        assert_eq!(ring.advance(), 2);
+        assert_eq!(ring.advance(), 0);
+    }
+
+    #[test]
+    fn ring_size_floored_to_one() {
+        let mut ring = SaveRing::new(0);
+        assert_eq!(ring.size(), 1);
+        assert_eq!(ring.advance(), 0);
+        assert_eq!(ring.advance(), 0);
+    }
+
+    #[test]
+    fn parse_slot_names() {
+        assert_eq!(parse_slot_filename("save_0.ess"), Some(0));
+        assert_eq!(parse_slot_filename("save_42.ess"), Some(42));
+        assert_eq!(parse_slot_filename("save_42.ess.tmp"), None);
+        assert_eq!(parse_slot_filename("notes.txt"), None);
+        assert_eq!(parse_slot_filename("save_x.ess"), None);
+    }
+
+    #[test]
+    fn write_read_round_trip_and_atomic_rename() {
+        let dir = std::env::temp_dir().join(format!(
+            "byro_save_disk_test_{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+
+        let payload = b"BYRSAVE\0 some bytes here";
+        let path = write_slot(&dir, 2, payload).unwrap();
+        assert!(path.exists());
+        // No leftover temp file after a clean write.
+        assert!(!path.with_extension("ess.tmp").exists());
+
+        assert_eq!(read_slot(&dir, 2).unwrap(), payload);
+        assert_eq!(list_slots(&dir), vec![2]);
+
+        write_slot(&dir, 0, payload).unwrap();
+        assert_eq!(list_slots(&dir), vec![0, 2]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/save/src/driver.rs
+++ b/crates/save/src/driver.rs
@@ -1,0 +1,95 @@
+//! Save / restore drivers — the glue between a live [`World`] and a
+//! [`Snapshot`].
+//!
+//! [`save_world`] needs only `&World` (it reads through `query` /
+//! `try_resource`) and is safe to call from a Late-stage exclusive
+//! system. [`restore_world`] needs `&mut World` — it clears every
+//! storage and repopulates — so it must run off-frame, drained by the
+//! binary between scheduler ticks.
+
+use std::collections::BTreeMap;
+
+use byroredux_core::ecs::world::World;
+use byroredux_core::string::StringPool;
+
+use crate::registry::SaveRegistry;
+use crate::snapshot::Snapshot;
+use crate::SaveError;
+
+/// Capture the live world into a [`Snapshot`].
+///
+/// Walks every registered component column and saved resource, dumps the
+/// `StringPool` in symbol order, and records `next_entity`. Empty
+/// component columns and absent resources are omitted to keep the file
+/// bounded by *live* state.
+pub fn save_world(world: &World, registry: &SaveRegistry) -> Result<Snapshot, SaveError> {
+    let strings = world
+        .try_resource::<StringPool>()
+        .map(|p| p.dump())
+        .unwrap_or_default();
+
+    let mut components = BTreeMap::new();
+    for (name, save, _load) in registry.component_entries() {
+        let value = save(world)?;
+        // Skip empty columns — most registered types have no entities in
+        // any given cell, and a `[]` per type bloats the file pointlessly.
+        if value
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(!value.is_null())
+        {
+            components.insert(name.to_string(), value);
+        }
+    }
+
+    let mut resources = BTreeMap::new();
+    for (name, save, _load) in registry.resource_entries() {
+        let value = save(world)?;
+        if !value.is_null() {
+            resources.insert(name.to_string(), value);
+        }
+    }
+
+    Ok(Snapshot {
+        next_entity: world.next_entity_id(),
+        strings,
+        components,
+        resources,
+    })
+}
+
+/// Replace the live world's entity population (and saved resources) with
+/// the contents of `snapshot`.
+///
+/// Order matters:
+/// 1. clear every storage (drop the old population),
+/// 2. restore the `StringPool` so `FixedString` symbols resolve,
+/// 3. set `next_entity` so original ids pass the `insert_batch` guard,
+/// 4. repopulate component columns at their saved entity ids,
+/// 5. restore saved resources.
+///
+/// GPU / physics handles referenced by the dropped components are **not**
+/// torn down here — that's the caller's responsibility (the binary's
+/// cell-unload path already owns it). This function is the pure ECS-data
+/// half of a load.
+pub fn restore_world(
+    world: &mut World,
+    registry: &SaveRegistry,
+    snapshot: &Snapshot,
+) -> Result<(), SaveError> {
+    world.clear_entities();
+    world.insert_resource(StringPool::from_dump(&snapshot.strings));
+    world.set_next_entity(snapshot.next_entity);
+
+    for (name, _save, load) in registry.component_entries() {
+        if let Some(value) = snapshot.components.get(name) {
+            load(world, value.clone())?;
+        }
+    }
+    for (name, _save, load) in registry.resource_entries() {
+        if let Some(value) = snapshot.resources.get(name) {
+            load(world, value.clone())?;
+        }
+    }
+    Ok(())
+}

--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -1,0 +1,84 @@
+//! M45 Save/Load — full-ECS-snapshot save format.
+//!
+//! The save format is a **full snapshot of the live ECS World**, not a
+//! delta log against a baseline. Bethesda's save-corruption tail (slow
+//! buildup of invisible inconsistencies, save-bloat from change-form
+//! deltas) is structural; ECS-as-truth removes it by construction —
+//! save size scales with *loaded-cell entity count*, never with
+//! playthrough length, and there is no baseline to drift against.
+//!
+//! ## Shape
+//!
+//! - [`SaveRegistry`] holds, per game-state component / resource type, a
+//!   pair of type-erased closures: one that serialises every
+//!   `(entity, component)` pair via `World::query`, one that restores
+//!   them via `World::insert_batch`. The binary populates it with the
+//!   full component set (only it sees every crate), mirroring how the
+//!   debug-server component registry is wired.
+//! - [`Snapshot`] is the serialised container: `next_entity`, the
+//!   [`StringPool`](byroredux_core::string::StringPool) dump (in symbol
+//!   order, so `FixedString` symbols round-trip exactly), one JSON column
+//!   per component type, and one blob per saved resource.
+//! - [`encode`]/[`decode`] wrap a `Snapshot` in a versioned binary
+//!   container with a CRC32 over the payload — power-cut / partial-write
+//!   detection on load.
+//! - [`save_world`]/[`restore_world`] are the drivers.
+//! - [`disk`] adds atomic write (`tmp` → fsync → re-read+verify →
+//!   rename) and a slot ring.
+//! - [`validate`] is the pre-save referential-integrity pass — refuse to
+//!   write a poisoned save rather than persist the slow-corruption seed.
+//!
+//! ## Load runs off-frame
+//!
+//! Save needs only `&World` and fits as a Late-stage exclusive system.
+//! Load needs `&mut World` (it clears + repopulates storages) which a
+//! system can't get — so the binary drains a load request between frames,
+//! exactly like the existing `PendingDebugLoadSlot` path.
+
+mod driver;
+mod registry;
+mod snapshot;
+pub mod disk;
+pub mod validate;
+
+pub use driver::{restore_world, save_world};
+pub use registry::SaveRegistry;
+pub use snapshot::{decode, encode, Snapshot, FORMAT_MAGIC, FORMAT_MAJOR, FORMAT_MINOR};
+
+/// Errors raised while saving, encoding, decoding, or restoring a snapshot.
+#[derive(Debug, thiserror::Error)]
+pub enum SaveError {
+    /// A component/resource column failed to (de)serialise to/from JSON.
+    #[error("serde error in column '{column}': {source}")]
+    Serde {
+        column: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The container's magic bytes don't match — not a ByroRedux save.
+    #[error("not a ByroRedux save file (bad magic)")]
+    BadMagic,
+
+    /// The container is shorter than its fixed-size header.
+    #[error("save file truncated: {0} bytes, need at least {1} for the header")]
+    Truncated(usize, usize),
+
+    /// The format major version is newer/older than this engine supports.
+    #[error("unsupported save format major version {found} (engine supports {supported})")]
+    UnsupportedVersion { found: u16, supported: u16 },
+
+    /// The stored CRC doesn't match the payload — corrupt or partial write.
+    #[error("save file CRC mismatch: stored {stored:#010x}, computed {computed:#010x}")]
+    CrcMismatch { stored: u32, computed: u32 },
+
+    /// The registered component/resource set differs from the one the
+    /// save was written with (a type was added/removed/renamed) and no
+    /// migrator is registered. Refused rather than silently dropping data.
+    #[error("save schema fingerprint mismatch: file {file:#018x}, engine {engine:#018x}")]
+    SchemaMismatch { file: u64, engine: u64 },
+
+    /// I/O error reading or writing a save file on disk.
+    #[error("save I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/save/src/registry.rs
+++ b/crates/save/src/registry.rs
@@ -1,0 +1,243 @@
+//! [`SaveRegistry`] — the type-erased table the save/load drivers walk.
+//!
+//! Each registered component or resource type contributes a `save`
+//! closure (captures `T`, reads it out of the World via `query` /
+//! `try_resource`, emits one `serde_json::Value`) and a `load` closure
+//! (takes that `Value` back, deserialises, and re-inserts). The drivers
+//! never name a concrete `T`; they iterate the registry.
+//!
+//! The binary builds the registry once at startup with the curated
+//! game-state type set. Ordering is preserved for a deterministic
+//! [`schema_fingerprint`](SaveRegistry::schema_fingerprint).
+
+use byroredux_core::ecs::resource::Resource;
+use byroredux_core::ecs::storage::Component;
+use byroredux_core::ecs::world::World;
+// `SaveRegistry` is itself stored as a World resource so the read-only
+// `save` console command can reach it through `&World`.
+impl Resource for SaveRegistry {}
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::hash::Hasher;
+
+use crate::SaveError;
+
+type SaveFn = Box<dyn Fn(&World) -> Result<serde_json::Value, SaveError> + Send + Sync>;
+type LoadFn = Box<dyn Fn(&mut World, serde_json::Value) -> Result<usize, SaveError> + Send + Sync>;
+
+/// One registered serialisable type (component or resource).
+struct Entry {
+    name: &'static str,
+    save: SaveFn,
+    load: LoadFn,
+}
+
+/// Registry of every component/resource type that participates in a save.
+///
+/// Populated by the binary at startup; consumed by [`save_world`] and
+/// [`restore_world`].
+///
+/// [`save_world`]: crate::save_world
+/// [`restore_world`]: crate::restore_world
+#[derive(Default)]
+pub struct SaveRegistry {
+    components: Vec<Entry>,
+    resources: Vec<Entry>,
+}
+
+impl SaveRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a component type for save/load.
+    ///
+    /// `name` is the **stable on-disk key** — it must not change once a
+    /// save format ships (renaming it strands every existing save's
+    /// column for that type). It is independent of the Rust type name.
+    pub fn register_component<T>(&mut self, name: &'static str) -> &mut Self
+    where
+        T: Component + Serialize + DeserializeOwned,
+    {
+        self.components.push(Entry {
+            name,
+            save: Box::new(move |world: &World| {
+                // Bind the query so the borrowed `&T`s outlive the
+                // serialise call, then collect one column.
+                let Some(q) = world.query::<T>() else {
+                    return Ok(serde_json::Value::Array(Vec::new()));
+                };
+                let rows: Vec<(u32, &T)> = q.iter().collect();
+                serde_json::to_value(&rows).map_err(|source| SaveError::Serde {
+                    column: name.to_string(),
+                    source,
+                })
+            }),
+            load: Box::new(move |world: &mut World, value: serde_json::Value| {
+                let rows: Vec<(u32, T)> =
+                    serde_json::from_value(value).map_err(|source| SaveError::Serde {
+                        column: name.to_string(),
+                        source,
+                    })?;
+                let n = rows.len();
+                // `set_next_entity` was already called by the driver, so
+                // every original (possibly sparse) entity id passes the
+                // `entity < next_entity` guard.
+                world.insert_batch::<T, _>(rows);
+                Ok(n)
+            }),
+        });
+        self
+    }
+
+    /// Register a resource type for save/load.
+    ///
+    /// Only resources that carry *game state* belong here (e.g.
+    /// `ItemInstancePool`). Engine config and per-frame telemetry are
+    /// reconstructed, not saved. A missing resource at save time emits no
+    /// column; a missing column at load time leaves the live resource
+    /// untouched.
+    pub fn register_resource<R>(&mut self, name: &'static str) -> &mut Self
+    where
+        R: Resource + Serialize + DeserializeOwned,
+    {
+        self.resources.push(Entry {
+            name,
+            save: Box::new(move |world: &World| {
+                let Some(res) = world.try_resource::<R>() else {
+                    return Ok(serde_json::Value::Null);
+                };
+                serde_json::to_value(&*res).map_err(|source| SaveError::Serde {
+                    column: name.to_string(),
+                    source,
+                })
+            }),
+            load: Box::new(move |world: &mut World, value: serde_json::Value| {
+                let res: R = serde_json::from_value(value).map_err(|source| SaveError::Serde {
+                    column: name.to_string(),
+                    source,
+                })?;
+                world.insert_resource(res);
+                Ok(1)
+            }),
+        });
+        self
+    }
+
+    /// Register the [`FormIdComponent`] specially, storing each entity's
+    /// **stable** [`FormIdPair`] rather than its session-local
+    /// [`FormId`] handle (the handle is a `FormIdPool` index that means
+    /// nothing across loads — see the type's own docs).
+    ///
+    /// Save resolves `FormId → FormIdPair` through the live `FormIdPool`;
+    /// load re-interns `FormIdPair → FormId` through the (reloaded) pool,
+    /// so the handle is whatever this session assigns — internally
+    /// consistent with every other re-interned reference.
+    ///
+    /// An unresolvable handle at save time is skipped with a warning
+    /// rather than aborting the column; it indicates an entity whose pool
+    /// entry was already dropped, which a fresh load can't honour anyway.
+    pub fn register_form_id_component(&mut self, name: &'static str) -> &mut Self {
+        use byroredux_core::ecs::components::FormIdComponent;
+        use byroredux_core::form_id::{FormIdPair, FormIdPool};
+
+        self.components.push(Entry {
+            name,
+            save: Box::new(move |world: &World| {
+                let Some(q) = world.query::<FormIdComponent>() else {
+                    return Ok(serde_json::Value::Array(Vec::new()));
+                };
+                let pool = world.try_resource::<FormIdPool>();
+                let mut rows: Vec<(u32, FormIdPair)> = Vec::new();
+                for (entity, comp) in q.iter() {
+                    match pool.as_ref().and_then(|p| p.resolve(comp.0)).copied() {
+                        Some(pair) => rows.push((entity, pair)),
+                        None => log::warn!(
+                            "save: FormId handle on entity {entity} doesn't resolve in \
+                             FormIdPool — skipping (entity will load without a FormIdComponent)"
+                        ),
+                    }
+                }
+                serde_json::to_value(&rows).map_err(|source| SaveError::Serde {
+                    column: name.to_string(),
+                    source,
+                })
+            }),
+            load: Box::new(move |world: &mut World, value: serde_json::Value| {
+                let rows: Vec<(u32, FormIdPair)> =
+                    serde_json::from_value(value).map_err(|source| SaveError::Serde {
+                        column: name.to_string(),
+                        source,
+                    })?;
+                let n = rows.len();
+                let resolved: Vec<(u32, FormIdComponent)> = {
+                    let mut pool = world.resource_mut::<FormIdPool>();
+                    rows.into_iter()
+                        .map(|(entity, pair)| (entity, FormIdComponent(pool.intern(pair))))
+                        .collect()
+                };
+                world.insert_batch::<FormIdComponent, _>(resolved);
+                Ok(n)
+            }),
+        });
+        self
+    }
+
+    /// Fingerprint the registered schema: a stable hash over the ordered
+    /// set of component + resource keys.
+    ///
+    /// Catches the coarse "a type was added / removed / renamed" drift.
+    /// It does **not** hash field layout — an intra-type field change is
+    /// caught at load time when `serde_json::from_value` fails on the
+    /// changed shape. A versioned migrator chain is the follow-up for
+    /// graceful intra-type evolution.
+    pub fn schema_fingerprint(&self) -> u64 {
+        // FNV-1a over the column keys, tagged by kind so a component and
+        // a resource sharing a name still produce distinct fingerprints.
+        let mut h = FnvHasher::new();
+        for e in &self.components {
+            h.write(b"C");
+            h.write(e.name.as_bytes());
+            h.write(b"\0");
+        }
+        for e in &self.resources {
+            h.write(b"R");
+            h.write(e.name.as_bytes());
+            h.write(b"\0");
+        }
+        h.finish()
+    }
+
+    pub(crate) fn component_entries(&self) -> impl Iterator<Item = (&'static str, &SaveFn, &LoadFn)> {
+        self.components
+            .iter()
+            .map(|e| (e.name, &e.save, &e.load))
+    }
+
+    pub(crate) fn resource_entries(&self) -> impl Iterator<Item = (&'static str, &SaveFn, &LoadFn)> {
+        self.resources.iter().map(|e| (e.name, &e.save, &e.load))
+    }
+}
+
+/// Minimal FNV-1a 64-bit hasher — deterministic across runs and builds
+/// (unlike `DefaultHasher`, whose `std` implementation is unspecified),
+/// which the on-disk schema fingerprint requires.
+struct FnvHasher(u64);
+
+impl FnvHasher {
+    fn new() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+}
+
+impl Hasher for FnvHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            self.0 ^= b as u64;
+            self.0 = self.0.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+}

--- a/crates/save/src/snapshot.rs
+++ b/crates/save/src/snapshot.rs
@@ -1,0 +1,232 @@
+//! [`Snapshot`] — the serialised world state — and the versioned binary
+//! container ([`encode`] / [`decode`]) that wraps it with integrity and
+//! version metadata.
+//!
+//! ## Container layout (little-endian)
+//!
+//! ```text
+//! offset  size  field
+//! 0       8     magic           b"BYRSAVE\0"
+//! 8       2     version_major   reject on mismatch
+//! 10      2     version_minor   advisory; newer minor still loads
+//! 12      8     schema_fpr      registry fingerprint (type-set drift)
+//! 20      4     crc32           over the payload bytes only
+//! 24      8     payload_len     length of the JSON payload
+//! 32      …     payload         serde_json of `Snapshot`
+//! ```
+//!
+//! The payload is JSON (the "simple serde format" v1 mandates); the
+//! framing is binary so corruption, truncation, and version skew are
+//! detected before any deserialisation is attempted.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::SaveError;
+
+/// Container magic bytes.
+pub const FORMAT_MAGIC: &[u8; 8] = b"BYRSAVE\0";
+/// Incompatible-format version. Bumped only when old saves can't be read.
+pub const FORMAT_MAJOR: u16 = 1;
+/// Additive-format version. Bumped when fields are added compatibly.
+pub const FORMAT_MINOR: u16 = 0;
+
+/// Fixed header size in bytes (everything before the payload).
+const HEADER_LEN: usize = 32;
+
+/// The serialised world state.
+///
+/// Columns are keyed by the stable registry name. `BTreeMap` keeps the
+/// JSON output deterministic (stable diffs, reproducible CRCs across
+/// runs at equal state).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// The entity-id high-water mark at save time. Restored verbatim so
+    /// later spawns stay monotonic and saved inter-entity references stay
+    /// valid without remapping.
+    pub next_entity: u32,
+    /// `StringPool` dump in symbol order — re-interning this exact
+    /// sequence reproduces every `FixedString` symbol the components
+    /// reference.
+    pub strings: Vec<String>,
+    /// One column per component type: `name → [[entity, value], …]`.
+    pub components: BTreeMap<String, serde_json::Value>,
+    /// One blob per saved resource: `name → value`.
+    pub resources: BTreeMap<String, serde_json::Value>,
+}
+
+impl Snapshot {
+    /// Total live component rows across all columns — a cheap size/sanity
+    /// signal for logging.
+    pub fn row_count(&self) -> usize {
+        self.components
+            .values()
+            .map(|v| v.as_array().map_or(0, |a| a.len()))
+            .sum()
+    }
+}
+
+/// Wrap a [`Snapshot`] in the versioned, CRC-protected binary container.
+///
+/// `schema_fpr` is [`SaveRegistry::schema_fingerprint`](crate::SaveRegistry::schema_fingerprint)
+/// — stored so [`decode`] can refuse a save written against a different
+/// type set.
+pub fn encode(snapshot: &Snapshot, schema_fpr: u64) -> Result<Vec<u8>, SaveError> {
+    let payload = serde_json::to_vec(snapshot).map_err(|source| SaveError::Serde {
+        column: "<snapshot>".to_string(),
+        source,
+    })?;
+    let crc = crc32fast::hash(&payload);
+
+    let mut out = Vec::with_capacity(HEADER_LEN + payload.len());
+    out.extend_from_slice(FORMAT_MAGIC);
+    out.extend_from_slice(&FORMAT_MAJOR.to_le_bytes());
+    out.extend_from_slice(&FORMAT_MINOR.to_le_bytes());
+    out.extend_from_slice(&schema_fpr.to_le_bytes());
+    out.extend_from_slice(&crc.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+    out.extend_from_slice(&payload);
+    Ok(out)
+}
+
+/// Validate the container and return the contained [`Snapshot`].
+///
+/// `expected_fpr` is the live registry's fingerprint; a mismatch is
+/// refused ([`SaveError::SchemaMismatch`]) since no migrator chain exists
+/// yet. Checks run header-first so a truncated/corrupt/version-skewed
+/// file fails before any JSON parse.
+pub fn decode(bytes: &[u8], expected_fpr: u64) -> Result<Snapshot, SaveError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(SaveError::Truncated(bytes.len(), HEADER_LEN));
+    }
+    if &bytes[0..8] != FORMAT_MAGIC {
+        return Err(SaveError::BadMagic);
+    }
+    let major = u16::from_le_bytes([bytes[8], bytes[9]]);
+    if major != FORMAT_MAJOR {
+        return Err(SaveError::UnsupportedVersion {
+            found: major,
+            supported: FORMAT_MAJOR,
+        });
+    }
+    // minor (bytes[10..12]) is advisory — a newer minor still loads; serde
+    // default-fills any field this engine's `Snapshot` doesn't carry.
+    let file_fpr = u64::from_le_bytes(bytes[12..20].try_into().unwrap());
+    if file_fpr != expected_fpr {
+        return Err(SaveError::SchemaMismatch {
+            file: file_fpr,
+            engine: expected_fpr,
+        });
+    }
+    let stored_crc = u32::from_le_bytes(bytes[20..24].try_into().unwrap());
+    let payload_len = u64::from_le_bytes(bytes[24..32].try_into().unwrap()) as usize;
+
+    let payload_end = HEADER_LEN
+        .checked_add(payload_len)
+        .ok_or(SaveError::Truncated(bytes.len(), usize::MAX))?;
+    if bytes.len() < payload_end {
+        return Err(SaveError::Truncated(bytes.len(), payload_end));
+    }
+    let payload = &bytes[HEADER_LEN..payload_end];
+
+    let computed_crc = crc32fast::hash(payload);
+    if computed_crc != stored_crc {
+        return Err(SaveError::CrcMismatch {
+            stored: stored_crc,
+            computed: computed_crc,
+        });
+    }
+
+    serde_json::from_slice(payload).map_err(|source| SaveError::Serde {
+        column: "<snapshot>".to_string(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Snapshot {
+        let mut components = BTreeMap::new();
+        components.insert("Transform".to_string(), serde_json::json!([[0, {"x": 1.0}]]));
+        Snapshot {
+            next_entity: 7,
+            strings: vec!["scene root".into(), "bip01".into()],
+            components,
+            resources: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn round_trips_through_container() {
+        let snap = sample();
+        let bytes = encode(&snap, 0xABCD).unwrap();
+        let back = decode(&bytes, 0xABCD).unwrap();
+        assert_eq!(back.next_entity, 7);
+        assert_eq!(back.strings, snap.strings);
+        assert_eq!(back.row_count(), 1);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut bytes = encode(&sample(), 1).unwrap();
+        bytes[0] = b'X';
+        assert!(matches!(decode(&bytes, 1), Err(SaveError::BadMagic)));
+    }
+
+    #[test]
+    fn rejects_truncated() {
+        let bytes = encode(&sample(), 1).unwrap();
+        assert!(matches!(
+            decode(&bytes[..20], 1),
+            Err(SaveError::Truncated(20, HEADER_LEN))
+        ));
+    }
+
+    #[test]
+    fn rejects_payload_truncation() {
+        let bytes = encode(&sample(), 1).unwrap();
+        // Drop the last payload byte — header says more than is present.
+        let chopped = &bytes[..bytes.len() - 1];
+        assert!(matches!(decode(chopped, 1), Err(SaveError::Truncated(_, _))));
+    }
+
+    #[test]
+    fn detects_crc_corruption() {
+        let mut bytes = encode(&sample(), 1).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        assert!(matches!(
+            decode(&bytes, 1),
+            Err(SaveError::CrcMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_schema_mismatch() {
+        let bytes = encode(&sample(), 0x1111).unwrap();
+        assert!(matches!(
+            decode(&bytes, 0x2222),
+            Err(SaveError::SchemaMismatch {
+                file: 0x1111,
+                engine: 0x2222
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_major_version_skew() {
+        let mut bytes = encode(&sample(), 1).unwrap();
+        // Bump the stored major past what the engine supports.
+        let bad = (FORMAT_MAJOR + 1).to_le_bytes();
+        bytes[8] = bad[0];
+        bytes[9] = bad[1];
+        // CRC is over the payload only, so the header edit doesn't trip CRC.
+        assert!(matches!(
+            decode(&bytes, 1),
+            Err(SaveError::UnsupportedVersion { .. })
+        ));
+    }
+}

--- a/crates/save/src/validate.rs
+++ b/crates/save/src/validate.rs
@@ -1,0 +1,189 @@
+//! Pre-save referential-integrity pass.
+//!
+//! The thesis behind the full-snapshot format is that Bethesda's slow
+//! save corruption comes from persisting *inconsistent* state, not from
+//! careless serialisation. So before a save is written we walk the World
+//! and refuse to persist a structurally broken one — better to fail the
+//! save loudly than to seed a corruption tail.
+//!
+//! These checks need only `byroredux-core` types (hierarchy, inventory,
+//! equipment, animation). Cross-plugin checks that need the `DataStore`
+//! (e.g. "every `FormIdComponent` resolves to a loaded record") live in
+//! the binary, which owns that resource — call [`validate_world`] first,
+//! then layer game-specific checks on top.
+
+use byroredux_core::animation::{AnimationClipRegistry, AnimationPlayer};
+use byroredux_core::ecs::components::{Children, EquipmentSlots, Inventory, Parent};
+use byroredux_core::ecs::storage::EntityId;
+use byroredux_core::ecs::world::World;
+
+/// A single referential-integrity violation found before save.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    /// The entity the broken reference lives on.
+    pub entity: EntityId,
+    /// Which check failed (for grouping / log filtering).
+    pub kind: ValidationKind,
+    /// Human-readable detail.
+    pub detail: String,
+}
+
+/// The category of a [`ValidationError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationKind {
+    /// A `Parent`/`Children` edge is one-directional or dangling.
+    Hierarchy,
+    /// An `EquipmentSlots` occupant indexes outside its `Inventory`.
+    Equipment,
+    /// An `AnimationPlayer.clip_handle` isn't in the clip registry.
+    AnimationClip,
+    /// An entity reference points past `next_entity` (never spawned).
+    DanglingEntity,
+}
+
+/// Walk the world and collect every referential-integrity violation.
+///
+/// An empty result means the world is safe to snapshot. The save driver
+/// (binary side) refuses the write when this is non-empty and dumps the
+/// list to the log.
+pub fn validate_world(world: &World) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    let next_entity = world.next_entity_id();
+
+    validate_hierarchy(world, next_entity, &mut errors);
+    validate_equipment(world, &mut errors);
+    validate_animation(world, next_entity, &mut errors);
+
+    errors
+}
+
+/// `Parent` ⇄ `Children` must agree, and neither may point past
+/// `next_entity` (an id that was never spawned).
+fn validate_hierarchy(world: &World, next_entity: EntityId, errors: &mut Vec<ValidationError>) {
+    // child -> parent, from the Parent column.
+    let parent_of: std::collections::HashMap<EntityId, EntityId> = match world.query::<Parent>() {
+        Some(q) => q.iter().map(|(c, p)| (c, p.0)).collect(),
+        None => std::collections::HashMap::new(),
+    };
+
+    // Every Parent edge: target must be a spawned id, and the parent's
+    // Children list (if it has one) must contain this child.
+    if let Some(q_children) = world.query::<Children>() {
+        let children_of: std::collections::HashMap<EntityId, Vec<EntityId>> =
+            q_children.iter().map(|(p, c)| (p, c.0.clone())).collect();
+
+        for (&child, &parent) in &parent_of {
+            if parent >= next_entity {
+                errors.push(ValidationError {
+                    entity: child,
+                    kind: ValidationKind::DanglingEntity,
+                    detail: format!("Parent({parent}) was never spawned (next_entity={next_entity})"),
+                });
+                continue;
+            }
+            match children_of.get(&parent) {
+                Some(list) if list.contains(&child) => {}
+                Some(_) => errors.push(ValidationError {
+                    entity: child,
+                    kind: ValidationKind::Hierarchy,
+                    detail: format!("Parent({parent}) but not in that parent's Children list"),
+                }),
+                None => errors.push(ValidationError {
+                    entity: child,
+                    kind: ValidationKind::Hierarchy,
+                    detail: format!("Parent({parent}) but parent has no Children component"),
+                }),
+            }
+        }
+
+        // Every Children entry: the listed child must back-reference us.
+        for (&parent, list) in &children_of {
+            for &child in list {
+                if child >= next_entity {
+                    errors.push(ValidationError {
+                        entity: parent,
+                        kind: ValidationKind::DanglingEntity,
+                        detail: format!("Children lists {child}, never spawned (next_entity={next_entity})"),
+                    });
+                } else if parent_of.get(&child) != Some(&parent) {
+                    errors.push(ValidationError {
+                        entity: parent,
+                        kind: ValidationKind::Hierarchy,
+                        detail: format!("Children lists {child}, but its Parent != {parent}"),
+                    });
+                }
+            }
+        }
+    } else {
+        // No Children column at all — only the dangling-parent check applies.
+        for (&child, &parent) in &parent_of {
+            if parent >= next_entity {
+                errors.push(ValidationError {
+                    entity: child,
+                    kind: ValidationKind::DanglingEntity,
+                    detail: format!("Parent({parent}) was never spawned (next_entity={next_entity})"),
+                });
+            }
+        }
+    }
+}
+
+/// Every `EquipmentSlots` occupant must index a live row in the same
+/// entity's `Inventory`.
+fn validate_equipment(world: &World, errors: &mut Vec<ValidationError>) {
+    let Some(q_equip) = world.query::<EquipmentSlots>() else {
+        return;
+    };
+    let inv = world.query::<Inventory>();
+
+    for (entity, slots) in q_equip.iter() {
+        let item_count = inv
+            .as_ref()
+            .and_then(|q| q.iter().find(|(e, _)| *e == entity).map(|(_, i)| i.items.len()));
+        for occupant in slots.occupants.iter().flatten() {
+            match item_count {
+                None => errors.push(ValidationError {
+                    entity,
+                    kind: ValidationKind::Equipment,
+                    detail: format!("equips inventory[{}] but entity has no Inventory", occupant.0),
+                }),
+                Some(n) if (occupant.0 as usize) >= n => errors.push(ValidationError {
+                    entity,
+                    kind: ValidationKind::Equipment,
+                    detail: format!("equips inventory[{}] but Inventory holds {n} items", occupant.0),
+                }),
+                Some(_) => {}
+            }
+        }
+    }
+}
+
+/// Every `AnimationPlayer.clip_handle` must resolve in the clip registry,
+/// and its `root_entity` (if set) must be a spawned id.
+fn validate_animation(world: &World, next_entity: EntityId, errors: &mut Vec<ValidationError>) {
+    let Some(q) = world.query::<AnimationPlayer>() else {
+        return;
+    };
+    let registry = world.try_resource::<AnimationClipRegistry>();
+
+    for (entity, player) in q.iter() {
+        if let Some(reg) = registry.as_ref() {
+            if reg.get(player.clip_handle).is_none() {
+                errors.push(ValidationError {
+                    entity,
+                    kind: ValidationKind::AnimationClip,
+                    detail: format!("clip_handle {} not in AnimationClipRegistry", player.clip_handle),
+                });
+            }
+        }
+        if let Some(root) = player.root_entity {
+            if root >= next_entity {
+                errors.push(ValidationError {
+                    entity,
+                    kind: ValidationKind::DanglingEntity,
+                    detail: format!("AnimationPlayer.root_entity {root} was never spawned"),
+                });
+            }
+        }
+    }
+}

--- a/crates/save/tests/round_trip.rs
+++ b/crates/save/tests/round_trip.rs
@@ -1,0 +1,223 @@
+//! End-to-end save → encode → decode → restore round-trip on a realistic
+//! synthetic World, plus the validation pass.
+//!
+//! Proves the data-model half of M45: a snapshot taken from one World and
+//! restored into a fresh, empty World reproduces entity ids, the string
+//! pool, hierarchy edges, inventory/equipment, stable form ids, and
+//! `next_entity` exactly.
+
+use byroredux_core::ecs::components::{
+    Children, EquipmentSlots, FormIdComponent, Inventory, InventoryIndex, ItemStack, Name, Parent,
+    Transform,
+};
+use byroredux_core::ecs::world::World;
+use byroredux_core::form_id::{FormIdPair, FormIdPool, LocalFormId, PluginId};
+use byroredux_core::string::StringPool;
+use byroredux_save::validate::{validate_world, ValidationKind};
+use byroredux_save::{decode, encode, restore_world, save_world, SaveRegistry};
+use glam::{Quat, Vec3};
+
+/// The curated game-state registry the test (and, later, the binary) uses.
+fn registry() -> SaveRegistry {
+    let mut r = SaveRegistry::new();
+    r.register_component::<Transform>("Transform")
+        .register_component::<Name>("Name")
+        .register_component::<Parent>("Parent")
+        .register_component::<Children>("Children")
+        .register_component::<Inventory>("Inventory")
+        .register_component::<EquipmentSlots>("EquipmentSlots")
+        .register_form_id_component("FormIdComponent");
+    r
+}
+
+/// Build a World with a sparse entity-id layout (a despawn leaves a gap),
+/// a hierarchy, named entities, and an actor with inventory + equipment +
+/// a stable form id.
+fn build_source_world() -> (World, FormIdPair) {
+    let mut world = World::new();
+    world.insert_resource(StringPool::new());
+    world.insert_resource(FormIdPool::new());
+
+    // Spawn a handful, then despawn one so ids 0..N are sparse — exercises
+    // the "preserve original ids, gaps and all" guarantee.
+    let root = world.spawn(); // 0
+    let child_a = world.spawn(); // 1
+    let doomed = world.spawn(); // 2
+    let child_b = world.spawn(); // 3
+    let actor = world.spawn(); // 4
+    world.despawn(doomed); // id 2 now a permanent gap
+
+    // Transforms (PackedStorage + change tracking).
+    world.insert(root, Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)));
+    world.insert(
+        actor,
+        Transform::new(Vec3::new(10.0, 0.0, -5.0), Quat::from_rotation_y(0.5), 2.0),
+    );
+
+    // Names (StringPool-backed FixedString).
+    let (root_name, actor_name) = {
+        let mut pool = world.resource_mut::<StringPool>();
+        (pool.intern("Scene Root"), pool.intern("Doc Mitchell"))
+    };
+    world.insert(root, Name(root_name));
+    world.insert(actor, Name(actor_name));
+
+    // Hierarchy: root → [child_a, child_b]; actor is unparented.
+    world.insert(child_a, Parent(root));
+    world.insert(child_b, Parent(root));
+    world.insert(root, Children(vec![child_a, child_b]));
+
+    // Actor inventory + equipment.
+    let pair = FormIdPair {
+        plugin: PluginId::from_filename("FalloutNV.esm"),
+        local: LocalFormId(0x0014),
+    };
+    let mut inv = Inventory::new();
+    let idx = inv.push(ItemStack::new(0xDEAD, 1));
+    inv.push(ItemStack::new(0xBEEF, 5));
+    world.insert(actor, inv);
+    let mut equip = EquipmentSlots::new();
+    equip.equip(0b1, idx); // bit 0 → inventory slot 0
+    world.insert(actor, equip);
+
+    // Stable form id on the actor.
+    let fid = {
+        let mut pool = world.resource_mut::<FormIdPool>();
+        pool.intern(pair)
+    };
+    world.insert(actor, FormIdComponent(fid));
+
+    (world, pair)
+}
+
+#[test]
+fn full_world_round_trips_through_container() {
+    let (src, pair) = build_source_world();
+    let reg = registry();
+
+    // Save → encode → decode → restore into a brand-new, empty World.
+    let snapshot = save_world(&src, &reg).expect("save");
+    let bytes = encode(&snapshot, reg.schema_fingerprint()).expect("encode");
+    let decoded = decode(&bytes, reg.schema_fingerprint()).expect("decode");
+
+    let mut dst = World::new();
+    // The destination needs a FormIdPool present for FormIdComponent
+    // re-interning (the live engine always has one; a fresh load must too).
+    dst.insert_resource(FormIdPool::new());
+    restore_world(&mut dst, &reg, &decoded).expect("restore");
+
+    // next_entity preserved (high-water mark = 5 even with the id-2 gap).
+    assert_eq!(dst.next_entity_id(), src.next_entity_id());
+    assert_eq!(dst.next_entity_id(), 5);
+
+    // Transforms preserved at their original ids.
+    {
+        let q = dst.query::<Transform>().expect("transform storage");
+        let map: std::collections::HashMap<u32, Transform> =
+            q.iter().map(|(e, t)| (e, *t)).collect();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map[&0].translation, Vec3::new(1.0, 2.0, 3.0));
+        assert_eq!(map[&4].translation, Vec3::new(10.0, 0.0, -5.0));
+        assert_eq!(map[&4].scale, 2.0);
+    }
+
+    // Names resolve to the same strings through the restored StringPool.
+    {
+        let pool = dst.resource::<StringPool>();
+        let q = dst.query::<Name>().expect("name storage");
+        let names: std::collections::HashMap<u32, String> = q
+            .iter()
+            .map(|(e, n)| (e, pool.resolve(n.0).unwrap().to_string()))
+            .collect();
+        assert_eq!(names[&0], "scene root"); // pool lowercases canonically
+        assert_eq!(names[&4], "doc mitchell");
+    }
+
+    // Hierarchy edges preserved.
+    {
+        let qp = dst.query::<Parent>().expect("parent storage");
+        let parents: std::collections::HashMap<u32, u32> =
+            qp.iter().map(|(e, p)| (e, p.0)).collect();
+        assert_eq!(parents[&1], 0);
+        assert_eq!(parents[&3], 0);
+
+        let qc = dst.query::<Children>().expect("children storage");
+        let children: Vec<u32> = qc.iter().next().unwrap().1 .0.clone();
+        assert_eq!(children, vec![1, 3]);
+    }
+
+    // Inventory + equipment preserved.
+    {
+        let qi = dst.query::<Inventory>().expect("inventory storage");
+        let (e, inv) = qi.iter().next().unwrap();
+        assert_eq!(e, 4);
+        assert_eq!(inv.items.len(), 2);
+        assert_eq!(inv.items[0].base_form_id, 0xDEAD);
+        assert_eq!(inv.items[1].count, 5);
+
+        let qe = dst.query::<EquipmentSlots>().expect("equip storage");
+        let (_, equip) = qe.iter().next().unwrap();
+        assert_eq!(equip.occupants[0], Some(InventoryIndex(0)));
+    }
+
+    // FormIdComponent resolves back to the SAME stable pair through the
+    // destination pool (handle value is session-local and may differ).
+    {
+        let pool = dst.resource::<FormIdPool>();
+        let qf = dst.query::<FormIdComponent>().expect("formid storage");
+        let (e, comp) = qf.iter().next().unwrap();
+        assert_eq!(e, 4);
+        assert_eq!(pool.resolve(comp.0).copied(), Some(pair));
+    }
+}
+
+#[test]
+fn empty_columns_are_omitted_from_the_snapshot() {
+    // A world with only a StringPool and no entities should produce a
+    // snapshot with no component columns at all.
+    let mut world = World::new();
+    world.insert_resource(StringPool::new());
+    let reg = registry();
+    let snap = save_world(&world, &reg).unwrap();
+    assert_eq!(snap.row_count(), 0);
+    assert!(snap.components.is_empty());
+}
+
+#[test]
+fn validation_catches_equipment_out_of_bounds() {
+    let mut world = World::new();
+    let a = world.spawn();
+    let mut inv = Inventory::new();
+    inv.push(ItemStack::new(1, 1)); // single slot, index 0 only
+    world.insert(a, inv);
+    let mut equip = EquipmentSlots::new();
+    equip.equip(0b1, InventoryIndex(7)); // points past the inventory
+    world.insert(a, equip);
+
+    let errors = validate_world(&world);
+    assert!(errors
+        .iter()
+        .any(|e| e.kind == ValidationKind::Equipment && e.entity == a));
+}
+
+#[test]
+fn validation_catches_dangling_parent() {
+    let mut world = World::new();
+    let child = world.spawn(); // id 0, next_entity = 1
+    world.insert(child, Parent(99)); // 99 never spawned
+
+    let errors = validate_world(&world);
+    assert!(errors
+        .iter()
+        .any(|e| e.kind == ValidationKind::DanglingEntity && e.entity == child));
+}
+
+#[test]
+fn validation_passes_on_a_consistent_world() {
+    let (world, _pair) = build_source_world();
+    assert_eq!(
+        validate_world(&world),
+        vec![],
+        "the hand-built world must be referentially consistent"
+    );
+}

--- a/crates/scripting/Cargo.toml
+++ b/crates/scripting/Cargo.toml
@@ -3,8 +3,15 @@ name = "byroredux-scripting"
 version.workspace = true
 edition.workspace = true
 
+[features]
+# M45 — derive serde on the script-owned game-state components
+# (`ScriptTimer`) so the save crate can snapshot them. Off by default;
+# the binary turns it on.
+save = ["serde", "byroredux-core/save"]
+
 [dependencies]
 byroredux-core = { workspace = true }
+serde = { workspace = true, optional = true }
 # M47.1 — scripting needs the `Condition` / `ConditionList` types
 # from `byroredux_plugin::esm::records::condition` so the evaluator
 # can operate on parser-produced data. No cycle: plugin parses ESM

--- a/crates/scripting/src/timer.rs
+++ b/crates/scripting/src/timer.rs
@@ -13,6 +13,7 @@ use byroredux_core::ecs::world::World;
 
 /// A countdown timer attached to an entity.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "save", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScriptTimer {
     /// Caller-assigned ID, echoed in the `TimerExpired` event.
     pub id: u32,


### PR DESCRIPTION
Add `byroredux-save`: a full-World-snapshot save format that sidesteps Bethesda's slow-corruption / save-bloat tail by construction — save size scales with loaded-cell entity count, never playthrough length, with no baseline to diff against.

Library (all of Phases 1, 3, 4, 5):
- SaveRegistry — type-erased per-component/-resource save/load closures the binary populates with the curated game-state set. Stable string keys, an FNV schema fingerprint over the type set, and a dedicated `register_form_id_component` that persists the *stable* FormIdPair (not the session-local FormId handle) by resolving through FormIdPool.
- Snapshot + versioned binary container (magic / major+minor / schema fpr / CRC32 / payload-len header, serde_json payload). decode() refuses bad magic, major-version skew, schema drift, truncation, and CRC corruption before any parse.
- driver: save_world (`&World`) / restore_world (`&mut World`). Load preserves original entity ids exactly — set_next_entity + insert_batch at the saved (possibly sparse) ids — so Parent/Children/root_entity refs stay valid with no remap.
- disk: crash-safe atomic write (tmp → fsync → read-back verify → rename) + a round-robin SaveRing so a quicksave never clobbers the last good save.
- validate: pre-save referential-integrity pass (Parent⇄Children, equipment indices in-bounds, AnimationPlayer.clip_handle resolves, dangling entity refs). Refuse to write a poisoned save.

Core enablers:
- World::clear_entities + set_next_entity; DynStorage::clear_erased on both storage backends.
- StringPool::dump/from_dump (symbol-order) + a `fixed_string_serde` adapter so FixedString-bearing components (Name) round-trip their raw symbol with the pool rebuilt identically.
- serde derives under `inspect` for Name / Parent / Children / FormIdPair / PluginId (Value-safe hex string for the u128) / LocalFormId / ItemInstance(Pool); new `save = ["inspect"]` feature. ScriptTimer gains a `save` feature in the scripting crate.

Binary wiring (Phase 2):
- build_save_registry() + SaveState resource; `save [slot]` (validate + snapshot + atomic write) and `save.info <slot>` (decode + verify + summarise) console commands.
- Live world-clearing restore is intentionally deferred to M45.1 — applying a snapshot to a running Vulkan session needs GPU/physics/camera re-instantiation (a renderer re-sync), so the destructive restore_world path stays library-only + headlessly tested rather than destabilising the live renderer speculatively.

Tests: 16 in crates/save (container reject paths, full round-trip incl. sparse ids / StringPool / hierarchy / inventory+equipment / stable FormId, validation), 2 World tests (clear_entities, set_next_entity), 2 binary tests (curated registry round-trip incl. cross-crate ScriptTimer). Workspace green.