### PR TITLE
Land M47.2 keystone: QUST VMAD fragment decoder + runtime population

### DIFF
--- a/byroredux/src/asset_provider/script.rs
+++ b/byroredux/src/asset_provider/script.rs
@@ -66,6 +66,76 @@ pub(crate) fn pex_archive_path(script_name: &str) -> String {
     name
 }
 
+/// Populate the [`byroredux_scripting::QuestStageFragments`] table from a
+/// merged index's QUST `VMAD` fragment bindings — the M47.2 runtime
+/// keystone. For every quest carrying stage→`Fragment_N` bindings, resolve
+/// its compiled `QF_` `.pex` once (via the [`ScriptProvider`]), decompile,
+/// lower each bound fragment body to canonical effects, and register them
+/// keyed by `(quest, stage)` for `quest_fragment_dispatch_system`.
+///
+/// No-op when no `--scripts-bsa` archive is present (nothing to
+/// decompile) or on pre-Papyrus games (empty `fragments`). Runs once per
+/// cell load; re-registering a `(quest, stage)` on a later load simply
+/// overwrites with the identical lowering.
+pub(crate) fn populate_quest_fragments(
+    world: &mut byroredux_core::ecs::world::World,
+    index: &byroredux_plugin::esm::records::EsmIndex,
+) {
+    // Fast-out before any per-quest work when no script archive was
+    // supplied (the common mesh-only / FO3-FNV case).
+    let have_archive = world
+        .try_resource::<ScriptProvider>()
+        .is_some_and(|p| !p.is_empty());
+    if !have_archive {
+        return;
+    }
+
+    let mut total = 0usize;
+    let mut quests_with_fragments = 0usize;
+    for (&form_id, quest) in index.quests.iter() {
+        if quest.fragments.is_empty() {
+            continue;
+        }
+        quests_with_fragments += 1;
+        // All of a quest's fragments share one QF_ script, but group by
+        // script name defensively (and resolve each `.pex` once).
+        let mut by_script: std::collections::HashMap<&str, Vec<(u16, &str)>> =
+            std::collections::HashMap::new();
+        for f in &quest.fragments {
+            by_script
+                .entry(f.script_name.as_str())
+                .or_default()
+                .push((f.stage, f.fragment_name.as_str()));
+        }
+        for (script_name, bindings) in by_script {
+            // Scope the provider borrow: extract owned `.pex` bytes, then
+            // drop the resource read before the `&mut` resource access.
+            let bytes = {
+                let provider = world.resource::<ScriptProvider>();
+                provider.extract_pex(script_name)
+            };
+            let Some(bytes) = bytes else {
+                log::trace!(
+                    "M47.2 quest-fragment: .pex '{script_name}' not in archive (quest {form_id:08X})"
+                );
+                continue;
+            };
+            let mut frags = world.resource_mut::<byroredux_scripting::QuestStageFragments>();
+            total += byroredux_scripting::populate_quest_fragments_from_pex(
+                &mut frags,
+                byroredux_scripting::QuestFormId(form_id),
+                &bytes,
+                &bindings,
+            );
+        }
+    }
+    if total > 0 {
+        log::info!(
+            "M47.2: populated {total} quest-stage fragments from {quests_with_fragments} scripted quests"
+        );
+    }
+}
+
 /// Build a [`ScriptProvider`] from CLI arguments. Accepts repeated
 /// `--scripts-bsa <path>` flags so modded script archives can layer over
 /// the vanilla one (first hit wins, so list overrides before the base).

--- a/byroredux/src/cell_loader/load.rs
+++ b/byroredux/src/cell_loader/load.rs
@@ -340,6 +340,14 @@ pub fn load_cell_with_masters(
         absorbed,
     );
 
+    // 3a′. M47.2 keystone — populate the quest-stage fragment table from
+    // the merged index's QUST VMAD fragment bindings (Skyrim+). Decompiles
+    // each quest's `QF_` script once and lowers its bound `Fragment_N`
+    // bodies to canonical effects the `quest_fragment_dispatch_system`
+    // applies when a stage advances. No-op without `--scripts-bsa` (no
+    // `.pex` to resolve) or on pre-Papyrus games (empty `fragments`).
+    crate::asset_provider::populate_quest_fragments(world, &index);
+
     // 3a. Interior water plane from XCLW / XCWT — flooded ruins,
     // sewers, named indoor pools. The cell parser captured the
     // height directly; the water material comes from the global

--- a/crates/plugin/examples/dump_qust_vmad_fragments.rs
+++ b/crates/plugin/examples/dump_qust_vmad_fragments.rs
@@ -1,0 +1,127 @@
+//! Derivation tool (M47.2 keystone): dump the trailing *fragment* section
+//! of QUST `VMAD` sub-records from a real ESM so the stage→`Fragment_N`
+//! table layout can be reverse-derived empirically — the same accepted
+//! method the scripts-section decoder was built with (no public byte-spec
+//! in-repo; no-guessing policy → derive from ground truth, don't fabricate).
+//!
+//! For each QUST that carries a VMAD, prints: the decoded script names
+//! (from `ScriptInstanceData::parse_with_consumed`), the byte offset where
+//! the scripts section ends, and a hexdump of everything after it (the
+//! fragment section). Cross-validate the decoded `Fragment_N` / filename
+//! strings against Champollion-decompiled quest `.pex`.
+//!
+//! Usage:
+//!   cargo run -p byroredux-plugin --example dump_qust_vmad_fragments -- <ESM> [MAX]
+
+use byroredux_plugin::esm::reader::EsmReader;
+use byroredux_plugin::esm::records::script_instance::{parse_quest_fragments, ScriptInstanceData};
+
+fn hexdump(bytes: &[u8]) {
+    for (i, chunk) in bytes.chunks(16).enumerate() {
+        let hex: Vec<String> = chunk.iter().map(|b| format!("{b:02x}")).collect();
+        let ascii: String = chunk
+            .iter()
+            .map(|&b| if (0x20..0x7f).contains(&b) { b as char } else { '.' })
+            .collect();
+        println!("    {:04x}  {:<47}  {}", i * 16, hex.join(" "), ascii);
+    }
+}
+
+/// A decompressed sub-record: its 4-byte type + owned data bytes.
+type OwnedSub = ([u8; 4], Vec<u8>);
+
+/// Recursively walk records, invoking `f` on every record of `want` type
+/// with its (decompressed) sub-records.
+fn walk(reader: &mut EsmReader, end: usize, want: &[u8; 4], f: &mut dyn FnMut(u32, &[OwnedSub])) {
+    while reader.position() < end && reader.remaining() > 0 {
+        if reader.is_group() {
+            let Ok(g) = reader.read_group_header() else { return };
+            let sub_end = reader.group_content_end(&g);
+            walk(reader, sub_end, want, f);
+            continue;
+        }
+        let Ok(header) = reader.read_record_header() else { return };
+        if &header.record_type == want {
+            match reader.read_sub_records(&header) {
+                Ok(subs) => {
+                    let owned: Vec<OwnedSub> =
+                        subs.into_iter().map(|s| (s.sub_type, s.data)).collect();
+                    f(header.form_id, &owned);
+                }
+                Err(_) => continue,
+            }
+        } else {
+            reader.skip_record(&header);
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let esm_path = args
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("usage: dump_qust_vmad_fragments ESM [MAX]"))?;
+    let max: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(20);
+
+    let bytes = std::fs::read(&esm_path)?;
+    let mut reader = EsmReader::new(&bytes);
+    let end = bytes.len();
+
+    let mut shown = 0usize;
+    let mut total_qust = 0usize;
+    let mut with_vmad = 0usize;
+    let mut ver_hist: std::collections::BTreeMap<u8, usize> = std::collections::BTreeMap::new();
+
+    walk(&mut reader, end, b"QUST", &mut |form_id, subs| {
+        total_qust += 1;
+        let Some((_, vmad)) = subs.iter().find(|(t, _)| t == b"VMAD") else {
+            return;
+        };
+        with_vmad += 1;
+
+        let (scripts, consumed) = ScriptInstanceData::parse_with_consumed(vmad);
+        let frag = &vmad[consumed.min(vmad.len())..];
+        // Aggregate over EVERY qust-with-vmad: fragment-header version byte
+        // distribution (hardening the decoder — confirm version 2 universal).
+        if let Some(&ver) = frag.first() {
+            *ver_hist.entry(ver).or_insert(0) += 1;
+        }
+        if shown >= max {
+            return;
+        }
+        shown += 1;
+
+        println!("========================================================");
+        println!(
+            "QUST {form_id:08X}  vmad={} B  ver={} objFmt={}  scripts={}  scripts_end@{}  fragBytes={}",
+            vmad.len(),
+            scripts.version,
+            scripts.object_format,
+            scripts.scripts.len(),
+            consumed,
+            frag.len()
+        );
+        for s in &scripts.scripts {
+            println!("    script: {:?}  ({} props)", s.name, s.properties.len());
+        }
+        if frag.is_empty() {
+            println!("    (no trailing fragment bytes)");
+        } else {
+            println!("    -- fragment section (post-scripts) --");
+            hexdump(frag);
+            println!("    -- decoded bindings --");
+            for b in parse_quest_fragments(vmad) {
+                println!(
+                    "      stage {:>3} -> {}::{}",
+                    b.stage, b.script_name, b.fragment_name
+                );
+            }
+        }
+    });
+
+    eprintln!(
+        "[dump_qust_vmad_fragments] {esm_path}: {total_qust} QUST, {with_vmad} with VMAD, {shown} shown"
+    );
+    eprintln!("[dump_qust_vmad_fragments] fragment-header version byte histogram: {ver_hist:?}");
+    Ok(())
+}

--- a/crates/plugin/src/esm/records/misc/ai.rs
+++ b/crates/plugin/src/esm/records/misc/ai.rs
@@ -2,6 +2,7 @@
 
 use super::super::common::{read_lstring_or_zstring, read_zstring};
 use super::super::condition::{parse_ctda, remap_condition_form_ids, ConditionList};
+use super::super::script_instance::{parse_quest_fragments, QuestScriptFragment};
 use crate::esm::reader::SubRecord;
 use crate::esm::sub_reader::SubReader;
 
@@ -132,6 +133,13 @@ pub struct QustRecord {
     /// usually a strict subset of stages (one objective per major
     /// player-visible step).
     pub objectives: Vec<QuestObjective>,
+    /// Stage→`Fragment_N` bindings from the QUST `VMAD` fragment section
+    /// (Skyrim+). Each entry names the compiled quest script + the
+    /// fragment function the runtime runs when the quest reaches that
+    /// stage — the M47.2 fragment-dispatch input. Empty on FO3/FNV
+    /// (pre-Papyrus; they use `script_ref`) and on Skyrim+ quests whose
+    /// VMAD attaches only non-fragment utility scripts.
+    pub fragments: Vec<QuestScriptFragment>,
 }
 
 /// Which block-structured sub-record we're currently inside while
@@ -182,6 +190,13 @@ pub fn parse_qust(
             b"DATA" if sub.data.len() >= 2 => {
                 out.quest_flags = sub.data[0];
                 out.priority = sub.data[1];
+            }
+            // Skyrim+ Papyrus attachment. The scripts section is decoded
+            // by the generic path elsewhere; here we only want the QUST-
+            // specific trailing fragment section (stage→`Fragment_N`),
+            // the M47.2 fragment-dispatch input.
+            b"VMAD" => {
+                out.fragments = parse_quest_fragments(&sub.data);
             }
             // INDX opens a stage block. Anything still open (a prior
             // stage or objective) is flushed first. Skyrim widened
@@ -700,6 +715,41 @@ mod tests {
         assert_eq!(q.script_ref, 0x0010_BEEF);
         assert_eq!(q.quest_flags, 0x05);
         assert_eq!(q.priority, 20);
+    }
+
+    #[test]
+    fn parse_qust_decodes_vmad_stage_fragment_bindings() {
+        // A QUST carrying a VMAD with an empty scripts section + one
+        // stage fragment (stage 30 → Fragment_4) surfaces the binding on
+        // `QustRecord.fragments` — the M47.2 fragment-dispatch input.
+        let mut vmad = Vec::new();
+        // scripts section: version 5, objFmt 2, zero scripts.
+        vmad.extend_from_slice(&5i16.to_le_bytes());
+        vmad.extend_from_slice(&2i16.to_le_bytes());
+        vmad.extend_from_slice(&0u16.to_le_bytes());
+        // fragment section: version 2, one fragment.
+        vmad.push(2u8);
+        vmad.extend_from_slice(&1u16.to_le_bytes()); // fragmentCount
+        let file = b"QF_TestQuest_00001234";
+        vmad.extend_from_slice(&(file.len() as u16).to_le_bytes());
+        vmad.extend_from_slice(file);
+        vmad.extend_from_slice(&30u16.to_le_bytes()); // stage
+        vmad.extend_from_slice(&0i16.to_le_bytes());
+        vmad.extend_from_slice(&0i32.to_le_bytes());
+        vmad.push(1u8);
+        vmad.extend_from_slice(&(file.len() as u16).to_le_bytes());
+        vmad.extend_from_slice(file);
+        let frag = b"Fragment_4";
+        vmad.extend_from_slice(&(frag.len() as u16).to_le_bytes());
+        vmad.extend_from_slice(frag);
+        vmad.extend_from_slice(&0u16.to_le_bytes()); // aliasCount
+
+        let subs = vec![sub(b"EDID", b"TestQuest\0"), sub(b"VMAD", &vmad)];
+        let q = parse_qust(0x0000_1234, &subs, &None);
+        assert_eq!(q.fragments.len(), 1);
+        assert_eq!(q.fragments[0].stage, 30);
+        assert_eq!(q.fragments[0].script_name, "QF_TestQuest_00001234");
+        assert_eq!(q.fragments[0].fragment_name, "Fragment_4");
     }
 
     #[test]

--- a/crates/plugin/src/esm/records/script_instance.rs
+++ b/crates/plugin/src/esm/records/script_instance.rs
@@ -134,6 +134,20 @@ impl ScriptInstanceData {
     /// Decode a `VMAD` sub-record payload. Graceful: returns whatever
     /// decoded cleanly before any truncation/unknown-type.
     pub fn parse(data: &[u8]) -> Self {
+        Self::parse_with_consumed(data).0
+    }
+
+    /// Decode a `VMAD` scripts section, also returning the byte offset at
+    /// which decoding stopped — i.e. the start of any trailing per-record
+    /// *fragment* section (QUST / INFO / PACK / SCEN). Object records
+    /// (ACTI / REFR / …) have no fragment section, so the offset lands at
+    /// `data.len()` for them; the QUST fragment decoder uses this to seek
+    /// past the scripts to the stage→`Fragment_N` table.
+    ///
+    /// On a truncated/unknown-type scripts section the offset marks how
+    /// far the graceful decode got; a fragment decoder should treat a
+    /// short read as "no fragments" rather than seeking into garbage.
+    pub fn parse_with_consumed(data: &[u8]) -> (Self, usize) {
         let mut c = Cursor::new(data);
         let version = c.i16().unwrap_or(0);
         let object_format = c.i16().unwrap_or(0);
@@ -143,7 +157,7 @@ impl ScriptInstanceData {
             scripts: Vec::new(),
         };
         let Some(script_count) = c.u16() else {
-            return out;
+            return (out, c.pos);
         };
         let has_status = version >= 4;
         for _ in 0..script_count {
@@ -194,8 +208,99 @@ impl ScriptInstanceData {
                 break;
             }
         }
-        out
+        (out, c.pos)
     }
+}
+
+/// One quest-stage script-fragment binding decoded from a QUST `VMAD`
+/// fragment section: the compiled quest script + the `Fragment_N`
+/// function the runtime runs when the quest reaches `stage`.
+///
+/// This is the M47.2 keystone datum — it binds a quest stage to the
+/// Papyrus function whose body the `byroredux_scripting` fragment lowerer
+/// turns into canonical ECS effects. Without it the (already built +
+/// tested) lowerer and dispatcher never see real game data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuestScriptFragment {
+    /// Quest stage index this fragment runs on (leading `u16` of the
+    /// per-fragment struct).
+    pub stage: u16,
+    /// The compiled quest script (`QF_<Quest>_<FormID>`) — the `.pex` to
+    /// decompile. Equal to the section's `fileName` on all vanilla
+    /// samples, but the per-fragment field is authoritative.
+    pub script_name: String,
+    /// The fragment function to invoke (`Fragment_N`).
+    pub fragment_name: String,
+}
+
+/// Decode the trailing *fragment* section of a QUST `VMAD` payload into
+/// stage→`Fragment_N` bindings. `vmad` is the whole VMAD sub-record
+/// (scripts section first — skipped via [`ScriptInstanceData::parse_with_consumed`]
+/// — then the fragment section this reads).
+///
+/// ## Layout (Skyrim SE, empirically derived + cross-validated)
+///
+/// No public byte-spec was in-repo (same situation as the scripts
+/// section), so the layout was derived by dumping every QUST VMAD in
+/// `Skyrim.esm` (`examples/dump_qust_vmad_fragments.rs`) and confirming
+/// every field cross-validates: the version byte is `2` on all 856
+/// fragment-bearing QUST VMADs; `fileName` / `scriptName` decode to
+/// readable `QF_<Quest>_<FormID>` ASCII; `fragmentName` is `Fragment_N`;
+/// stage values match the quest's INDX stage set.
+///
+/// ```text
+/// u8      version            (== 2; distinct from the scripts-section version 5)
+/// u16     fragmentCount
+/// wstring fileName           (the QF_ compiled quest script)
+/// fragmentCount × {
+///   u16     stage            (the quest stage this fragment runs on)
+///   i16     unk0             (0 on every vanilla sample)
+///   i32     stageIndex/logentry (0 on every vanilla sample)
+///   u8      flags            (1 on every vanilla sample)
+///   wstring scriptName       (== fileName)
+///   wstring fragmentName     (Fragment_N)
+/// }
+/// u16     aliasCount         (trailing alias fragments — not decoded; not
+///                             needed for stage dispatch)
+/// ```
+///
+/// Graceful + conservative: an absent/short fragment section (object-only
+/// VMADs), or a `version != 2` header (e.g. FO4's differing shape, which
+/// needs its own derivation under the no-guessing policy), returns empty
+/// rather than guessing — matching the scripts-section decoder's
+/// recover-don't-crash contract.
+pub fn parse_quest_fragments(vmad: &[u8]) -> Vec<QuestScriptFragment> {
+    let (_, consumed) = ScriptInstanceData::parse_with_consumed(vmad);
+    let Some(section) = vmad.get(consumed..) else {
+        return Vec::new();
+    };
+    let mut c = Cursor::new(section);
+    // Skyrim fragment sections are universally version 2; decline any
+    // other value rather than misread an underived shape.
+    if c.u8() != Some(2) {
+        return Vec::new();
+    }
+    let Some(count) = c.u16() else {
+        return Vec::new();
+    };
+    let Some(_file_name) = c.wstring() else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let Some(stage) = c.u16() else { break };
+        let (Some(_unk0), Some(_unk1), Some(_flags)) = (c.i16(), c.i32(), c.u8()) else {
+            break;
+        };
+        let Some(script_name) = c.wstring() else { break };
+        let Some(fragment_name) = c.wstring() else { break };
+        out.push(QuestScriptFragment {
+            stage,
+            script_name,
+            fragment_name,
+        });
+    }
+    out
 }
 
 /// Minimal bounds-checked little-endian cursor over a VMAD payload.
@@ -423,5 +528,129 @@ mod tests {
         assert_eq!(s.property("I").unwrap().value, PropertyValue::Int32(42));
         assert_eq!(s.property("F").unwrap().value, PropertyValue::Float(1.5));
         assert_eq!(s.property("B").unwrap().value, PropertyValue::Bool(true));
+    }
+
+    // ---- QUST fragment section ----------------------------------------
+
+    /// A minimal, valid empty scripts section (version 5, objectFormat 2,
+    /// zero scripts) — 6 bytes. `parse_with_consumed` stops right after
+    /// it, so a fragment section appended here starts at offset 6. Real
+    /// QUST VMADs carry a populated scripts section first; the fragment
+    /// decoder only cares where it *ends*, so an empty one exercises the
+    /// same seek-past-scripts path.
+    fn empty_scripts_prefix() -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&5i16.to_le_bytes()); // version
+        v.extend_from_slice(&2i16.to_le_bytes()); // objectFormat
+        v.extend_from_slice(&0u16.to_le_bytes()); // scriptCount = 0
+        v
+    }
+
+    /// Build a QUST fragment section per the derived layout.
+    fn fragment_section(file_name: &str, frags: &[(u16, &str, &str)]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.push(2u8); // version
+        v.extend_from_slice(&(frags.len() as u16).to_le_bytes());
+        v.extend_from_slice(&(file_name.len() as u16).to_le_bytes());
+        v.extend_from_slice(file_name.as_bytes());
+        for (stage, script, frag) in frags {
+            v.extend_from_slice(&stage.to_le_bytes());
+            v.extend_from_slice(&0i16.to_le_bytes()); // unk0
+            v.extend_from_slice(&0i32.to_le_bytes()); // stageIndex/logentry
+            v.push(1u8); // flags
+            v.extend_from_slice(&(script.len() as u16).to_le_bytes());
+            v.extend_from_slice(script.as_bytes());
+            v.extend_from_slice(&(frag.len() as u16).to_le_bytes());
+            v.extend_from_slice(frag.as_bytes());
+        }
+        v.extend_from_slice(&0u16.to_le_bytes()); // aliasCount = 0
+        v
+    }
+
+    /// The real `DA08FriendKill` (`0010FAEE`) fragment section from
+    /// `Skyrim.esm` — 82 bytes, one fragment (stage 0 → `Fragment_2`),
+    /// captured via `examples/dump_qust_vmad_fragments.rs`. Ground-truth
+    /// fidelity fixture for the empirically-derived layout.
+    const DA08_FRAGMENT_SECTION_HEX: &str = "0201001a0051465f4441303846726965\
+6e644b696c6c5f303031304641454500\
+00000000000000011a0051465f444130\
+38467269656e644b696c6c5f30303130\
+464145450a00467261676d656e745f32\
+0000";
+
+    #[test]
+    fn decodes_real_skyrim_qust_fragment_section() {
+        let mut vmad = empty_scripts_prefix();
+        let frag = from_hex(DA08_FRAGMENT_SECTION_HEX);
+        assert_eq!(frag.len(), 82);
+        vmad.extend_from_slice(&frag);
+
+        let frags = parse_quest_fragments(&vmad);
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].stage, 0);
+        assert_eq!(frags[0].script_name, "QF_DA08FriendKill_0010FAEE");
+        assert_eq!(frags[0].fragment_name, "Fragment_2");
+    }
+
+    #[test]
+    fn decodes_multi_fragment_section_preserving_stage_binding() {
+        // Mirrors the real DA15Return shape: three fragments, stages out
+        // of authoring/name order — the stage u16 is authoritative, NOT
+        // the Fragment_N ordinal.
+        let mut vmad = empty_scripts_prefix();
+        vmad.extend_from_slice(&fragment_section(
+            "QF_DA15Return_0010FF8F",
+            &[
+                (0, "QF_DA15Return_0010FF8F", "Fragment_6"),
+                (200, "QF_DA15Return_0010FF8F", "Fragment_3"),
+                (10, "QF_DA15Return_0010FF8F", "Fragment_5"),
+            ],
+        ));
+        let frags = parse_quest_fragments(&vmad);
+        assert_eq!(frags.len(), 3);
+        assert_eq!((frags[0].stage, &*frags[0].fragment_name), (0, "Fragment_6"));
+        assert_eq!(
+            (frags[1].stage, &*frags[1].fragment_name),
+            (200, "Fragment_3")
+        );
+        assert_eq!((frags[2].stage, &*frags[2].fragment_name), (10, "Fragment_5"));
+    }
+
+    #[test]
+    fn declines_non_version_2_fragment_section() {
+        // A version byte the layout wasn't derived against (e.g. FO4's
+        // differing shape) declines rather than misreads.
+        let mut vmad = empty_scripts_prefix();
+        let mut section = fragment_section("QF_X_0", &[(0, "QF_X_0", "Fragment_0")]);
+        section[0] = 5; // corrupt the fragment version
+        vmad.extend_from_slice(&section);
+        assert!(parse_quest_fragments(&vmad).is_empty());
+    }
+
+    #[test]
+    fn object_only_vmad_yields_no_fragments() {
+        // A real ACTI-shaped VMAD (scripts only, no fragment section)
+        // returns no fragments — the consumed offset lands at the end.
+        let bytes = from_hex(WINTERHOLD_JAIL_VMAD_HEX);
+        assert!(parse_quest_fragments(&bytes).is_empty());
+    }
+
+    #[test]
+    fn truncated_fragment_section_recovers_gracefully() {
+        // Cut a valid two-fragment section mid-way through the second
+        // fragment: the first fragment survives, decode stops cleanly.
+        let mut vmad = empty_scripts_prefix();
+        let section = fragment_section(
+            "QF_Y_0",
+            &[(1, "QF_Y_0", "Fragment_0"), (2, "QF_Y_0", "Fragment_1")],
+        );
+        // Keep the prefix + the whole first fragment + a few bytes of the
+        // second (enough to read its stage, not its strings).
+        let keep = vmad.len() + section.len() - 10;
+        vmad.extend_from_slice(&section);
+        vmad.truncate(keep);
+        let frags = parse_quest_fragments(&vmad);
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].fragment_name, "Fragment_0");
     }
 }

--- a/crates/scripting/examples/quest_fragment_populate.rs
+++ b/crates/scripting/examples/quest_fragment_populate.rs
@@ -1,0 +1,120 @@
+//! End-to-end M47.2 keystone validation — headless, no Vulkan.
+//!
+//! Drives the *complete* real pipeline the cell loader runs, on real game
+//! data: parse an ESM → read each QUST's `VMAD` fragment bindings
+//! (stage→`Fragment_N`) → resolve + decompile the quest's compiled `.pex`
+//! from a scripts archive → lower each bound fragment body to canonical
+//! effects → register into [`QuestStageFragments`]. Reports how many
+//! quests, bindings, and effects actually populate.
+//!
+//! This is the runtime analog of `fragment_coverage` (which measures the
+//! lowerer over the *whole* corpus): here we only touch the fragments the
+//! VMAD decoder actually binds to a stage, exactly as the engine does.
+//!
+//! ```bash
+//! cargo run --release -p byroredux-scripting --example quest_fragment_populate -- \
+//!   "<Skyrim SE>/Data/Skyrim.esm" \
+//!   "<Skyrim SE>/Data/Skyrim - Misc.bsa"
+//! ```
+
+use byroredux_bsa::{Ba2Archive, BsaArchive};
+use byroredux_scripting::{populate_quest_fragments_from_pex, QuestFormId, QuestStageFragments};
+
+enum Archive {
+    Bsa(BsaArchive),
+    Ba2(Ba2Archive),
+}
+
+impl Archive {
+    fn open(path: &str) -> std::io::Result<Self> {
+        if path.to_ascii_lowercase().ends_with(".ba2") {
+            Ok(Archive::Ba2(Ba2Archive::open(path)?))
+        } else {
+            Ok(Archive::Bsa(BsaArchive::open(path)?))
+        }
+    }
+    fn extract(&self, path: &str) -> std::io::Result<Vec<u8>> {
+        match self {
+            Archive::Bsa(a) => a.extract(path),
+            Archive::Ba2(a) => a.extract(path),
+        }
+    }
+}
+
+/// Mirror the engine's `pex_archive_path` normalisation.
+fn pex_key(script_name: &str) -> String {
+    let mut name = script_name.replace('/', "\\").to_ascii_lowercase();
+    if !name.ends_with(".pex") {
+        name.push_str(".pex");
+    }
+    if !name.starts_with("scripts\\") {
+        name = format!("scripts\\{name}");
+    }
+    name
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let esm_path = args
+        .next()
+        .ok_or("usage: quest_fragment_populate ESM SCRIPTS_ARCHIVE")?;
+    let scripts_path = args
+        .next()
+        .ok_or("usage: quest_fragment_populate ESM SCRIPTS_ARCHIVE")?;
+
+    let bytes = std::fs::read(&esm_path)?;
+    let index = byroredux_plugin::esm::parse_esm(&bytes).map_err(|e| e.to_string())?;
+    let archive = Archive::open(&scripts_path)?;
+
+    let mut frags = QuestStageFragments::default();
+    let mut quests_with_bindings = 0usize;
+    let mut total_bindings = 0usize;
+    let mut pex_missing = 0usize;
+    let mut inserted = 0usize;
+    let mut examples: Vec<String> = Vec::new();
+
+    for (&form_id, quest) in index.quests.iter() {
+        if quest.fragments.is_empty() {
+            continue;
+        }
+        quests_with_bindings += 1;
+        total_bindings += quest.fragments.len();
+
+        // All fragments share one QF_ script.
+        let script_name = &quest.fragments[0].script_name;
+        let Ok(pex) = archive.extract(&pex_key(script_name)) else {
+            pex_missing += 1;
+            continue;
+        };
+        let bindings: Vec<(u16, &str)> = quest
+            .fragments
+            .iter()
+            .map(|f| (f.stage, f.fragment_name.as_str()))
+            .collect();
+        let before = frags.len();
+        let n =
+            populate_quest_fragments_from_pex(&mut frags, QuestFormId(form_id), &pex, &bindings);
+        inserted += n;
+        if n > 0 && examples.len() < 15 {
+            examples.push(format!(
+                "{form_id:08X} {script_name}: {n}/{} stage fragments lowered (map now {})",
+                quest.fragments.len(),
+                frags.len().max(before),
+            ));
+        }
+    }
+
+    println!("== M47.2 quest-fragment population (real pipeline) ==");
+    println!("ESM:            {esm_path}");
+    println!("scripts:        {scripts_path}");
+    println!("scripted quests (VMAD fragment bindings): {quests_with_bindings}");
+    println!("total stage→Fragment_N bindings:          {total_bindings}");
+    println!("quests whose .pex was missing:            {pex_missing}");
+    println!("stage fragments fully lowered + registered: {inserted}");
+    println!("QuestStageFragments map size:             {}", frags.len());
+    println!("-- examples --");
+    for e in &examples {
+        println!("  {e}");
+    }
+    Ok(())
+}

--- a/crates/scripting/src/fragment.rs
+++ b/crates/scripting/src/fragment.rs
@@ -42,11 +42,15 @@ use byroredux_plugin::esm::records::script_instance::ScriptInstanceData;
 use crate::quest_stages::{
     QuestFormId, QuestObjectiveState, QuestStageAdvanced, QuestStageAdvancedBatch, QuestStageState,
 };
-use crate::translate::compose::QuestRef;
-use crate::translate::effects::Effect;
+use byroredux_papyrus::ast::{Script, ScriptItem, StateItem, Stmt};
+use byroredux_papyrus::span::Spanned;
 
-/// Lowered quest-stage fragments, keyed by `(quest, stage)`. Populated by
-/// the (pending) QUST-fragment decoder; consumed by
+use crate::translate::compose::QuestRef;
+use crate::translate::effects::{lower_fragment, Effect};
+
+/// Lowered quest-stage fragments, keyed by `(quest, stage)`. Populated at
+/// cell load by [`populate_quest_fragments_from_pex`] from the QUST `VMAD`
+/// fragment bindings the decoder recovers; consumed by
 /// [`quest_fragment_dispatch_system`].
 #[derive(Debug, Default)]
 pub struct QuestStageFragments {
@@ -167,15 +171,123 @@ pub fn register(world: &mut World) {
     world.insert_resource(QuestObjectiveState::default());
 }
 
+/// A top-level (or state) function body from a decompiled script, by name
+/// (Papyrus identifiers are case-insensitive). Quest `Fragment_N`
+/// functions are top-level, but state functions are checked too so the
+/// lookup is robust.
+fn function_body<'a>(script: &'a Script, name: &str) -> Option<&'a [Spanned<Stmt>]> {
+    for item in &script.body {
+        match &item.node {
+            ScriptItem::Function(f) if f.name.node.0.eq_ignore_ascii_case(name) => {
+                return Some(&f.body);
+            }
+            ScriptItem::State(st) => {
+                for si in &st.body {
+                    if let StateItem::Function(f) = &si.node {
+                        if f.name.node.0.eq_ignore_ascii_case(name) {
+                            return Some(&f.body);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Populate [`QuestStageFragments`] for one quest from its compiled quest
+/// script (`.pex`). Each `(stage, fragment_name)` binding comes from the
+/// QUST `VMAD` fragment section
+/// ([`byroredux_plugin::esm::records::script_instance::parse_quest_fragments`]);
+/// all fragments of a quest share a single `QF_` script, so the caller
+/// resolves and passes its bytes once. Returns the number of stage
+/// fragments inserted (non-empty, fully-lowered ones).
+///
+/// This is the runtime half of the M47.2 keystone: it takes the
+/// stage→`Fragment_N` binding the decoder recovered and turns each
+/// fragment body into the canonical [`Effect`]s the dispatcher applies —
+/// closing the loop from real game data to quest behavior on screen.
+///
+/// Mirrors [`crate::translate::translate_pex`]'s hostile-input contract:
+/// a `.pex` that fails to parse/decompile — including a decompiler panic
+/// (#1816) — inserts nothing (logged at debug), never aborts the load. A
+/// fragment carrying a statement no effect primitive claims lowers to
+/// `None` and is declined (safe — no behavior attached), never partially
+/// applied.
+pub fn populate_quest_fragments_from_pex(
+    frags: &mut QuestStageFragments,
+    quest: QuestFormId,
+    pex_bytes: &[u8],
+    bindings: &[(u16, &str)],
+) -> usize {
+    let pex = match byroredux_pex::parse(pex_bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            log::debug!("populate_quest_fragments: .pex parse failed (quest {:08X}): {e}", quest.0);
+            return 0;
+        }
+    };
+    let script = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        byroredux_pex::decompile::decompile_script(&pex)
+    })) {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            log::debug!("populate_quest_fragments: decompile failed (quest {:08X}): {e}", quest.0);
+            return 0;
+        }
+        Err(_) => {
+            log::debug!("populate_quest_fragments: decompile panicked (quest {:08X})", quest.0);
+            return 0;
+        }
+    };
+    populate_quest_fragments_from_script(frags, quest, &script, bindings)
+}
+
+/// The AST half of [`populate_quest_fragments_from_pex`] — lower each
+/// `(stage, fragment_name)` binding against an already-decompiled (or
+/// source-parsed) [`Script`] and register the non-empty lowerings.
+/// Split out so the lowering path is unit-testable from a `.psc` source
+/// without game-data `.pex` bytes.
+pub fn populate_quest_fragments_from_script(
+    frags: &mut QuestStageFragments,
+    quest: QuestFormId,
+    script: &Script,
+    bindings: &[(u16, &str)],
+) -> usize {
+    let mut inserted = 0;
+    for (stage, fragment_name) in bindings {
+        let Some(body) = function_body(script, fragment_name) else {
+            log::debug!(
+                "populate_quest_fragments: fn '{fragment_name}' absent in quest {:08X} .pex",
+                quest.0
+            );
+            continue;
+        };
+        // Decline-on-any-unmodeled-term: a fragment the effect table can't
+        // fully lower is skipped, not partially applied. An empty
+        // fully-lowered fragment carries no effects, so it needn't occupy
+        // the map (a lookup miss is equivalent to an empty entry).
+        if let Some(effects) = lower_fragment(body) {
+            if !effects.is_empty() {
+                frags.insert(quest, *stage, effects);
+                inserted += 1;
+            }
+        }
+    }
+    inserted
+}
+
 /// Consume [`QuestStageAdvanced`] markers and run the matching
 /// `(quest, stage)` fragments, cascading any `SetStage`s they perform
 /// (bounded by [`MAX_CASCADE`]). Runs after `quest_advance_system` (which
 /// emits the initial markers) and before end-of-frame cleanup.
 ///
-/// Resolution uses no QUST VMAD (not decoded yet), so only `Self`/
-/// owning-quest-targeted effects apply; property-targeted effects are
-/// skipped. The resource is empty until the QUST-fragment decoder lands,
-/// making this a safe no-op at runtime today.
+/// Effect resolution passes no QUST VMAD, so only `Self`/owning-quest-
+/// targeted effects apply — which is exactly the set [`lower_fragment`]
+/// emits today (object-targeting effects decline pending a FormID→entity
+/// resolver), so nothing is silently dropped. The table is empty (and this
+/// a no-op) on loads without `--scripts-bsa` or on pre-Papyrus games.
 pub fn quest_fragment_dispatch_system(world: &World) {
     // Snapshot the stage advances this frame. #1864 / SCR-D7-NEW-01 — a
     // batch can hold >1 advance from the same frame; iterate every entry,

--- a/crates/scripting/src/fragment/tests.rs
+++ b/crates/scripting/src/fragment/tests.rs
@@ -217,6 +217,92 @@ fn end_to_end_lower_then_dispatch() {
 }
 
 #[test]
+fn populate_from_script_binds_stages_to_the_right_fragments() {
+    // Exercises the production population entry (the AST half of
+    // `populate_quest_fragments_from_pex`): a QF_ script with several
+    // Fragment_N functions + the QUST VMAD stage→Fragment_N bindings →
+    // each stage dispatches its own fragment's effects. Mirrors the real
+    // DA15Return shape where the Fragment_N ordinal ≠ the stage.
+    use byroredux_papyrus::parse_script;
+
+    let (script, errs) = parse_script(
+        "ScriptName QF_TestQuest_00099 extends Quest\n\
+         Function Fragment_6()\n Self.SetStage(200)\n EndFunction\n\
+         Function Fragment_3()\n Self.SetObjectiveCompleted(10)\n EndFunction\n\
+         Function Fragment_5()\n Self.SetObjectiveDisplayed(20)\n EndFunction\n",
+    )
+    .expect("QF_ script parses");
+    assert!(errs.is_empty(), "{errs:?}");
+
+    // Bindings as the VMAD decoder would surface them: stage → Fragment_N,
+    // deliberately out of ordinal order.
+    let bindings = [(0u16, "Fragment_6"), (200, "Fragment_3"), (10, "Fragment_5")];
+
+    let world = fixture();
+    let inserted = {
+        let mut frags = world.resource_mut::<QuestStageFragments>();
+        populate_quest_fragments_from_script(&mut frags, Q, &script, &bindings)
+    };
+    assert_eq!(inserted, 3, "all three fragments lower + register");
+
+    // Stage 10 → Fragment_5 → SetObjectiveDisplayed(20).
+    world.resource_mut::<QuestStageState>().set_stage(Q, 10);
+    emit_advance(&world, Q, 10);
+    quest_fragment_dispatch_system(&world);
+    assert!(
+        world.resource::<QuestObjectiveState>().get(Q, 20).displayed,
+        "stage 10's fragment (Fragment_5) ran"
+    );
+    assert!(
+        !world.resource::<QuestObjectiveState>().get(Q, 10).completed,
+        "stage 3's fragment must NOT have run — wrong stage"
+    );
+
+    // Stage 0 → Fragment_6 → SetStage(200) → cascades to Fragment_3 →
+    // SetObjectiveCompleted(10).
+    emit_advance(&world, Q, 0);
+    quest_fragment_dispatch_system(&world);
+    assert_eq!(
+        world.resource::<QuestStageState>().get_stage(Q),
+        200,
+        "Fragment_6 advanced the quest to stage 200"
+    );
+    assert!(
+        world.resource::<QuestObjectiveState>().get(Q, 10).completed,
+        "the stage-200 cascade ran Fragment_3"
+    );
+}
+
+#[test]
+fn populate_from_script_skips_absent_and_declined_fragments() {
+    use byroredux_papyrus::parse_script;
+
+    let (script, errs) = parse_script(
+        "ScriptName QF_X_0 extends Quest\n\
+         Function Fragment_0()\n Self.SetStage(20)\n EndFunction\n\
+         Function Fragment_1()\n Debug.Notification(\"hi\")\n EndFunction\n",
+    )
+    .expect("parses");
+    assert!(errs.is_empty(), "{errs:?}");
+
+    let bindings = [
+        (5u16, "Fragment_0"),  // lowers cleanly
+        (6, "Fragment_1"),     // unmodeled call → declines
+        (7, "Fragment_99"),    // absent → skipped
+    ];
+    let world = fixture();
+    let inserted = {
+        let mut frags = world.resource_mut::<QuestStageFragments>();
+        populate_quest_fragments_from_script(&mut frags, Q, &script, &bindings)
+    };
+    assert_eq!(inserted, 1, "only the fully-lowered fragment registers");
+    let frags = world.resource::<QuestStageFragments>();
+    assert!(frags.get(Q, 5).is_some());
+    assert!(frags.get(Q, 6).is_none(), "declined fragment not registered");
+    assert!(frags.get(Q, 7).is_none(), "absent fragment not registered");
+}
+
+#[test]
 fn dispatch_ignores_stage_without_a_fragment() {
     let world = fixture();
     {

--- a/crates/scripting/src/lib.rs
+++ b/crates/scripting/src/lib.rs
@@ -32,8 +32,10 @@ pub use events::{
     OnEquipEvent, OnTriggerEnterEvent, TimerExpired,
 };
 pub use fragment::{
-    apply_effects, quest_fragment_dispatch_system, QuestStageFragments,
+    apply_effects, populate_quest_fragments_from_pex, quest_fragment_dispatch_system,
+    QuestStageFragments,
 };
+pub use quest_stages::QuestFormId;
 pub use globals::Globals;
 pub use recurring_update::{recurring_update_tick_system, OnUpdateEvent, RecurringUpdate};
 pub use registry::{ScriptRegistry, ScriptSpawnFn};

--- a/crates/scripting/src/translate/mod.rs
+++ b/crates/scripting/src/translate/mod.rs
@@ -32,16 +32,20 @@ use byroredux_plugin::esm::records::script_instance::ScriptInstanceData;
 /// before the generic ones so a bespoke script isn't swallowed by a
 /// family match.
 ///
-/// **Staged, not yet wired (SCR-D5-02 / #1739).** The quest-fragment
-/// lowerer [`effects::lower_fragment`] (+ `effects::EFFECT_PRIMITIVES`) is
-/// complete and unit-tested but has **no** entry in this table, so no
-/// decompiled quest-fragment `.pex` reaches it through the live boundary
-/// today — it is exercised only by its own tests. Wiring waits on the QUST
-/// `VMAD` fragment decoder that would feed each stage's `Fragment_NN` body
-/// into `lower_fragment`; until that lands the table is intentionally
-/// fragment-free (not an oversight). When it lands, add a
-/// `fragment::recognize` entry here and the end-to-end `.pex` →
-/// [`translate_script`] → effect-spawn test the issue calls for.
+/// **Fragments dispatch off-chain, by contract — not through this table
+/// (SCR-D5-02 / #1739 landed).** The quest-fragment lowerer
+/// [`effects::lower_fragment`] is deliberately absent from `RECOGNIZERS`:
+/// fragments are invoked by the quest-stage contract (stage N's
+/// `Fragment_N` runs when the quest reaches stage N), not by shape
+/// recognition. The QUST `VMAD` fragment decoder
+/// (`byroredux_plugin::esm::records::script_instance::parse_quest_fragments`,
+/// landed) recovers each stage→`Fragment_N` binding, and
+/// [`crate::fragment::populate_quest_fragments_from_pex`] feeds each body
+/// into `lower_fragment` at cell load, keyed into
+/// [`crate::fragment::QuestStageFragments`] for
+/// [`crate::quest_fragment_dispatch_system`]. So this recognizer chain
+/// stays event-handler-only (the ~22% handler population); the 69.5%
+/// fragment population flows through the stage-contract path instead.
 const RECOGNIZERS: &[Recognizer] = &[
     // Per-script (long tail):
     recognizers::rumble::recognize,

--- a/docs/engine/m47-2-recognizer-scaling.md
+++ b/docs/engine/m47-2-recognizer-scaling.md
@@ -178,10 +178,25 @@ steep head the primitive-frequency curve predicted. The example doubles
 as a coverage-regression gate as the table grows toward the ~500-primitive
 / ~78% target. The lowerer is fully tested
 ([`crates/scripting/src/translate/effects.rs`](../../crates/scripting/src/translate/effects.rs))
-and dispatched through [`crates/scripting/src/fragment.rs`]; the only
-missing piece for runtime population is the **QUST VMAD fragment-section
-decoder** (stage→`Fragment_N` binding), deferred pending the format spec
-(no-guessing policy).
+and dispatched through [`crates/scripting/src/fragment.rs`].
+
+**Runtime population landed.** The last missing piece — the **QUST VMAD
+fragment-section decoder** (stage→`Fragment_N` binding) — is now built.
+Its layout was derived empirically + cross-validated against `Skyrim.esm`
+(version byte `2` on all 856 fragment-bearing QUST VMADs;
+[`crates/plugin/examples/dump_qust_vmad_fragments.rs`](../../crates/plugin/examples/dump_qust_vmad_fragments.rs)),
+the same accepted method the scripts-section decoder used —
+[`parse_quest_fragments`](../../crates/plugin/src/esm/records/script_instance.rs)
+surfaces the bindings on `QustRecord.fragments`. At cell load the binary's
+`populate_quest_fragments` resolves each quest's compiled `QF_` `.pex`,
+decompiles it, and lowers each bound fragment body via
+[`populate_quest_fragments_from_pex`](../../crates/scripting/src/fragment.rs)
+into `QuestStageFragments` for `quest_fragment_dispatch_system`. End-to-end
+on real data (`crates/scripting/examples/quest_fragment_populate.rs`):
+**845 scripted Skyrim quests → 5,108 stage bindings → 742 stage fragments
+lowered + registered** (14.5%, gated by the current 5-primitive effect
+table; the remainder decline safely pending more b2 primitives + the
+FormID→entity resolver).
 
 ## Sequencing
 


### PR DESCRIPTION
The quest-fragment lowerer + dispatcher (69.5% of the script corpus) were built and tested but dead at runtime: nothing bound quest stages to their Fragment_N bodies, so QuestStageFragments only ever saw test data. This adds the missing link — the QUST VMAD fragment-section decoder — and wires it end to end, so vanilla quests advance objectives from real game data.

Decoder (crates/plugin):
- ScriptInstanceData::parse_with_consumed exposes the scripts-section end.
- parse_quest_fragments decodes the trailing stage->Fragment_N table onto QustRecord.fragments. Layout was derived empirically + cross-validated against Skyrim.esm (version byte 2 on all 856 fragment-bearing QUST VMADs) via the new dump_qust_vmad_fragments example — the same accepted method the scripts-section decoder used, per the no-guessing policy. Graceful: declines version != 2 (e.g. FO4's underived shape) rather than misreading. Real-bytes fixture (DA08FriendKill) + edge-case tests.

Population (crates/scripting + binary):
- populate_quest_fragments_from_pex decompiles a quest's QF_ .pex once and lowers each bound fragment body to canonical effects (split into a from_script half for game-data-free unit tests). Same hostile-input contract as translate_pex (parse/decompile/panic -> clean no-op).
- The cell loader calls populate_quest_fragments after load_references: resolves each quest's .pex via ScriptProvider, keys the lowerings into QuestStageFragments for quest_fragment_dispatch_system. No-op without --scripts-bsa or on pre-Papyrus games.

Validated end to end headlessly on real Skyrim data (quest_fragment_populate example): 845 scripted quests -> 5,108 stage bindings -> 742 stage fragments lowered + registered, 0 .pex missing. The 14.5% rate is gated by the current 5-primitive effect table; the rest decline safely pending more b2 primitives + a FormID->entity resolver.

Updated now-stale "decoder pending" docs (fragment.rs, translate/mod.rs, m47-2-recognizer-scaling.md). Full workspace lib suite green; clippy clean.