### PR TITLE
fix(nif): gate FO4 legacy shader type

### DIFF
--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -831,7 +831,7 @@ impl BSLightingShaderProperty {
     /// | Range | Parser | Distinguishing features |
     /// |---|---|---|
     /// | BSVER 83-129 | [`parse_skyrim`](Self::parse_skyrim) | u32 shader-flag pair, `lighting_effect_1/2`, no `root_material_path`, no wetness, no FO76 trailing |
-    /// | BSVER 130-154 | [`parse_fo4`](Self::parse_fo4) | u32 pair at BSVER=130 only (gap at 131; CRC32 from 132); `root_material_path`; FO4 subsurface block 130-139; wetness; glossiness scale ×100 |
+    /// | BSVER 130-154 | [`parse_fo4`](Self::parse_fo4) | legacy shader type + u32 pair at BSVER=130 only (gap at 131; CRC32 from 132); `root_material_path`; FO4 subsurface block 130-139; wetness; glossiness scale ×100 |
     /// | BSVER ≥ 155 | [`parse_fo76_plus`](Self::parse_fo76_plus) | shader-type comes AFTER name; material-reference stopcond; CRC32 flag arrays; FO76 luminance/translucency/texture-arrays; FO76 shader-type-data table |
     ///
     /// The three per-variant parsers are bit-for-bit equivalent to the
@@ -948,7 +948,8 @@ impl BSLightingShaderProperty {
 
     /// Fallout 4 + dev-band parser (BSVER 130-154).
     ///
-    /// - `legacy_shader_type` (u32) precedes `NiObjectNETData`.
+    /// - `legacy_shader_type` (u32) precedes `NiObjectNETData` only through
+    ///   BSVER 139; BSVER 140-154 defaults it to 0 and starts at the name.
     /// - **Shader-flag encoding splits within the range**:
     ///   - BSVER == 130: u32 pair (`shader_flags_1/2`), no CRC32.
     ///   - BSVER == 131 (`FO4_SHADER_GAP`): NEITHER — dev-stream 131 ships
@@ -974,7 +975,11 @@ impl BSLightingShaderProperty {
     /// - No `lighting_effect_1/2` (Skyrim-only).
     /// - No FO76 luminance/translucency/texture-arrays.
     fn parse_fo4(stream: &mut NifStream, bsver: u32) -> io::Result<Self> {
-        let shader_type = stream.read_u32_le()?;
+        let shader_type = if bsver < crate::version::bsver::FO4_DLC_UPPER {
+            stream.read_u32_le()?
+        } else {
+            0
+        };
         let net = NiObjectNETData::parse(stream)?;
 
         let (shader_flags_1, shader_flags_2) = if bsver <= crate::version::bsver::FALLOUT4 {

--- a/crates/nif/src/blocks/shader_tests.rs
+++ b/crates/nif/src/blocks/shader_tests.rs
@@ -707,6 +707,52 @@ fn bs_lighting_bsver_132_reads_crc_counts_but_not_flag_pair() {
     );
 }
 
+/// Regression for #2002: BSVER 140+ no longer carries the legacy shader
+/// type before `NiObjectNETData`. Reading it shifts Name and every following
+/// field by four bytes.
+#[test]
+fn bs_lighting_bsver_140_skips_legacy_shader_type() {
+    let header = make_fo4_header_with_bsver(140);
+    let mut data = Vec::new();
+
+    // NiObjectNET is the first field at BSVER >= FO4_DLC_UPPER.
+    data.extend_from_slice(&0i32.to_le_bytes());
+    data.extend_from_slice(&0u32.to_le_bytes());
+    data.extend_from_slice(&(-1i32).to_le_bytes());
+    // CRC flags: Num SF1 only; Num SF2 starts at BSVER 152.
+    data.extend_from_slice(&0u32.to_le_bytes());
+    for v in [0.0f32, 0.0, 1.0, 1.0] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    data.extend_from_slice(&3i32.to_le_bytes());
+    for v in [0.0f32, 0.5, 1.0, 2.0] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    data.extend_from_slice(&(-1i32).to_le_bytes());
+    data.extend_from_slice(&3u32.to_le_bytes());
+    for v in [0.8f32, 0.0, 0.5] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in [1.0f32, 0.9, 0.8, 1.5] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    // BSVER 140 omits the FO4 subsurface block.
+    data.extend_from_slice(&0.7f32.to_le_bytes());
+    data.extend_from_slice(&5.0f32.to_le_bytes());
+    // Wetness has six floats; shader_type defaults to 0, so no trailing data.
+    for v in [0.1f32, 0.2, 0.3, 0.5, 0.6, 0.95] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+
+    let expected_len = data.len();
+    let mut stream = NifStream::new(&data, &header);
+    let prop = BSLightingShaderProperty::parse(&mut stream).unwrap();
+    assert_eq!(prop.shader_type, 0);
+    assert!(prop.sf1_crcs.is_empty());
+    assert!(prop.sf2_crcs.is_empty());
+    assert_eq!(stream.position() as usize, expected_len);
+}
+
 // ── N23.9: FO76/Starfield tests ──────────────────────────────────
 
 fn make_fo76_header(name: &str) -> NifHeader {


### PR DESCRIPTION
# fix(nif): gate FO4 legacy shader type

## Summary

`BSLightingShaderProperty::parse_fo4` unconditionally read the legacy shader type before `NiObjectNETData`, even though the field is absent starting at BSVER 140. This shifted the stream by four bytes and made the parser read Name and all following fields at the wrong offsets. The parser now reads that field only below `FO4_DLC_UPPER` and otherwise uses the default shader type.

Fixes #2002

## Changes

- Gate the legacy pre-Name shader-type read to BSVER 130-139.
- Add a BSVER 140 synthetic parser regression test that asserts exact stream consumption.
- Correct the nearby parser documentation to describe the BSVER 140-154 layout.

## Testing

- `git diff --check` — passed.
- `sandbox-run "cargo fmt --check"` — could not run because the sandbox image has no `cargo` executable (`cargo: command not found`).
- `sandbox-run "cargo test -p byroredux-nif bs_lighting_bsver_140_skips_legacy_shader_type"` — could not run for the same reason.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
