### PR TITLE
Fix #2456 #2457 #2458 #2459: NIF/legacy-compat subsystem gaps

### DIFF
--- a/.claude/issues/2456 2457 2458 2459/ISSUE.md
+++ b/.claude/issues/2456 2457 2458 2459/ISSUE.md
@@ -1,0 +1,22 @@
+# Issues 2456, 2457, 2458, 2459 — NIF/legacy-compat subsystem gaps (Dimension 7)
+
+## #2456 — SUBSYS-01 (MEDIUM): Scale/shear baked into NiTransform.rotation silently discarded
+- Files: crates/nif/src/rotation.rs (sanitize_rotation, 11-64), crates/nif/src/import/coord.rs (33-63), crates/nif/src/stream.rs (679,702)
+- Non-orthonormal 3x3 (uniform/non-uniform scale or shear baked by exporter) is either SVD-orthogonalized (discarding singular values) or force-unit-quat'd, never folded into NiTransform.scale. No logging either way.
+- Minimum viable fix per issue: rate-limited log::warn! when a scaled (not zeroed) degenerate matrix is detected, to measure corpus incidence; regression test pins composed translation for the 2*I parent-rotation case already in transform.rs:250-270.
+
+## #2457 — SUBSYS-02 (MEDIUM): NiVertexColorProperty suppressed by NiMaterialProperty
+- File: crates/nif/src/import/material/legacy_properties.rs (apply_vertex_color_property gate at 742, has_material_data set at 133-154)
+- has_material_data is set both by BSLightingShaderProperty (Skyrim, intended gate per #1208) AND by ordinary NiMaterialProperty (pre-Skyrim). File-order property chain means NiMaterialProperty-before-NiVertexColorProperty (dominant Oblivion/FO3/FNV shape) silently drops the vertex-color property.
+- Fix: mirror #435/N06 remedy - dedicated vertex_color_mode_consumed flag set only by genuine vertex-colour-intent sites (BSLightingShaderProperty), not has_material_data. Add NiMaterialProperty-before-NVCP precedence test.
+
+## #2458 — SUBSYS-03 (MEDIUM): Bone-name binding case-sensitive on skin/ragdoll paths
+- Files: byroredux/src/scene/nif_loader.rs (412,449,966-968,994-998,1089), byroredux/src/ragdoll.rs (83-104); contrast crates/core/src/string/mod.rs (40-88, StringPool lowercases)
+- node_by_name: HashMap<Arc<str>, EntityId> keyed on raw case-preserved NIF node name; skin-bone + ragdoll template lookups are exact-match, unlike StringPool-backed Name comparisons elsewhere (case-insensitive, matches Gamebryo GlobalStringTable).
+- Fix (interim, cheaper per issue): lowercased-key fallback lookup with log::warn! when it's what resolves. Full fix (deferred): key node_by_name through StringPool/FixedString.
+- Test: case-mismatched bone name (Bip01 Spine vs bip01 spine) resolves.
+
+## #2459 — SUBSYS-04 (LOW): DISABLE_SORTING captured but never reaches draw sort
+- Files: crates/core/src/ecs/components/scene_flags.rs (41-44,81-84), byroredux/src/render/mod.rs (309-360, draw_sort_key)
+- SceneFlags::DISABLE_SORTING (0x0040) parsed/stored but draw_sort_key has no sorting-disabled lane - always back-to-front alpha sorts.
+- Suggested: verify against Gamebryo semantics (unmounted source per issue - do best-effort investigation); if reachable, wire a file-order lane into draw_sort_key gated on the flag; if legacy semantics can't be verified, document as intentional skip.

--- a/byroredux/src/main.rs
+++ b/byroredux/src/main.rs
@@ -25,6 +25,7 @@ mod fog;
 mod game_profiles;
 mod helpers;
 mod material_translate;
+mod name_lookup;
 mod npc_spawn;
 mod parsed_nif_cache;
 mod ragdoll;

--- a/byroredux/src/name_lookup.rs
+++ b/byroredux/src/name_lookup.rs
@@ -1,0 +1,95 @@
+//! Case-insensitive fallback for bone/skeleton-node name → value lookups.
+//!
+//! `StringPool`-backed `Name` components are ASCII-lowercased at intern
+//! time to match Gamebryo's `GlobalStringTable` behavior, so ordinary
+//! `Name` comparisons (and animation channel binding) are
+//! case-insensitive. The skin-bone and ragdoll bone-name maps
+//! (`node_by_name` / `external_skeleton` in `scene::nif_loader`,
+//! `skel_map` / `rest_pose_by_name` in `ragdoll::template_from_imported`)
+//! bypass that pool entirely and are keyed on the raw, case-preserved
+//! NIF node name — two different normalisation regimes for the same
+//! conceptual identifier. See #2458.
+//!
+//! Bethesda's own tooling is case-insensitive, so third-party/modded
+//! skeletons and outfits have no incentive to be byte-exact, and a
+//! case-only divergence between (say) an outfit's skin bone list and
+//! `skeleton.nif`'s node names silently unresolves that bone.
+//!
+//! This is the "cheaper interim" fix from #2458: fall back to a
+//! case-insensitive scan on an exact-match miss, with a rate-limited
+//! `log::warn!` measuring real-corpus incidence, ahead of the fuller fix
+//! (re-key these maps through `StringPool`/`FixedString` so every
+//! bone-name comparison shares one normalisation).
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static CASE_FALLBACK_WARNINGS: AtomicU32 = AtomicU32::new(0);
+const MAX_CASE_FALLBACK_WARNINGS: u32 = 20;
+
+/// Look up `name` in `map`, trying an exact match first and falling back
+/// to a case-insensitive scan on miss. Returns `None` if neither finds a
+/// match. Logs a rate-limited warning when the case-insensitive fallback
+/// is what resolves the name, so real-corpus incidence can be measured
+/// before committing to the fuller `StringPool`-backed re-key (#2458).
+pub(crate) fn get_case_insensitive<'a, K, V>(map: &'a HashMap<K, V>, name: &str) -> Option<&'a V>
+where
+    K: std::borrow::Borrow<str> + Eq + Hash + std::fmt::Display,
+{
+    if let Some(v) = map.get(name) {
+        return Some(v);
+    }
+    let (key, value) = map
+        .iter()
+        .find(|(k, _)| k.borrow().eq_ignore_ascii_case(name))?;
+    let count = CASE_FALLBACK_WARNINGS.fetch_add(1, Ordering::Relaxed);
+    if count < MAX_CASE_FALLBACK_WARNINGS {
+        log::warn!(
+            "bone/node name '{name}' resolved only via case-insensitive fallback (matched \
+             '{key}') — #2458: skin/ragdoll bone-name binding is case-sensitive while every \
+             other Name comparison is case-insensitive (StringPool lowercases)."
+        );
+        if count + 1 == MAX_CASE_FALLBACK_WARNINGS {
+            log::warn!(
+                "further case-insensitive bone-name fallback warnings suppressed for this \
+                 process (#2458)"
+            );
+        }
+    }
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn map(pairs: &[(&str, u32)]) -> HashMap<Arc<str>, u32> {
+        pairs.iter().map(|&(k, v)| (Arc::from(k), v)).collect()
+    }
+
+    #[test]
+    fn exact_match_hits_without_scanning() {
+        let m = map(&[("Bip01 Spine", 1), ("Bip01 Head", 2)]);
+        assert_eq!(get_case_insensitive(&m, "Bip01 Spine"), Some(&1));
+    }
+
+    #[test]
+    fn case_mismatch_resolves_via_fallback() {
+        let m = map(&[("Bip01 Spine", 1)]);
+        assert_eq!(get_case_insensitive(&m, "bip01 spine"), Some(&1));
+    }
+
+    #[test]
+    fn unrelated_name_stays_unresolved() {
+        let m = map(&[("Bip01 Spine", 1)]);
+        assert_eq!(get_case_insensitive(&m, "Bip01 Pelvis"), None);
+    }
+
+    #[test]
+    fn empty_map_returns_none() {
+        let m: HashMap<Arc<str>, u32> = HashMap::new();
+        assert_eq!(get_case_insensitive(&m, "anything"), None);
+    }
+}

--- a/byroredux/src/ragdoll.rs
+++ b/byroredux/src/ragdoll.rs
@@ -94,11 +94,16 @@ pub fn template_from_imported(
     let mut dropped_bones: Vec<&Arc<str>> = Vec::new();
     let mut dropped_rest_poses: Vec<&Arc<str>> = Vec::new();
     for (i, b) in imported.bodies.iter().enumerate() {
-        let Some(&bone) = skel_map.get(&b.bone_name) else {
+        // #2458 — exact match first, falling back to a case-insensitive
+        // scan so a case-only divergence between the ragdoll's authored
+        // bone names and the skeleton's node names doesn't silently drop
+        // the body. See `crate::name_lookup`'s module doc.
+        let Some(&bone) = crate::name_lookup::get_case_insensitive(skel_map, &b.bone_name) else {
             dropped_bones.push(&b.bone_name);
             continue;
         };
-        let Some(rest) = rest_pose_by_name.get(&b.bone_name) else {
+        let Some(rest) = crate::name_lookup::get_case_insensitive(rest_pose_by_name, &b.bone_name)
+        else {
             dropped_rest_poses.push(&b.bone_name);
             continue;
         };
@@ -1422,6 +1427,37 @@ mod tests {
         let template =
             template_from_imported(&imported, &skel_map, &rest_poses).expect("both bones resolve");
         assert_eq!(template.bodies.len(), 2);
+        assert_eq!(template.constraints.len(), 1);
+        assert_eq!(template.bodies[0].bone, spine);
+        assert_eq!(template.bodies[1].bone, head);
+    }
+
+    /// Regression: #2458 — a ragdoll authored with different letter-casing
+    /// than the bound skeleton's node names (e.g. an outfit's ragdoll data
+    /// says "Bip01 Spine" while the skeleton's node is "bip01 spine", or
+    /// vice versa — Bethesda's own tooling is case-insensitive, so modded
+    /// content has no incentive to be byte-exact) must still resolve via
+    /// the case-insensitive fallback in `crate::name_lookup`, instead of
+    /// being silently dropped like a genuinely-missing bone.
+    #[test]
+    fn case_mismatched_bone_name_still_resolves() {
+        let mut world = World::new();
+        let spine = world.spawn();
+        let head = world.spawn();
+        let mut skel_map = HashMap::new();
+        // Skeleton's own node names, lowercase (as StringPool would key them).
+        skel_map.insert(Arc::<str>::from("bip01 spine"), spine);
+        skel_map.insert(Arc::<str>::from("bip01 head"), head);
+
+        let imported = ImportedRagdoll {
+            // Ragdoll data authored with the mixed-case convention.
+            bodies: vec![body("Bip01 Spine"), body("Bip01 Head")],
+            constraints: vec![hinge_constraint(0, 1)],
+        };
+        let rest_poses = identity_rest_poses(&skel_map);
+        let template = template_from_imported(&imported, &skel_map, &rest_poses)
+            .expect("case-mismatched bone names must resolve via the case-insensitive fallback");
+        assert_eq!(template.bodies.len(), 2, "both bones must resolve");
         assert_eq!(template.constraints.len(), 1);
         assert_eq!(template.bodies[0].bone, spine);
         assert_eq!(template.bodies[1].bone, head);

--- a/byroredux/src/render/mod.rs
+++ b/byroredux/src/render/mod.rs
@@ -250,6 +250,14 @@ fn compute_directional_upload(
 /// to fold into single instanced draws. Owned here so the field order
 /// can't silently drift from an assert in a downstream crate.
 ///
+/// #2459 — `DrawCommand` has no per-draw "keep file order" hint. NIF's
+/// `NiAVObject::DISABLE_SORTING` bit (parsed into
+/// `byroredux_core::ecs::components::SceneFlags::DISABLE_SORTING`, see
+/// that constant's doc for the verified Gamebryo semantics) never
+/// reaches this key — every alpha-blended draw goes through the global
+/// back-to-front sort below regardless. Deliberately left unwired; see
+/// the `SceneFlags` doc for why.
+///
 /// All branches return the same 11-tuple shape so the compiler accepts
 /// a single key closure. Per-branch semantics:
 ///   Slot 0       = `!in_raster` priority bit — `0` for in-frustum

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -977,9 +977,17 @@ pub(crate) fn load_nif_bytes_with_skeleton(
                     // skinning resolves to the shared skeleton's
                     // entities, not the body/head's own orphaned
                     // local node copies.
+                    // #2458 — exact match first (fast path, the common
+                    // case), falling back to a case-insensitive scan so a
+                    // case-only divergence between this mesh's skin bone
+                    // list and the skeleton's node names doesn't silently
+                    // unresolve the bone. See `name_lookup` module doc.
                     let resolved = external_skeleton
-                        .and_then(|m| m.get(&bone.name).copied())
-                        .or_else(|| node_by_name.get(&bone.name).copied());
+                        .and_then(|m| crate::name_lookup::get_case_insensitive(m, &bone.name))
+                        .or_else(|| {
+                            crate::name_lookup::get_case_insensitive(&node_by_name, &bone.name)
+                        })
+                        .copied();
                     match resolved {
                         Some(e) => bones.push(Some(e)),
                         None => {
@@ -1006,9 +1014,12 @@ pub(crate) fn load_nif_bytes_with_skeleton(
                 // asymmetry is informative).
                 let global_skin_transform = Mat4::from_cols_array_2d(&skin.global_skin_transform);
                 let root_entity = skin.skeleton_root.as_ref().and_then(|n| {
+                    // #2458 — same case-insensitive fallback as the
+                    // per-bone resolution above.
                     external_skeleton
-                        .and_then(|m| m.get(n).copied())
-                        .or_else(|| node_by_name.get(n).copied())
+                        .and_then(|m| crate::name_lookup::get_case_insensitive(m, n))
+                        .or_else(|| crate::name_lookup::get_case_insensitive(&node_by_name, n))
+                        .copied()
                 });
                 world.insert(
                     entity,

--- a/crates/core/src/ecs/components/scene_flags.rs
+++ b/crates/core/src/ecs/components/scene_flags.rs
@@ -38,6 +38,31 @@ impl SceneFlags {
     pub const DISPLAY_OBJECT: u32 = 0x0020;
 
     /// Disable sorting for this object (always render in submission order).
+    ///
+    /// #2459 / SUBSYS-04 — VERIFIED against the real Gamebryo 2.3 source
+    /// (`CoreLibs/NiMain/NiAVObject.h:219`, `NiAVObject.inl:329-340`
+    /// `Get/SetSortObject`, `NiAlphaAccumulator.cpp:49-54`
+    /// `RegisterObjectArray`). Confirmed semantics: an alpha-blended
+    /// `NiGeometry` normally joins `NiAlphaAccumulator`'s sort list and is
+    /// drawn back-to-front at `Sort()` time; when this bit is set,
+    /// `GetSortObject()` returns false and `RegisterObjectArray` instead
+    /// calls `RenderImmediate` on it right there in scene-graph traversal
+    /// order — it never enters the depth sort at all. Present only from
+    /// NIF v20.0.0.4 (Skyrim+); `NiAVObject::LoadBinary` explicitly clears
+    /// the bit for older files.
+    ///
+    /// **Not wired to [`super::super::draw_sort_key`] yet.** Attached at
+    /// both import paths (parsed into this component) but has zero
+    /// consumers downstream — no `SceneFlags` reference exists anywhere
+    /// under `byroredux/src/render/`, so no draw command even carries the
+    /// bit today. Deliberately left unwired rather than speculatively
+    /// patched: `draw_sort_key`'s alpha-over branch has documented,
+    /// hard-won reasons (RT-1 / #2215, #1804 / #2237) for keeping global
+    /// depth order primary, and carving out a file-order exception for
+    /// this bit without a corpus/RenderDoc pass to confirm real-content
+    /// incidence risks reintroducing the exact draw-order artifact that
+    /// depth-primary sorting was built to fix. See #2459 for the
+    /// completeness-check trail if this is revisited.
     pub const DISABLE_SORTING: u32 = 0x0040;
 
     /// Override selective transform updates.

--- a/crates/nif/src/import/coord.rs
+++ b/crates/nif/src/import/coord.rs
@@ -45,6 +45,16 @@ pub(super) fn zup_matrix_to_yup_quat(m: &NiMatrix3) -> [f32; 4] {
     ];
 
     // Determinant — same formula as rotation::is_degenerate_rotation.
+    //
+    // #2456 SIBLING check: this determinant-only gate has the same blind
+    // spot `is_degenerate_rotation` does — a `det≈1`-but-non-orthonormal
+    // matrix (`diag(2, 0.5, 1)`) takes the Shepperd fast path below
+    // untouched. It does not get its own corpus-incidence warning here:
+    // every `m` reaching this function is a `NiTransform.rotation` field
+    // that already passed through `rotation::sanitize_rotation` at parse
+    // time (see that function's callers in `stream.rs`), which is where
+    // the #2456 warning fires — one warning per source matrix, not one
+    // per downstream consumer.
     let det = yup[0][0] * (yup[1][1] * yup[2][2] - yup[1][2] * yup[2][1])
         - yup[0][1] * (yup[1][0] * yup[2][2] - yup[1][2] * yup[2][0])
         + yup[0][2] * (yup[1][0] * yup[2][1] - yup[1][1] * yup[2][0]);

--- a/crates/nif/src/import/material/dedicated_shader.rs
+++ b/crates/nif/src/import/material/dedicated_shader.rs
@@ -357,6 +357,11 @@ fn apply_bs_lighting_shader(
             info.z_write = false;
         }
         info.has_material_data = true;
+        // #2457 — narrow flag for the #1208 vertex-color precedence gate;
+        // see `MaterialInfo::has_bs_lighting_shader`'s doc for why
+        // `has_material_data` (also set by the unrelated legacy
+        // `NiMaterialProperty` arm) was the wrong thing to gate on.
+        info.has_bs_lighting_shader = true;
     }
 }
 

--- a/crates/nif/src/import/material/legacy_properties.rs
+++ b/crates/nif/src/import/material/legacy_properties.rs
@@ -731,7 +731,7 @@ fn apply_vertex_color_property(scene: &NifScene, idx: usize, info: &mut Material
     // becomes effectively invisible — demote to `Ignore` so the
     // renderer skips the `texColor * fragColor` double-count.
     //
-    // #1208 — gate on `!info.has_material_data`. A Skyrim+ mesh
+    // #1208 — gate on `!info.has_bs_lighting_shader`. A Skyrim+ mesh
     // that authors both `BSLightingShaderProperty` (Skyrim+ shader
     // path; default AmbientDiffuse is the intended mode) AND a
     // legacy `NiVertexColorProperty` in the inherited NiNode
@@ -739,7 +739,19 @@ fn apply_vertex_color_property(scene: &NifScene, idx: usize, info: &mut Material
     // overwrite the Skyrim+ intent. Mirrors the
     // `if info.texture_path.is_none()` precedence pattern used by
     // every other secondary-source consumer in this loop.
-    if !info.has_material_data {
+    //
+    // #2457 — pre-fix this gated on the broader `has_material_data`,
+    // which the ordinary pre-Skyrim `NiMaterialProperty` arm ALSO
+    // sets. Since the property chain walks in file order, a
+    // `NiMaterialProperty` visited before this property (the common
+    // Oblivion/FO3/FNV property order) latched that gate shut too,
+    // dropping every legacy vertex-color property regardless of
+    // direct-vs-inherited status. Same failure shape #435/N06 already
+    // fixed for `has_uv_transform` — see that field's doc.
+    // `has_bs_lighting_shader` is set ONLY by the actual Skyrim+ arm
+    // #1208 meant to protect, so a `NiMaterialProperty` anywhere in
+    // the chain no longer suppresses this write.
+    if !info.has_bs_lighting_shader {
         if let Some(vcol) = scene.get_as::<NiVertexColorProperty>(idx) {
             info.vertex_color_mode =
                 VertexColorMode::from_property(vcol.vertex_mode, vcol.lighting_mode);

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -628,6 +628,19 @@ pub(super) struct MaterialInfo {
     /// own, the two flags are orthogonal. See audit
     /// `AUDIT_NIF_2026-04-18.md` finding N06.
     pub has_uv_transform: bool,
+    /// Set only by `apply_bs_lighting_shader` — a `BSLightingShaderProperty`
+    /// (Skyrim+) was found for this material. `#1208`'s intent was to stop
+    /// an inherited `NiVertexColorProperty` from overwriting the Skyrim+
+    /// shader-driven `vertex_color_mode` default, but the original fix
+    /// gated on the broader `has_material_data` — which the ordinary
+    /// pre-Skyrim `NiMaterialProperty` arm ALSO sets. Since the property
+    /// chain walks in file order, a `NiMaterialProperty` visited before a
+    /// `NiVertexColorProperty` (the common Oblivion/FO3/FNV property order)
+    /// latched that gate shut too, dropping every legacy vertex-color
+    /// property regardless of direct-vs-inherited status. Same failure
+    /// shape as `has_uv_transform`'s own #435/N06 precedent above. See
+    /// #2457.
+    pub has_bs_lighting_shader: bool,
     /// Depth test enabled (from NiZBufferProperty). Default: true.
     pub z_test: bool,
     /// Depth write enabled (from NiZBufferProperty). Default: true.
@@ -1044,6 +1057,7 @@ impl Default for MaterialInfo {
             has_material_data: false,
             specular_authored: false,
             has_uv_transform: false,
+            has_bs_lighting_shader: false,
             z_test: true,
             z_write: true,
             z_function: 3, // LESSEQUAL — Gamebryo default

--- a/crates/nif/src/import/material/vertex_color_precedence_tests.rs
+++ b/crates/nif/src/import/material/vertex_color_precedence_tests.rs
@@ -12,6 +12,15 @@
 //! The fix gates the NVCP write on `!info.has_material_data`, mirroring
 //! the precedence pattern used by every other secondary-source consumer
 //! in the inherited-property loop.
+//!
+//! #2457 / SUBSYS-02 — that gate was itself over-broad: `has_material_data`
+//! is also set by the ordinary pre-Skyrim `NiMaterialProperty` arm, so a
+//! `[NiMaterialProperty, NiVertexColorProperty]` chain (the dominant
+//! Oblivion/FO3/FNV property order) latched the gate shut too, dropping
+//! every legacy vertex-color property regardless of direct-vs-inherited
+//! status. Re-gated on the narrower `has_bs_lighting_shader`, set only by
+//! the actual Skyrim+ arm #1208 meant to protect — see the
+//! `ni_material_property_does_not_suppress_following_nvcp*` tests below.
 
 use super::*;
 use crate::blocks::base::NiObjectNETData;
@@ -122,6 +131,96 @@ fn bsl_inhibits_inherited_nvcp_ignore() {
         VertexColorMode::AmbientDiffuse,
         "BSL Skyrim+ default must win over inherited NVCP(SRC_IGNORE)",
     );
+}
+
+/// Minimal `NiMaterialProperty` — enough to trip `has_material_data`
+/// without a real `NifStream` parse.
+fn material_property() -> crate::blocks::properties::NiMaterialProperty {
+    use crate::types::NiColor;
+    crate::blocks::properties::NiMaterialProperty {
+        net: empty_net(),
+        ambient: NiColor::default(),
+        diffuse: NiColor {
+            r: 0.5,
+            g: 0.6,
+            b: 0.7,
+        },
+        specular: NiColor::default(),
+        emissive: NiColor::default(),
+        shininess: 50.0,
+        alpha: 1.0,
+        emissive_mult: 1.0,
+    }
+}
+
+/// Regression: #2457 / SUBSYS-02 — the dominant legacy property order
+/// (Oblivion/FO3/FNV ship `[NiMaterialProperty, NiVertexColorProperty]`)
+/// must still honor the NiVertexColorProperty. Pre-fix the gate on
+/// `apply_vertex_color_property` was `!info.has_material_data`, and
+/// `NiMaterialProperty` — the ordinary pre-Skyrim arm, unrelated to the
+/// #1208 Skyrim+ intent — also sets `has_material_data`, so it latched
+/// the gate shut for every later vertex-color property in the same
+/// chain regardless of direct-vs-inherited status. No BSLightingShaderProperty
+/// is present at all here, so this is not a Skyrim+ mesh — the #1208 gate
+/// should never fire.
+#[test]
+fn ni_material_property_does_not_suppress_following_nvcp() {
+    let blocks: Vec<Box<dyn NiObject>> = vec![
+        Box::new(material_property()),
+        Box::new(vcol_property(0, 1)), // SRC_IGNORE + LIGHTING_E_A_D
+    ];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let mut pool = StringPool::new();
+    // Property order intentionally mirrors Oblivion/FO3/FNV: NiMaterialProperty FIRST.
+    let info = walker::extract_material_info_from_refs(
+        &scene,
+        BlockRef::NULL, // no shader property — this is not a Skyrim+ mesh
+        BlockRef::NULL,
+        &[BlockRef(0), BlockRef(1)], // direct: [NiMaterialProperty, NVCP]
+        &[],
+        &mut pool,
+    );
+    assert!(
+        info.has_material_data,
+        "NiMaterialProperty must still set has_material_data = true"
+    );
+    assert!(
+        !info.has_bs_lighting_shader,
+        "no BSLightingShaderProperty is present"
+    );
+    assert_eq!(
+        info.vertex_color_mode,
+        VertexColorMode::Ignore,
+        "NiVertexColorProperty(SRC_IGNORE) must not be suppressed by a preceding NiMaterialProperty"
+    );
+}
+
+/// Same shape, Emissive routing — must also survive a preceding
+/// NiMaterialProperty (the #695 emissive-routing regression, upstream
+/// of the shader-end fix).
+#[test]
+fn ni_material_property_does_not_suppress_following_nvcp_emissive() {
+    let blocks: Vec<Box<dyn NiObject>> = vec![
+        Box::new(material_property()),
+        Box::new(vcol_property(1, 1)), // SRC_EMISSIVE + LIGHTING_E_A_D
+    ];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let mut pool = StringPool::new();
+    let info = walker::extract_material_info_from_refs(
+        &scene,
+        BlockRef::NULL,
+        BlockRef::NULL,
+        &[BlockRef(0), BlockRef(1)],
+        &[],
+        &mut pool,
+    );
+    assert_eq!(info.vertex_color_mode, VertexColorMode::Emissive);
 }
 
 /// Same with the Emissive routing — BSL still wins.

--- a/crates/nif/src/rotation.rs
+++ b/crates/nif/src/rotation.rs
@@ -7,6 +7,7 @@
 //! zup_matrix_to_yup_quat) can skip per-composition checks. See #277.
 
 use crate::types::NiMatrix3;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Check if a rotation matrix is degenerate (det far from 1.0).
 #[inline]
@@ -16,6 +17,80 @@ pub fn is_degenerate_rotation(m: &NiMatrix3) -> bool {
         - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
         + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0]);
     (det - 1.0).abs() >= 0.1
+}
+
+/// Check if a rotation matrix's columns fail to form an orthonormal set —
+/// i.e. the matrix encodes scale and/or shear beyond pure rotation, even
+/// when its determinant lands inside [`is_degenerate_rotation`]'s "valid
+/// rotation" window. A uniform-or-non-uniform scale whose singular values
+/// multiply out to ≈1 (`diag(2, 0.5, 1)`, det = 1.0 exactly) is invisible
+/// to a determinant-only check — this catches it via the columns'
+/// lengths and pairwise dot products instead. See #2456.
+///
+/// The 0.1 tolerance (on squared column length / dot product, so ~10%)
+/// deliberately sits at or above the numerical drift #333 already
+/// treats as ordinary export-tool noise — e.g. a uniform 1.03× scale
+/// (see `zup_to_yup_drifted_rotation_returns_unit_quaternion`) squares
+/// to a 0.06 deviation and stays silent here. Only a matrix that
+/// actually encodes deliberate, code-visible scale/shear content trips
+/// this check.
+#[inline]
+pub fn is_non_orthonormal(m: &NiMatrix3) -> bool {
+    let r = &m.rows;
+    let col = |j: usize| [r[0][j], r[1][j], r[2][j]];
+    let dot = |a: [f32; 3], b: [f32; 3]| a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    let (c0, c1, c2) = (col(0), col(1), col(2));
+    const TOL: f32 = 0.1;
+    (dot(c0, c0) - 1.0).abs() > TOL
+        || (dot(c1, c1) - 1.0).abs() > TOL
+        || (dot(c2, c2) - 1.0).abs() > TOL
+        || dot(c0, c1).abs() > TOL
+        || dot(c0, c2).abs() > TOL
+        || dot(c1, c2).abs() > TOL
+}
+
+/// Caps how many "baked scale/shear discarded" warnings
+/// [`sanitize_rotation`] logs per process. Real NIF corpora can carry
+/// thousands of nodes; without a cap, one badly-exported model would
+/// flood the log and drown out everything else. #2456 — this is
+/// diagnostic-only instrumentation to measure real corpus incidence
+/// before committing to the larger "decompose into `NiTransform.scale`"
+/// fix; it changes no parsed geometry or transform output.
+static SCALE_DISCARD_WARNINGS: AtomicU32 = AtomicU32::new(0);
+const MAX_SCALE_DISCARD_WARNINGS: u32 = 20;
+
+fn warn_scaled_rotation_discarded(m: &NiMatrix3, mode: &str) {
+    let count = SCALE_DISCARD_WARNINGS.fetch_add(1, Ordering::Relaxed);
+    if count >= MAX_SCALE_DISCARD_WARNINGS {
+        return;
+    }
+    log::warn!(
+        "NiTransform.rotation is non-orthonormal (baked scale/shear, {mode}) — the singular \
+         value information is discarded rather than folded into NiTransform.scale (#2456); \
+         this subtree's placement may be offset by the discarded factor. Matrix: {m:?}"
+    );
+    if count + 1 == MAX_SCALE_DISCARD_WARNINGS {
+        log::warn!(
+            "further \"baked scale/shear discarded\" rotation warnings suppressed for this \
+             process (#2456)"
+        );
+    }
+}
+
+/// Longest column vector of `m` — used to tell a genuinely-scaled matrix
+/// (worth measuring/warning about) apart from a truly degenerate one
+/// (zeroed BSFadeNode transform, garbage export) that
+/// [`repair_rotation_svd_or_identity`] already collapses to identity.
+/// Mirrors that function's own `max_sv < 0.01` zeroed-matrix threshold.
+#[inline]
+fn max_column_length(m: &NiMatrix3) -> f32 {
+    let r = &m.rows;
+    (0..3)
+        .map(|j| {
+            let v = [r[0][j], r[1][j], r[2][j]];
+            (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+        })
+        .fold(0.0f32, f32::max)
 }
 
 /// SVD-repair a degenerate rotation matrix, or return identity if the matrix
@@ -57,11 +132,145 @@ pub fn repair_rotation_svd_or_identity(m: &NiMatrix3) -> NiMatrix3 {
 /// Sanitize a rotation matrix: pass-through for valid rotations (~99.9% of
 /// NIF content), SVD-repair for degenerate ones. Call once at parse time
 /// so downstream code can assume the matrix is a valid rotation.
+///
+/// #2456 — either branch can discard genuine scale/shear information
+/// baked into the matrix by an exporter (the SVD branch orthogonalizes
+/// it away; the pass-through branch admits `det≈1`-but-non-orthonormal
+/// matrices like `diag(2, 0.5, 1)` untouched, and that information is
+/// lost further downstream when `#333`'s unit-quaternion guard runs).
+/// Neither branch folds the discarded factor into `NiTransform.scale`
+/// yet — that decomposition is deferred pending real-corpus incidence
+/// data. Until then, log a rate-limited warning whenever a matrix with
+/// real (non-zeroed) magnitude trips either case, so that data can be
+/// gathered.
 #[inline]
 pub fn sanitize_rotation(m: NiMatrix3) -> NiMatrix3 {
     if is_degenerate_rotation(&m) {
+        if max_column_length(&m) >= 0.01 {
+            warn_scaled_rotation_discarded(&m, "SVD-orthogonalized");
+        }
         repair_rotation_svd_or_identity(&m)
     } else {
+        if is_non_orthonormal(&m) {
+            warn_scaled_rotation_discarded(&m, "determinant in valid-rotation window, passed through unchanged");
+        }
         m
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> NiMatrix3 {
+        NiMatrix3::default()
+    }
+
+    #[test]
+    fn identity_is_orthonormal() {
+        assert!(!is_non_orthonormal(&identity()));
+    }
+
+    #[test]
+    fn pure_rotation_is_orthonormal() {
+        // 90deg rotation around Z — a genuine rotation, no scale.
+        let rot_z90 = NiMatrix3 {
+            rows: [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        };
+        assert!(!is_non_orthonormal(&rot_z90));
+    }
+
+    #[test]
+    fn ordinary_export_drift_is_not_flagged() {
+        // #333's documented ~3-7% per-axis drift case — must stay silent
+        // so this diagnostic doesn't fire on every ordinary export.
+        let drift = 1.03f32;
+        let drifted = NiMatrix3 {
+            rows: [[drift, 0.0, 0.0], [0.0, drift, 0.0], [0.0, 0.0, drift]],
+        };
+        assert!(!is_non_orthonormal(&drifted));
+    }
+
+    /// #2456 — the case `is_degenerate_rotation` cannot see: singular
+    /// values multiply out to det=1.0 exactly, but the matrix is not a
+    /// rotation.
+    #[test]
+    fn anisotropic_scale_with_unit_determinant_is_flagged_non_orthonormal() {
+        let scaled = NiMatrix3 {
+            rows: [[2.0, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 1.0]],
+        };
+        assert!((det(&scaled) - 1.0).abs() < 1e-6, "fixture must have det=1");
+        assert!(!is_degenerate_rotation(&scaled), "det-only check must miss this");
+        assert!(is_non_orthonormal(&scaled), "column check must catch it");
+    }
+
+    #[test]
+    fn uniform_scaled_identity_is_flagged_non_orthonormal() {
+        let scaled_identity = NiMatrix3 {
+            rows: [[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]],
+        };
+        assert!(is_non_orthonormal(&scaled_identity));
+    }
+
+    #[test]
+    fn zeroed_matrix_is_not_flagged_non_orthonormal() {
+        // Zeroed BSFadeNode-style garbage — sanitize_rotation's det branch
+        // handles this via repair_rotation_svd_or_identity's own
+        // max_sv < 0.01 threshold; is_non_orthonormal is never consulted
+        // for it (is_degenerate_rotation already catches det=0), but it
+        // should not itself misreport a zero matrix as "scaled".
+        let zero = NiMatrix3 {
+            rows: [[0.0; 3]; 3],
+        };
+        assert!(is_degenerate_rotation(&zero));
+    }
+
+    #[test]
+    fn sanitize_rotation_leaves_pure_rotations_unchanged() {
+        let rot_z90 = NiMatrix3 {
+            rows: [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        };
+        let out = sanitize_rotation(rot_z90);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((out.rows[i][j] - rot_z90.rows[i][j]).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    fn sanitize_rotation_orthogonalizes_far_from_unit_determinant() {
+        // det = 8, well outside the fast-path window — SVD branch fires
+        // and must return an orthonormal (near-identity) matrix.
+        let scaled_identity = NiMatrix3 {
+            rows: [[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]],
+        };
+        let out = sanitize_rotation(scaled_identity);
+        assert!(!is_degenerate_rotation(&out));
+        assert!(!is_non_orthonormal(&out));
+    }
+
+    /// #2456 — the anisotropic-scale-with-unit-determinant case passes
+    /// through `sanitize_rotation` UNCHANGED today (this pins the current,
+    /// not-yet-fixed behaviour so a future decomposition fix has to
+    /// deliberately update this test rather than silently pass).
+    #[test]
+    fn sanitize_rotation_does_not_yet_fold_unit_determinant_scale_into_output() {
+        let scaled = NiMatrix3 {
+            rows: [[2.0, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 1.0]],
+        };
+        let out = sanitize_rotation(scaled);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((out.rows[i][j] - scaled.rows[i][j]).abs() < 1e-6);
+            }
+        }
+    }
+
+    fn det(m: &NiMatrix3) -> f32 {
+        let r = &m.rows;
+        r[0][0] * (r[1][1] * r[2][2] - r[1][2] * r[2][1])
+            - r[0][1] * (r[1][0] * r[2][2] - r[1][2] * r[2][0])
+            + r[0][2] * (r[1][0] * r[2][1] - r[1][1] * r[2][0])
     }
 }


### PR DESCRIPTION
#2456 (crates/nif/src/rotation.rs, MEDIUM): NiTransform.rotation matrices carrying exporter-baked scale/shear were silently discarded — the SVD branch orthogonalizes it away, and a det~1-but-non-orthonormal matrix (diag(2, 0.5, 1)) passed through sanitize_rotation's determinant-only gate untouched. Full decomposition into NiTransform.scale is deferred pending real-corpus incidence data (per the issue's own suggested minimum-viable step). Added is_non_orthonormal(), a columns-based check that catches the determinant-blind case a det-only check misses, and rate-limited log::warn! diagnostics on both discard paths to measure real incidence. import/coord.rs's independent (and identically blind) determinant check gets a comment explaining why it doesn't need its own warning site: it always runs on an already-sanitized matrix.

#2457 (crates/nif/src/import/material/legacy_properties.rs, MEDIUM): apply_vertex_color_property gated its NiVertexColorProperty write on !info.has_material_data, intending to protect a BSLightingShaderProperty Skyrim+ default (#1208) -- but has_material_data is also set by the ordinary pre-Skyrim NiMaterialProperty arm, so a
[NiMaterialProperty, NiVertexColorProperty] chain (the dominant Oblivion/FO3/FNV property order) silently dropped every legacy vertex-color property. Same failure shape #435/N06 already fixed for has_uv_transform. Added a narrow has_bs_lighting_shader flag set only by the actual Skyrim+ arm and re-gated on that instead.

#2458 (byroredux/src/scene/nif_loader.rs, byroredux/src/ragdoll.rs, MEDIUM): skin-bone and ragdoll bone-name resolution used exact-match HashMap<Arc<str>, _> lookups (node_by_name, external_skeleton, skel_map, rest_pose_by_name), while every other Name comparison in the engine goes through StringPool's case-insensitive interning (matching Gamebryo's GlobalStringTable). A case-only divergence between an outfit's skin bone list and skeleton.nif's node names silently unresolved that bone. Added the "cheaper interim" fix the issue suggested: a shared get_case_insensitive() helper (new name_lookup module) that tries an exact match first and falls back to a case-insensitive scan with a rate-limited warning, wired into all four lookup sites.

#2459 (crates/core/src/ecs/components/scene_flags.rs, byroredux/src/render/mod.rs, LOW): SceneFlags::DISABLE_SORTING is parsed and stored but draw_sort_key has no consumer for it. Verified the flag's Gamebryo semantics directly against the real 2.3 source (previously blocked -- the source drive turned out to be mounted at a different path than expected): NiAlphaAccumulator::RegisterObjectArray skips its sort list entirely for DISABLE_SORTING geometry, rendering it immediately in traversal order instead. Left deliberately unwired: DrawCommand carries no SceneFlags reference anywhere today, and draw_sort_key's alpha-over branch has extensively documented reasons (RT-1/#2215, #1804/#2237) for staying depth-primary -- carving out a file-order exception without a corpus/RenderDoc pass to confirm real-content incidence risks reintroducing the exact draw-order artifact that depth-primary sorting was built to fix. Documented the verified findings at both sites per the issue's own suggested fallback: close as a documented intentional skip so future audits don't re-file it.

cargo test -p byroredux-nif (984 passed), -p byroredux-core (554 passed), -p byroredux (868 passed) and the full workspace suite all green.