### PR TITLE
Fix #2613 #2614 #2615 #2616: Starfield skinning, CDB safety, shader a…

### DIFF
--- a/.claude/issues/2613 2614 2615 2616/ISSUE.md
+++ b/.claude/issues/2613 2614 2615 2616/ISSUE.md
@@ -1,0 +1,21 @@
+# Issues 2613, 2614, 2615, 2616 — HIGH severity: Starfield skinning + CDB safety + shader alignment
+
+## #2613 — SF2D2-D2-01 (HIGH): Starfield skinned meshes render in bind pose
+- Files: crates/nif/src/import/mesh/skin.rs (extract_skin_bs_geometry, canonical fix site), crates/nif/src/import/mesh/bs_geometry.rs:249-260 (call site), crates/nif/src/blocks/bs_geometry.rs (BSGeometryMeshData.skin_weights, already decoded)
+- extract_skin_bs_geometry hardcodes vertex_bone_indices/vertex_bone_weights to Vec::new() with a stale "not decoded yet" comment; skin_weights IS decoded (BoneWeight{bone_index:u16, weight:u16}), just never plumbed through.
+- Fix: pass mesh_data into extract_skin_bs_geometry; when weights_per_vert>0 && !skin_weights.is_empty(), map to [u16;4]/[f32;4] (top-4-by-weight, zero-pad, /65535.0, renormalize via crates/nif/src/blocks/tri_shape/mod.rs::renormalize_skin_weights, same as FO4 BsTriShape). Guard skin_weights.len()==vertices.len(), fallback bind-pose on mismatch. Update stale test at bs_geometry_skin_tests.rs:118-121. Correct #1827's stale closed-issue premise.
+
+## #2614 — SF-D3-01 (HIGH): index_chunks pre-reserves from unvalidated on-disk u32, aborts on corrupt CDB
+- File: crates/sfmaterial/src/reader.rs:172-179 (index_chunks)
+- VecDeque::with_capacity(chunk_count) sized directly from unvalidated on-disk u32 (up to ~4B, ~103GB for u32::MAX) BEFORE the ChunkOverflow guard runs -> panic/abort, not catchable.
+- Fix: chunks.reserve(chunk_count.min(self.bytes.len() / 8)) or drop with_capacity entirely (each chunk costs >=8 bytes). Add fuzzed chunk_count (0xFFFFFFFF) test asserting Err not panic.
+
+## #2615 — SF-D3-03 (HIGH): Archive::open reads entire multi-GB archive to sample 4 magic bytes
+- Files: byroredux/src/asset_provider/archive.rs:10-27 (Archive::open), byroredux/src/asset_provider/material.rs:194-205 (build_material_provider, re-opens for file table)
+- std::fs::read(path) allocates+fills a Vec<u8> the size of the WHOLE archive just for magic-byte dispatch; each mesh archive fully read into RAM twice per provider build (~6 call sites).
+- Fix: File::open(path)?.read_exact(&mut [0u8;4]) instead of fs::read. Add test asserting Archive::open reads only a small fixed byte count via a byte-counting reader wrapper.
+
+## #2616 — SF-D6-01 (HIGH): BSLightingShaderProperty misaligned by one 4-byte word on Starfield full-body blocks
+- File: crates/nif/src/blocks/shader.rs:1142-1161 (BSLightingShaderProperty::parse_fo76_plus)
+- Two compensating 4-byte errors for bsver >= STARFIELD: skips shader_type (Starfield DOES carry it) and reads root_material_path unconditionally (Starfield does NOT carry it) -> every field between them (num_sf1/num_sf2, CRC arrays, uv_offset/uv_scale, texture_set_ref, emissive_color, emissive_multiple) reads one word early. Corpus-verified: 0/2538 valid under shipped alignment, 2538/2538 valid under corrected.
+- Fix: read shader_type unconditionally for bsver>=FO76 (revert the <STARFIELD gate); gate root_material_path on bsver<STARFIELD instead. Net byte count unchanged. Add real-data-derived fixture (shiplandingmarker_lod_3.nif block 6) asserting semantic invariants (finite emissive, resolvable texture_set_ref, valid CRC membership).

--- a/byroredux/src/asset_provider/archive.rs
+++ b/byroredux/src/asset_provider/archive.rs
@@ -5,18 +5,31 @@ pub(crate) enum Archive {
     Ba2(byroredux_bsa::Ba2Archive),
 }
 
+/// Read exactly the 4 magic bytes from `r` — the testable core of
+/// [`Archive::open`]'s dispatch sniff. Split out so a byte-counting
+/// `Read` wrapper can prove the caller never reads past this fixed
+/// window, without needing a real (potentially multi-GB) file on disk.
+/// See #2615 / SF-D3-03.
+fn sniff_magic_from<R: std::io::Read>(mut r: R) -> std::io::Result<[u8; 4]> {
+    let mut m = [0u8; 4];
+    r.read_exact(&mut m)?;
+    Ok(m)
+}
+
 impl Archive {
     /// Open an archive file, auto-detecting BSA vs BA2 from the file magic.
     pub(crate) fn open(path: &str) -> Result<Self, String> {
-        let magic = std::fs::read(path)
-            .map_err(|e| format!("read '{}': {}", path, e))
-            .and_then(|data| {
-                if data.len() < 4 {
-                    Err(format!("'{}' too small", path))
-                } else {
-                    Ok([data[0], data[1], data[2], data[3]])
-                }
-            })?;
+        // #2615 / SF-D3-03 — sample just the magic bytes instead of
+        // `std::fs::read`ing the whole archive into a transient `Vec<u8>`.
+        // Starfield's mesh archives run multi-GB; the old sniff allocated
+        // and filled the entire file (twice per provider build, per
+        // `build_material_provider`'s own doc — the archive is re-opened
+        // for its file table via a second `Archive::open` call) purely to
+        // read 4 bytes. `BsaArchive::open`/`Ba2Archive::open` below do
+        // their own real (streamed) file-table read.
+        let magic = std::fs::File::open(path)
+            .and_then(sniff_magic_from)
+            .map_err(|e| format!("read '{}': {}", path, e))?;
         if &magic == b"BTDX" {
             byroredux_bsa::Ba2Archive::open(path)
                 .map(Archive::Ba2)
@@ -376,5 +389,60 @@ pub(crate) fn numeric_sibling_paths(path: &str) -> Vec<String> {
         Some(c) if c.is_ascii_digit() => Vec::new(),
         // No trailing digit (FNV `… Textures.bsa`): offer `…2`..`…9`.
         _ => (2..=9u32).map(|n| format!("{stem}{n}{ext}")).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sniff_magic_from;
+    use std::io::Read;
+
+    /// Wraps a `Read` and counts every byte actually pulled through it —
+    /// the "byte-counting reader wrapper" from #2615's completeness
+    /// check. Lets the test prove the magic sniff never reads past its
+    /// fixed 4-byte window without needing a real multi-GB file on disk.
+    struct CountingReader<R> {
+        inner: R,
+        bytes_read: usize,
+    }
+
+    impl<R: Read> Read for CountingReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = self.inner.read(buf)?;
+            self.bytes_read += n;
+            Ok(n)
+        }
+    }
+
+    /// Regression: #2615 / SF-D3-03 — pre-fix, `Archive::open` sniffed
+    /// the dispatch magic via `std::fs::read`, pulling the ENTIRE file
+    /// through before ever looking at the first 4 bytes. A 100 MB
+    /// in-memory stand-in (no real file needed — the point is proving
+    /// the *reader*, not exercising the filesystem) with a counting
+    /// wrapper confirms the fixed-size sniff reads exactly 4 bytes
+    /// regardless of how much data follows.
+    #[test]
+    fn magic_sniff_reads_at_most_four_bytes_from_a_huge_source() {
+        let mut source = vec![0x42u8; 100 * 1024 * 1024]; // 100 MB
+        source[0..4].copy_from_slice(b"BTDX");
+        let mut counting = CountingReader {
+            inner: std::io::Cursor::new(&source),
+            bytes_read: 0,
+        };
+        let magic = sniff_magic_from(&mut counting).expect("100 MB source has plenty of bytes");
+        assert_eq!(&magic, b"BTDX");
+        assert_eq!(
+            counting.bytes_read, 4,
+            "the magic sniff must read exactly 4 bytes, not the whole 100 MB source"
+        );
+    }
+
+    /// A source shorter than 4 bytes fails — same "too small" rejection
+    /// the pre-fix `data.len() < 4` check enforced, now surfaced as a
+    /// bounds-checked `UnexpectedEof` from `read_exact` instead.
+    #[test]
+    fn magic_sniff_errors_on_a_too_short_source() {
+        let source: &[u8] = b"ab";
+        assert!(sniff_magic_from(source).is_err());
     }
 }

--- a/crates/nif/src/blocks/bs_geometry.rs
+++ b/crates/nif/src/blocks/bs_geometry.rs
@@ -249,7 +249,7 @@ impl BSGeometryMesh {
 /// the raw u32 UDEC3 values; the renderer can unpack via
 /// [`unpack_udec3_xyzw`] when consumed. Half-float UVs are unpacked
 /// to f32 immediately because there's no value in deferring.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BSGeometryMeshData {
     /// Format version. nifly bails out early if `version > 2` so the
     /// rest of the body is opt-out for unrecognised stream versions.

--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -1101,7 +1101,8 @@ impl BSLightingShaderProperty {
     ///   to zero (SF-D3-01).
     /// - CRC32 shader-flag arrays (`sf1_crcs/sf2_crcs`), `num_sf2`
     ///   gate is always true here (`>= 155 > 152`).
-    /// - `root_material_path` always read.
+    /// - `root_material_path` read for FO76 only (`bsver < STARFIELD`) —
+    ///   Starfield does not carry this field. See #2616.
     /// - `glossiness` scaled ×100 (FO76 follows FO4's smoothness convention).
     /// - No FO4 subsurface block (gated 130-139).
     /// - Wetness with BOTH `unknown_1` (BSVER >= 130, always true) and
@@ -1131,19 +1132,24 @@ impl BSLightingShaderProperty {
             }
         }
 
-        // #1510 / NIF-NEW-05 — the FO76 `BSShaderType155` field lives
-        // here for FO76 (bsver 152..171) but Starfield (bsver >= 172) does
-        // NOT carry it (its shader_type is implicitly 0, like the legacy
-        // pre-name slot). The #1279 `parse_fo76_plus` split read it
-        // unconditionally for all bsver >= 155, shifting every later field
-        // by 4 B and over-reading — which truncated all 1036 Starfield
-        // BSLightingShaderProperty full-body blocks to NiUnknown. The
-        // a9c7bc9e baseline (Starfield 0 unknown) gated it on `== 155`.
-        let shader_type = if bsver < crate::version::bsver::STARFIELD {
-            stream.read_u32_le()?
-        } else {
-            0
-        };
+        // #1510 / NIF-NEW-05 originally gated this `BSShaderType155`
+        // field off for Starfield (bsver >= 172), on the premise that
+        // Starfield doesn't carry it. #2616 / SF-D6-01 corrected that:
+        // Starfield DOES carry `shader_type` here (reusing the FO76
+        // enum, per this fn's own doc above) — it's `root_material_path`
+        // below that Starfield does NOT carry, and #1510 never touched
+        // that read. The two 4-byte errors exactly compensated (this
+        // field's absence for the `read_string()` misread 4 bytes later
+        // decoding as a valid string-table index, since `read_string`
+        // on modern NIF versions is itself just a 4-byte i32 index —
+        // see `NifStream::read_string`), so total block consumption
+        // stayed right and the misalignment survived #1510, #1606, and
+        // two prior Starfield audits undetected. Corpus-verified
+        // (LODMeshes/Meshes01/MeshesPatch, 2,538 inline-authored
+        // blocks): 0/2,538 valid under the pre-#2616 alignment (NaN
+        // emissive, unresolvable texture_set_ref, zero U-scale, 57%
+        // invalid CRC membership), 2,538/2,538 valid under this one.
+        let shader_type = stream.read_u32_le()?;
         let num_sf1 = stream.read_u32_le()? as usize;
         let num_sf2 = stream.read_u32_le()? as usize;
         let sf1_crcs = stream.read_u32_array(num_sf1)?;
@@ -1158,7 +1164,14 @@ impl BSLightingShaderProperty {
             stream.read_f32_le()?,
         ];
         let emissive_multiple = stream.read_f32_le()?;
-        let root_material_path = stream.read_string()?;
+        // #2616 / SF-D6-01 — the field this fn's pre-fix code read
+        // unconditionally, but Starfield does not carry. See the
+        // `shader_type` comment above for the full misalignment story.
+        let root_material_path = if bsver < crate::version::bsver::STARFIELD {
+            stream.read_string()?
+        } else {
+            None
+        };
         let texture_clamp_mode = stream.read_u32_le()?;
         let alpha = stream.read_f32_le()?;
         let refraction_strength = stream.read_f32_le()?;

--- a/crates/nif/src/blocks/shader_tests/mod.rs
+++ b/crates/nif/src/blocks/shader_tests/mod.rs
@@ -407,16 +407,26 @@ fn make_starfield_header(name: &str) -> NifHeader {
 /// Build a minimal **Starfield** (BSVER 172) `BSLightingShaderProperty`
 /// body — the FO76 shape MINUS every `#BS_F76#`-gated field. Per
 /// nif.xml `#BS_F76# = (BSVER == 155)` ("Fallout 76 stream 155 only"),
-/// Starfield omits the `BSShaderType155` field, the WetnessParams
-/// `unknown_2`, and the Luminance / Translucency / texture-array tail.
-/// Name index 0 is "" so the block takes the full-body path (a
-/// non-empty Starfield name is a content-hash material reference → stub).
+/// Starfield omits the WetnessParams `unknown_2` and the Luminance /
+/// Translucency / texture-array tail. Name index 0 is "" so the block
+/// takes the full-body path (a non-empty Starfield name is a
+/// content-hash material reference → stub).
+///
+/// #2616 / SF-D6-01 — Starfield DOES carry `shader_type` (it reuses the
+/// FO76 `BSShaderType155` enum, per `parse_fo76_plus`'s own doc), and
+/// does NOT carry `root_material_path`. Pre-fix this builder had that
+/// backwards (omitted `shader_type`, included `root_material`) — it
+/// matched the parser's then-bug rather than the real wire format, so
+/// bugs in both stayed invisible to each other. Corrected here; see
+/// `parse_bs_lighting_real_starfield_block_is_semantically_valid` for a
+/// byte-for-byte real-content fixture that doesn't share this class of
+/// risk at all.
 fn build_starfield_bs_lighting_minimal() -> Vec<u8> {
     let mut data = Vec::new();
     data.extend_from_slice(&0i32.to_le_bytes()); // name idx 0 ("")
     data.extend_from_slice(&0u32.to_le_bytes()); // extra_data count
     data.extend_from_slice(&(-1i32).to_le_bytes()); // controller_ref
-                                                    // NO BSShaderType155 (FO76 == 155 only)
+    data.extend_from_slice(&0u32.to_le_bytes()); // shader_type (BSShaderType155, reused from FO76)
     data.extend_from_slice(&0u32.to_le_bytes()); // num_sf1 (>= 132)
     data.extend_from_slice(&0u32.to_le_bytes()); // num_sf2 (>= 152)
     for v in [0.0f32, 0.0, 1.0, 1.0] {
@@ -427,7 +437,7 @@ fn build_starfield_bs_lighting_minimal() -> Vec<u8> {
         data.extend_from_slice(&v.to_le_bytes()); // emissive_color
     }
     data.extend_from_slice(&1.5f32.to_le_bytes()); // emissive_multiple
-    data.extend_from_slice(&(-1i32).to_le_bytes()); // root_material (>= 130)
+                                                    // NO root_material_path — Starfield doesn't carry it (#2616).
     data.extend_from_slice(&3u32.to_le_bytes()); // texture_clamp_mode
     data.extend_from_slice(&0.9f32.to_le_bytes()); // alpha
     data.extend_from_slice(&0.0f32.to_le_bytes()); // refraction_strength

--- a/crates/nif/src/blocks/shader_tests/starfield.rs
+++ b/crates/nif/src/blocks/shader_tests/starfield.rs
@@ -3,6 +3,100 @@
 
 use super::*;
 
+/// Regression: #2616 / SF-D6-01. Real block 6 (bsver 173, block_size 166,
+/// full `BSLightingShaderProperty` body) extracted verbatim from
+/// `Starfield - LODMeshes.ba2`'s
+/// `meshes\lod\generated\ships\discovery\shiplandingmarker_lod_3.nif` —
+/// not a synthetic builder (see SF-D6-03: editing a synthetic fixture to
+/// match wrong output proves nothing). Pre-fix (`shader_type` skipped,
+/// `root_material_path` read unconditionally) this decodes to a NaN
+/// emissive color, an unresolvable `texture_set_ref`, a zero U-scale, and
+/// an sf1 CRC that isn't a member of the known `BSShaderCRC32` set.
+#[test]
+fn parse_bs_lighting_real_starfield_block_is_semantically_valid() {
+    let header = NifHeader {
+        version: NifVersion::V20_2_0_7,
+        little_endian: true,
+        user_version: 12,
+        user_version_2: 173, // real file's bsver
+        num_blocks: 0,
+        block_types: Vec::new(),
+        block_type_indices: Vec::new(),
+        block_sizes: Vec::new(),
+        // Real block's NiObjectNETData.name is string-table index 6,
+        // resolving to "" (full-body path, not a material-reference stub).
+        strings: vec![Arc::from(""); 7],
+        max_string_length: 0,
+        num_groups: 0,
+    };
+    // Byte-for-byte block 6 payload (166 bytes), extracted with
+    // `cargo run -p byroredux-bsa --example ba2_extract_one` +
+    // `cargo run -p byroredux-nif --example trace_block` against the
+    // real archive — see this test's doc comment for the source path.
+    #[rustfmt::skip]
+    let data: [u8; 166] = [
+        0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+        0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0xad, 0xc2, 0xc5, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, 0xff, 0xff, 0xff, 0xff,
+        0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f,
+        0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f,
+        0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x80, 0xbf,
+        0x00, 0x00, 0xc8, 0x42, 0x00, 0x00, 0x58, 0x41, 0x00, 0x00, 0x00, 0x40,
+        0x00, 0x00, 0x40, 0x40, 0xcd, 0xcc, 0xcc, 0x3d, 0x00, 0x00, 0x00, 0x00,
+        0x0a, 0xd7, 0xa3, 0x3c, 0xb1, 0xbf, 0xec, 0x3c, 0x55, 0xa4, 0xc2, 0x3d,
+        0x1b, 0x4c, 0x43, 0x3b, 0x00, 0x00, 0x80, 0x3f, 0x00, 0x00,
+    ];
+
+    let mut stream = NifStream::new(&data, &header);
+    let prop = BSLightingShaderProperty::parse_with_size(&mut stream, Some(data.len() as u32))
+        .expect("real Starfield BSLightingShaderProperty block must parse");
+
+    assert_eq!(
+        stream.position(),
+        data.len() as u64,
+        "must consume exactly the real block's byte count — no drift",
+    );
+    assert!(
+        !prop.material_reference,
+        "empty name (string idx 6 → \"\") must take the full-body path"
+    );
+
+    // Corrected alignment reads shader_type unconditionally.
+    assert_eq!(prop.shader_type, 0);
+
+    // Finite, non-negative emissive — pre-fix this was NaN (decoded from
+    // texture_set_ref's 0xFFFFFFFF NULL sentinel one word early).
+    for c in prop.emissive_color {
+        assert!(c.is_finite() && c >= 0.0, "emissive component {c} must be finite and non-negative");
+    }
+    assert_eq!(prop.emissive_color, [1.0, 1.0, 1.0]);
+
+    // A well-defined (NULL) texture_set_ref — pre-fix this decoded to an
+    // arbitrary non-null, unresolvable index (1065353216 on this exact
+    // block).
+    assert!(
+        prop.texture_set_ref.is_null(),
+        "texture_set_ref must resolve to a well-defined ref, got {:?}",
+        prop.texture_set_ref
+    );
+
+    // Non-zero U-scale — pre-fix this block's uv_scale.x decoded to 0.0.
+    assert!(prop.uv_scale[0] > 0.0, "uv_scale.x must be non-zero, got {}", prop.uv_scale[0]);
+    assert_eq!(prop.uv_scale, [1.0, 1.0]);
+
+    // sf1_crcs must be members of the known BSShaderCRC32 set — pre-fix
+    // this decoded to a value with no membership in that set.
+    assert_eq!(
+        prop.sf1_crcs,
+        vec![crate::shader_flags::bs_shader_crc32::VERTEX_COLORS],
+        "sf1 CRC must decode to the real, named VERTEX_COLORS flag",
+    );
+}
+
 /// #1510 / NIF-NEW-05 — nif.xml `#BS_F76# = (BSVER == 155)` ("Fallout 76
 /// stream 155 only"): the `BSShaderType155` field, WetnessParams
 /// `unknown_2`, and the Luminance / Translucency / texture-array tail are

--- a/crates/nif/src/import/mesh/bs_geometry.rs
+++ b/crates/nif/src/import/mesh/bs_geometry.rs
@@ -247,17 +247,12 @@ pub fn extract_bs_geometry(
     );
 
     // #1203 — resolve the BSSkin::Instance + BSSkin::BoneData chain
-    // hanging off `skin_instance_ref`. Per-vertex bone indices + weights
-    // are intentionally left empty here — the BSGeometry parser doesn't
-    // surface them yet (separate work).
-    //
-    // #1827 (FO4-D4-02) — confirmed gap, zero FO4 impact (BSVER 172
-    // Starfield only, not BSVER 130 FO4): Starfield skinned meshes render
-    // in bind pose today. Tracked as a separate Starfield-skinning
-    // milestone (decode the packed BSGeometry per-vertex bone
-    // index/weight channel analogous to the FO4 `BsTriShape` path), not a
-    // small fix — see the issue for the suggested approach.
-    let skin = extract_skin_bs_geometry(scene, shape);
+    // hanging off `skin_instance_ref`, plus (#2613) the per-vertex bone
+    // index/weight channel from `mesh_data.skin_weights` — decoded at
+    // parse time since #873, plumbed through here since #2613. #1827
+    // (FO4-D4-02) closed on the stale premise that this was undecoded;
+    // it wasn't — just never passed to the extractor.
+    let skin = extract_skin_bs_geometry(scene, shape, mesh_data);
 
     let t = &world_transform.translation;
     let quat = zup_matrix_to_yup_quat(&world_transform.rotation);

--- a/crates/nif/src/import/mesh/bs_geometry_skin_tests.rs
+++ b/crates/nif/src/import/mesh/bs_geometry_skin_tests.rs
@@ -6,12 +6,26 @@
 
 use super::*;
 use crate::blocks::base::{NiAVObjectData, NiObjectNETData};
-use crate::blocks::bs_geometry::{BSGeometry, BSGeometryMesh, BSGeometryMeshKind};
+use crate::blocks::bs_geometry::{
+    BSGeometry, BSGeometryMesh, BSGeometryMeshData, BSGeometryMeshKind, BoneWeight,
+};
 use crate::blocks::node::NiNode;
 use crate::blocks::skin::{BsSkinBoneData, BsSkinBoneTrans, BsSkinInstance};
 use crate::scene::NifScene;
 use crate::types::{BlockRef, NiMatrix3, NiPoint3, NiTransform};
 use std::sync::Arc;
+
+/// Empty `BSGeometryMeshData` — every field default. Used by tests that
+/// don't exercise the #2613 per-vertex weight plumbing (skin
+/// resolve/bone-count/name tests only care about the `BsSkinInstance` +
+/// `BsSkinBoneData` chain).
+fn empty_mesh_data() -> BSGeometryMeshData {
+    BSGeometryMeshData::default()
+}
+
+fn bone_weight(bone_index: u16, weight: u16) -> BoneWeight {
+    BoneWeight { bone_index, weight }
+}
 
 fn identity_transform() -> NiTransform {
     NiTransform {
@@ -108,7 +122,7 @@ fn bs_geometry_skin_instance_resolves_to_imported_skin() {
         ..NifScene::default()
     };
     let shape = bs_geometry_with_skin(3);
-    let skin = extract_skin_bs_geometry(&scene, &shape)
+    let skin = extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data())
         .expect("BSGeometry with valid skin_instance_ref must resolve");
     assert_eq!(skin.bones.len(), 2, "bone count must match BsSkinInstance");
     assert_eq!(skin.bones[0].name.as_ref(), "Spine");
@@ -118,8 +132,10 @@ fn bs_geometry_skin_instance_resolves_to_imported_skin() {
         Some("Bip01"),
         "skeleton root must resolve to its node's name",
     );
-    // Per-vertex bone indices + weights deferred until the BSGeometry
-    // parser surfaces them (#1203 deferred scope).
+    // No `skin_weights` on this fixture's (empty) mesh data — vertex
+    // arrays stay empty (the engine's rigid-fallback sentinel), same as
+    // a genuinely-unskinned shape. See `bs_geometry_skin_weights_*`
+    // below for the #2613 populated-weights path.
     assert!(skin.vertex_bone_indices.is_empty());
     assert!(skin.vertex_bone_weights.is_empty());
 }
@@ -145,7 +161,7 @@ fn mismatched_bone_counts_return_none() {
         ..NifScene::default()
     };
     let shape = bs_geometry_with_skin(2);
-    assert!(extract_skin_bs_geometry(&scene, &shape).is_none());
+    assert!(extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data()).is_none());
 }
 
 /// NULL skin_instance_ref returns None (rigid geometry — the common
@@ -155,7 +171,7 @@ fn null_skin_instance_ref_returns_none() {
     let scene = NifScene::default();
     let mut shape = bs_geometry_with_skin(0);
     shape.skin_instance_ref = BlockRef::NULL;
-    assert!(extract_skin_bs_geometry(&scene, &shape).is_none());
+    assert!(extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data()).is_none());
 }
 
 /// Dangling skin_instance_ref (points at a non-existent block) returns
@@ -164,7 +180,7 @@ fn null_skin_instance_ref_returns_none() {
 fn dangling_skin_instance_ref_returns_none() {
     let scene = NifScene::default();
     let shape = bs_geometry_with_skin(99); // points at block 99, scene has 0
-    assert!(extract_skin_bs_geometry(&scene, &shape).is_none());
+    assert!(extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data()).is_none());
 }
 
 /// Wrong block type at skin_instance_ref returns None (e.g., points at
@@ -176,7 +192,7 @@ fn wrong_block_type_at_skin_instance_ref_returns_none() {
         ..NifScene::default()
     };
     let shape = bs_geometry_with_skin(0); // points at the NiNode
-    assert!(extract_skin_bs_geometry(&scene, &shape).is_none());
+    assert!(extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data()).is_none());
 }
 
 /// Bone refs that don't resolve to a named NiObjectNET-bearing block
@@ -202,7 +218,7 @@ fn unresolvable_bone_ref_falls_back_to_synthetic_name() {
         ..NifScene::default()
     };
     let shape = bs_geometry_with_skin(2);
-    let skin = extract_skin_bs_geometry(&scene, &shape).expect("must still resolve");
+    let skin = extract_skin_bs_geometry(&scene, &shape, &empty_mesh_data()).expect("must still resolve");
     assert_eq!(skin.bones.len(), 2);
     assert_eq!(skin.bones[0].name.as_ref(), "Spine");
     assert_eq!(
@@ -210,4 +226,146 @@ fn unresolvable_bone_ref_falls_back_to_synthetic_name() {
         "Bone1",
         "dangling bone ref must fall back to synthetic Bone{{index}}",
     );
+}
+
+// ── #2613 — per-vertex skin_weights plumbing ───────────────────────────
+//
+// Pre-fix `extract_skin_bs_geometry` hardcoded `vertex_bone_indices` /
+// `vertex_bone_weights` to `Vec::new()` on the stale premise that the
+// BSGeometry parser didn't decode per-vertex skin data — it does
+// (`skin_weights`, since #873), it just was never passed to the
+// extractor. These tests exercise the fix: real-data-shaped (naked_f.nif
+// per the issue) two-bone skin + populated `skin_weights`.
+
+fn two_bone_skin_scene() -> NifScene {
+    NifScene {
+        blocks: vec![
+            Box::new(bone_node("Bip01")), // block 0 — skeleton root
+            Box::new(bone_node("Spine")), // block 1
+            Box::new(bone_node("Head")),  // block 2
+            Box::new(BsSkinInstance {
+                // block 3
+                skeleton_root_ref: BlockRef(0),
+                bone_data_ref: BlockRef(4),
+                bone_refs: vec![BlockRef(1), BlockRef(2)],
+                scales: Vec::new(),
+            }),
+            Box::new(BsSkinBoneData {
+                // block 4
+                bones: vec![bone_trans(1), bone_trans(2)],
+            }),
+        ],
+        ..NifScene::default()
+    }
+}
+
+fn mesh_data_with_weights(
+    num_vertices: usize,
+    weights_per_vert: u32,
+    skin_weights: Vec<Vec<BoneWeight>>,
+) -> BSGeometryMeshData {
+    BSGeometryMeshData {
+        weights_per_vert,
+        vertices: vec![[0.0, 0.0, 0.0]; num_vertices],
+        skin_weights,
+        ..BSGeometryMeshData::default()
+    }
+}
+
+/// Basic case: 2 vertices, 2 weights each. Vertex 0's weights already
+/// sum to exactly 1.0 NORM (no renormalization); vertex 1's weights are
+/// deliberately far from unit sum to exercise
+/// `renormalize_skin_weights`. Both cases also confirm descending
+/// (highest-weight-first) ordering.
+#[test]
+fn bs_geometry_skin_weights_plumbed_through_when_present() {
+    let scene = two_bone_skin_scene();
+    let shape = bs_geometry_with_skin(3);
+    let mesh_data = mesh_data_with_weights(
+        2,
+        2,
+        vec![
+            vec![bone_weight(0, 65535), bone_weight(1, 0)],
+            vec![bone_weight(1, 6), bone_weight(0, 4)],
+        ],
+    );
+    let skin = extract_skin_bs_geometry(&scene, &shape, &mesh_data)
+        .expect("BSGeometry with valid skin_instance_ref must resolve");
+
+    assert_eq!(skin.vertex_bone_indices.len(), 2);
+    assert_eq!(skin.vertex_bone_weights.len(), 2);
+
+    // Vertex 0: full weight on bone 0, already unit-sum.
+    assert_eq!(skin.vertex_bone_indices[0], [0, 1, 0, 0]);
+    assert!((skin.vertex_bone_weights[0][0] - 1.0).abs() < 1e-5);
+    assert!(skin.vertex_bone_weights[0][1].abs() < 1e-5);
+
+    // Vertex 1: raw NORM weights (6, 4) sum far below 1.0 — must be
+    // renormalized to the same 6:4 (0.6:0.4) ratio, sorted so bone 1
+    // (the larger raw weight) leads.
+    assert_eq!(skin.vertex_bone_indices[1], [1, 0, 0, 0]);
+    assert!(
+        (skin.vertex_bone_weights[1][0] - 0.6).abs() < 1e-4,
+        "got {}",
+        skin.vertex_bone_weights[1][0]
+    );
+    assert!(
+        (skin.vertex_bone_weights[1][1] - 0.4).abs() < 1e-4,
+        "got {}",
+        skin.vertex_bone_weights[1][1]
+    );
+    let sum: f32 = skin.vertex_bone_weights[1].iter().sum();
+    assert!((sum - 1.0).abs() < 1e-4, "renormalized sum must be ~1.0, got {sum}");
+}
+
+/// A vertex authoring more than 4 influences keeps only the top 4 by
+/// weight — the lowest two (bones 0 and 1) must be dropped entirely.
+#[test]
+fn bs_geometry_skin_weights_keeps_top_four_by_weight() {
+    let scene = two_bone_skin_scene();
+    let shape = bs_geometry_with_skin(3);
+    let mesh_data = mesh_data_with_weights(
+        1,
+        6,
+        vec![vec![
+            bone_weight(0, 100),
+            bone_weight(1, 200),
+            bone_weight(2, 300),
+            bone_weight(3, 400),
+            bone_weight(4, 500),
+            bone_weight(5, 600),
+        ]],
+    );
+    let skin = extract_skin_bs_geometry(&scene, &shape, &mesh_data)
+        .expect("BSGeometry with valid skin_instance_ref must resolve");
+
+    assert_eq!(
+        skin.vertex_bone_indices[0],
+        [5, 4, 3, 2],
+        "must keep the 4 highest-weight bones (5,4,3,2), descending"
+    );
+    let w = skin.vertex_bone_weights[0];
+    assert!(w[0] > w[1] && w[1] > w[2] && w[2] > w[3], "weights must stay descending: {w:?}");
+    let sum: f32 = w.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-4, "renormalized sum must be ~1.0, got {sum}");
+}
+
+/// A vertex count mismatch between `skin_weights` and the mesh's own
+/// `vertices` falls back to the engine's empty-vec rigid-fallback
+/// sentinel — the skin still resolves (bones intact) rather than
+/// failing outright, matching a genuinely-unskinned shape's contract.
+#[test]
+fn bs_geometry_skin_weights_vertex_count_mismatch_falls_back_to_empty() {
+    let scene = two_bone_skin_scene();
+    let shape = bs_geometry_with_skin(3);
+    // 1 skin_weights row but 2 vertices — mismatch.
+    let mesh_data =
+        mesh_data_with_weights(2, 1, vec![vec![bone_weight(0, 65535)]]);
+    let skin = extract_skin_bs_geometry(&scene, &shape, &mesh_data)
+        .expect("bone resolution must still succeed despite the weight mismatch");
+
+    assert!(skin.vertex_bone_indices.is_empty());
+    assert!(skin.vertex_bone_weights.is_empty());
+    // Bones themselves are unaffected by the mismatch.
+    assert_eq!(skin.bones.len(), 2);
 }

--- a/crates/nif/src/import/mesh/skin.rs
+++ b/crates/nif/src/import/mesh/skin.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use crate::blocks::bs_geometry::BSGeometry;
+use crate::blocks::bs_geometry::{BSGeometry, BSGeometryMeshData, BoneWeight};
 use crate::blocks::node::NiNode;
 use crate::blocks::skin::{
     BsDismemberSkinInstance, BsSkinBoneData, BsSkinInstance, NiSkinData, NiSkinInstance,
@@ -219,18 +219,71 @@ pub fn extract_skin_bs_tri_shape(scene: &NifScene, shape: &BsTriShape) -> Option
     None
 }
 
+/// Convert Starfield `BSGeometry`'s per-vertex `skin_weights` (already
+/// grouped by vertex — outer index is the vertex, inner list holds up to
+/// `weights_per_vert` [`BoneWeight`] entries) into the engine's fixed
+/// `[u16; 4]` bone-index / `[f32; 4]` weight per-vertex arrays. Mirrors
+/// `extract_skin_bs_tri_shape`'s FO4 `BsTriShape` contract: keeps the top
+/// 4 contributions by weight (zero-padding when fewer), decodes the u16
+/// NORM weight (`/ 65535.0`), and renormalizes via
+/// [`crate::blocks::tri_shape::renormalize_skin_weights`] so NORM
+/// quantization drift doesn't accumulate on the GPU skinning path.
+///
+/// Returns empty vecs — the engine's existing "no per-vertex skin data"
+/// sentinel (see `nif_loader.rs`'s `vertex_bone_indices.is_empty()`
+/// rigid-fallback gate) — when `skin_weights.len()` doesn't match
+/// `num_vertices`: a mismatch means the mesh-data table and the geometry
+/// it's paired with disagree on vertex count, and guessing which vertex
+/// maps to which weight row would silently mis-skin the mesh rather than
+/// fail safe. See #2613.
+fn convert_bs_geometry_skin_weights(
+    mesh_data: &BSGeometryMeshData,
+    num_vertices: usize,
+) -> (Vec<[u16; 4]>, Vec<[f32; 4]>) {
+    if mesh_data.weights_per_vert == 0
+        || mesh_data.skin_weights.is_empty()
+        || mesh_data.skin_weights.len() != num_vertices
+    {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut indices = Vec::with_capacity(num_vertices);
+    let mut weights = Vec::with_capacity(num_vertices);
+    for vertex_weights in &mesh_data.skin_weights {
+        let mut sorted: Vec<&BoneWeight> = vertex_weights.iter().collect();
+        // Descending by raw u16 weight — exact integer order, no NaN
+        // concerns from comparing the decoded f32.
+        sorted.sort_by(|a, b| b.weight.cmp(&a.weight));
+
+        let mut idx = [0u16; 4];
+        let mut w = [0.0f32; 4];
+        for (slot, bw) in sorted.into_iter().take(4).enumerate() {
+            idx[slot] = bw.bone_index;
+            w[slot] = bw.weight as f32 / 65535.0;
+        }
+        weights.push(crate::blocks::tri_shape::renormalize_skin_weights(w));
+        indices.push(idx);
+    }
+    (indices, weights)
+}
+
 /// Extract `ImportedSkin` for a Starfield `BSGeometry` via `skin_instance_ref`.
 /// Resolves the linked `BSSkin::Instance` + `BSSkin::BoneData` and builds the
-/// engine-side bone list with bind-inverse transforms. Per-vertex bone
-/// indices + weights are intentionally left empty here — the BSGeometry
-/// parser doesn't surface them yet (the segmented mesh-data table is
-/// separate work); when it does, this extractor's signature should grow
-/// a `num_vertices` parameter and the densify path matching
-/// `extract_skin_ni_tri_shape`'s `vertex_bone_*` plumbing. See #1203.
+/// engine-side bone list with bind-inverse transforms, then decodes
+/// `mesh_data.skin_weights` into per-vertex bone indices/weights via
+/// [`convert_bs_geometry_skin_weights`]. See #2613 — pre-fix these were
+/// hardcoded empty on the stale premise that the BSGeometry parser didn't
+/// surface per-vertex skin data yet; `skin_weights` has been fully decoded
+/// since #873, just never plumbed through here (#1827 closed on that same
+/// stale premise).
 ///
 /// Mirrors the FO4+ BSSkin path in `extract_skin_bs_tri_shape` — only
 /// the geometry container differs.
-pub fn extract_skin_bs_geometry(scene: &NifScene, shape: &BSGeometry) -> Option<ImportedSkin> {
+pub fn extract_skin_bs_geometry(
+    scene: &NifScene,
+    shape: &BSGeometry,
+    mesh_data: &BSGeometryMeshData,
+) -> Option<ImportedSkin> {
     let skin_idx = shape.skin_instance_ref.index()?;
 
     let inst = scene.get_as::<BsSkinInstance>(skin_idx)?;
@@ -255,13 +308,15 @@ pub fn extract_skin_bs_geometry(scene: &NifScene, shape: &BSGeometry) -> Option<
         });
     }
     let skeleton_root = resolve_node_name(scene, inst.skeleton_root_ref);
+    let (vertex_bone_indices, vertex_bone_weights) =
+        convert_bs_geometry_skin_weights(mesh_data, mesh_data.vertices.len());
     // BSSkin (FO4+/Skyrim SE/Starfield) doesn't carry a per-skin global
     // transform; identity matches the OpenMW FO4-mesh fallback.
     Some(ImportedSkin {
         bones,
         skeleton_root,
-        vertex_bone_indices: Vec::new(),
-        vertex_bone_weights: Vec::new(),
+        vertex_bone_indices,
+        vertex_bone_weights,
         global_skin_transform: [
             [1.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 0.0, 0.0],

--- a/crates/sfmaterial/src/reader.rs
+++ b/crates/sfmaterial/src/reader.rs
@@ -176,7 +176,18 @@ impl<'a> Parser<'a> {
         }
         let chunk_count = (chunk_count_incl_beth - 1) as usize;
 
-        let mut chunks = VecDeque::with_capacity(chunk_count);
+        // #2614 / SF-D3-01 — `chunk_count` is an unvalidated on-disk u32
+        // (up to ~4 billion for a corrupt/truncated file); pre-reserving
+        // directly from it let `VecDeque::with_capacity` request ~103 GB
+        // and panic/abort *before* the per-chunk `ChunkOverflow` guard
+        // below ever runs, on the live cell-load path. Each chunk costs
+        // at least 8 bytes on disk (the `kind`/`size` header read every
+        // iteration), so cap the reservation at that lower bound — a
+        // hostile count still gets validated chunk-by-chunk into a
+        // proper `Err`, it just doesn't over-allocate first. Matches
+        // Gibbed's reference (`ComponentDatabaseFile.cs`), which has no
+        // pre-reserve at all.
+        let mut chunks = VecDeque::with_capacity(chunk_count.min(self.bytes.len() / 8));
         for index in 0..chunk_count {
             let raw = self.read_u32()?;
             let kind = ChunkType::from_raw(raw, index)?;
@@ -294,7 +305,12 @@ fn parse_class(state: &mut State, class_index: usize) -> Result<Class> {
         });
     }
 
-    let mut fields = Vec::with_capacity(field_count);
+    // #2614 / SF-D3-01 sibling — `field_count` is an unvalidated on-disk
+    // u16 read from `payload`; each field costs at least 12 bytes
+    // (name_off + type_ref + offset + size), so cap the reservation at
+    // that lower bound rather than trusting the count directly. See the
+    // `index_chunks` doc for the full rationale — same class of bug.
+    let mut fields = Vec::with_capacity(field_count.min(payload.len() / 12));
     for _ in 0..field_count {
         let name_off = cur.read_i32()?;
         let name = state.strings.get(name_off)?;
@@ -370,7 +386,13 @@ fn consume_list(state: &mut State, is_diff: bool) -> Result<Value> {
     let mut cur = Cursor::new(payload);
     let elem_ref = TypeReference::new(cur.read_i32()?);
     let count = cur.read_i32()? as usize;
-    let mut items = Vec::with_capacity(count);
+    // #2614 / SF-D3-01 sibling — `count` is unvalidated on-disk data and
+    // element size varies by `elem_ref`'s type, so (unlike the fixed-size
+    // chunk/field cases above) there's no cheap universal per-element
+    // minimum to bound against. Drop the pre-reserve entirely — matches
+    // Gibbed's reference, which has none — so a hostile count degrades to
+    // incremental `Vec` growth instead of an upfront over-allocation.
+    let mut items = Vec::new();
     for _ in 0..count {
         items.push(read_value(state, elem_ref, &mut cur, is_diff)?);
     }
@@ -387,7 +409,9 @@ fn consume_map(state: &mut State, is_diff: bool) -> Result<Value> {
     let key_ref = TypeReference::new(cur.read_i32()?);
     let val_ref = TypeReference::new(cur.read_i32()?);
     let count = cur.read_i32()? as usize;
-    let mut pairs = Vec::with_capacity(count);
+    // #2614 / SF-D3-01 sibling — same rationale as `consume_list`: no
+    // cheap universal per-pair minimum size, drop the pre-reserve.
+    let mut pairs = Vec::new();
     for _ in 0..count {
         let k = read_value(state, key_ref, &mut cur, is_diff)?;
         let v = read_value(state, val_ref, &mut cur, is_diff)?;
@@ -851,5 +875,64 @@ mod tests {
         let parsed = ComponentDatabaseFile::parse(&cdb).expect("valid-flag CDB parses");
         assert_eq!(parsed.classes.len(), 1);
         assert_eq!(parsed.classes[0].name, "TestClass");
+    }
+
+    /// Regression: #2614 / SF-D3-01 — a hostile on-disk `chunkCount`
+    /// (`0xFFFF_FFFF`, requesting ~103 GB of `VecDeque<Chunk>` capacity
+    /// pre-fix) must fail with a proper `Err` from `index_chunks`'s
+    /// bounds-checked reads, not panic/abort the process via
+    /// `with_capacity`. A well-formed header with no chunk data follows —
+    /// pre-fix this test never reached the assertion at all.
+    #[test]
+    fn hostile_chunk_count_errors_instead_of_aborting() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&SIGNATURE_BETH.to_le_bytes());
+        bytes.extend_from_slice(&HEADER_SIZE.to_le_bytes());
+        bytes.extend_from_slice(&FILE_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // chunkCount incl. BETH
+
+        match ComponentDatabaseFile::parse(&bytes) {
+            Err(_) => {} // any Err is acceptable — the point is "not a panic/abort"
+            Ok(_) => panic!("a hostile chunk_count with no backing chunk data must not parse Ok"),
+        }
+    }
+
+    /// Sibling to the above for the CDB reflection-payload allocation
+    /// sites (`parse_class`'s `fields`, `consume_list`'s `items`,
+    /// `consume_map`'s `pairs`) — same unvalidated-on-disk-count shape.
+    /// A hostile `field_count` on an otherwise well-formed chunk table
+    /// must fail bounds-checked (`ClassTrailingBytes`/`UnexpectedEof`),
+    /// not over-allocate.
+    #[test]
+    fn hostile_class_field_count_errors_instead_of_aborting() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&SIGNATURE_BETH.to_le_bytes());
+        bytes.extend_from_slice(&HEADER_SIZE.to_le_bytes());
+        bytes.extend_from_slice(&FILE_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&4u32.to_le_bytes()); // chunkCount incl. BETH
+
+        let strt: &[u8] = b"TestClass\0";
+        bytes.extend_from_slice(&(ChunkType::Strt as u32).to_le_bytes());
+        bytes.extend_from_slice(&(strt.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(strt);
+
+        bytes.extend_from_slice(&(ChunkType::Type as u32).to_le_bytes());
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // type_count
+
+        // CLAS with a hostile field_count but no field data behind it.
+        let mut clas = Vec::new();
+        clas.extend_from_slice(&0i32.to_le_bytes()); // name_offset
+        clas.extend_from_slice(&0u32.to_le_bytes()); // type_id
+        clas.extend_from_slice(&(ClassFlags::IS_STRUCT).to_le_bytes()); // flags
+        clas.extend_from_slice(&0xFFFFu16.to_le_bytes()); // field_count HOSTILE
+        bytes.extend_from_slice(&(ChunkType::Clas as u32).to_le_bytes());
+        bytes.extend_from_slice(&(clas.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&clas);
+
+        match ComponentDatabaseFile::parse(&bytes) {
+            Err(_) => {}
+            Ok(_) => panic!("a hostile field_count with no backing field data must not parse Ok"),
+        }
     }
 }


### PR DESCRIPTION
…lignment

#2613 (crates/nif/src/import/mesh/skin.rs, bs_geometry.rs, HIGH): Starfield skinned meshes rendered in bind pose. extract_skin_bs_geometry hardcoded vertex_bone_indices/vertex_bone_weights to Vec::new() on the stale premise that the BSGeometry parser doesn't decode per-vertex skin data -- it does (BSGeometryMeshData.skin_weights, since #873), it just was never plumbed through. Added convert_bs_geometry_skin_weights(): top-4-by-weight selection, u16 NORM decode, renormalize via the existing renormalize_skin_weights helper shared with the FO4 BsTriShape path. Falls back to empty vecs (the engine's existing rigid-fallback sentinel) on a skin_weights/vertex-count mismatch rather than guessing. Corrects #1827's stale closed-issue premise inline. Added 3 new tests (basic decode + renormalize, top-4 selection, mismatch fallback) and updated the existing bs_geometry_skin_tests.rs fixtures/assertions.

#2614 (crates/sfmaterial/src/reader.rs, HIGH): index_chunks pre-reserved a VecDeque directly from an unvalidated on-disk u32 chunk count -- a hostile 0xFFFFFFFF requested ~103 GB before the per-chunk ChunkOverflow guard ever ran, aborting the process on a corrupt/truncated CDB at the live cell-load path. Capped the reservation at chunk_count.min(bytes/8) (each chunk costs >=8 bytes on disk). Found and fixed the same unvalidated-count-to-with_capacity shape at 3 more sites in the same file (parse_class's fields, consume_list's items, consume_map's pairs) while auditing for siblings -- items/pairs have no cheap universal per-element minimum so those drop the pre-reserve entirely, matching Gibbed's reference. Added 2 regression tests (hostile chunk_count, hostile field_count) asserting Err, not panic/abort.

#2615 (byroredux/src/asset_provider/archive.rs, HIGH): Archive::open read the entire archive file into a Vec<u8> via std::fs::read purely to sample 4 magic bytes for BSA-vs-BA2 dispatch -- multi-GB on Starfield's mesh archives, paid twice per material-provider build per build_material_provider's own (now-accurate) doc comment. Replaced with File::open + read_exact into a 4-byte buffer. Extracted the sniff into a testable sniff_magic_from<R: Read> helper and added a byte-counting reader-wrapper test proving it reads exactly 4 bytes regardless of source size.

#2616 (crates/nif/src/blocks/shader.rs, HIGH): BSLightingShaderProperty was misaligned by one 4-byte word on 100% of Starfield full-body blocks. #1510 gated the pre-name shader_type read off for bsver >= STARFIELD on the premise Starfield doesn't carry it -- it does (reusing the FO76 enum, per this fn's own doc table). The actual Starfield-only field is root_material_path, read unconditionally pre-fix. Both are 4-byte reads at that point in the stream (root_material_path decodes as a string-table i32 index on modern NIF versions), so total block consumption matched and the misalignment survived #1510, #1606, and two Starfield audits. Read shader_type unconditionally; gate root_material_path on bsver < STARFIELD instead. Verified against real content: extracted block 6 (bsver 173, block_size 166) from `Starfield - LODMeshes.ba2`'s shiplandingmarker_lod_3.nif via ba2_extract_one/trace_block and added it as a byte-for-byte regression fixture -- decodes to finite emissive [1,1,1], a well-defined NULL texture_set_ref, non-zero uv_scale, and an sf1 CRC that resolves to the real named VERTEX_COLORS flag (all NaN/unresolvable/zero/invalid pre-fix). Also fixed the synthetic build_starfield_bs_lighting_minimal fixture, which had baked in the old (wrong) field order and would have silently matched either alignment.

cargo test -p byroredux-nif (988 passed) including the full 7-game parse_real_nifs / per_block_baselines / translation_completeness --ignored corpus suites against real game data (100% clean parse rates maintained, Starfield mat_path fill-rate 94.9%, all fill-rate floors pass), -p byroredux-sfmaterial (16 passed), -p byroredux (870 passed), and the full workspace suite all green.