### PR TITLE
Fix #2629 #2630 #2631 #2632: BA2 header doc drift + test coverage + BSGeometry LOD-slot + tangent normalization

### DIFF
--- a/.claude/issues/2629-2630-2631-2632/ISSUE.md
+++ b/.claude/issues/2629-2630-2631-2632/ISSUE.md
@@ -1,0 +1,106 @@
+# Issues 2629, 2630, 2631, 2632
+
+All four are LOW-severity Starfield-audit findings. Two domains:
+- #2629, #2630 → **bsa** (`byroredux-bsa`) — BA2 v2/v3 archive header
+- #2631, #2632 → **nif** (`byroredux-nif`) — BSGeometry mesh extraction (Starfield)
+
+---
+
+## #2629 — SF-D1-04: log_v2_v3_extra_bytes doc claims name-table-size field that is always constant 1, dead heuristic
+
+**Severity**: LOW · **Dimension**: 1 (BA2 v2/v3 LZ4 Block Decompression)
+**Location**: `crates/bsa/src/ba2.rs:431-474` (`log_v2_v3_extra_bytes`)
+**Status**: NEW — sibling of #2360 (SF-BA2-02, OPEN, LOW), different defect in the same helper
+
+### Description
+`log_v2_v3_extra_bytes` documents a "compressed name-table size" field that is always the constant `1` on every real archive — the malformed-header heuristic built on it is dead code. All 129 archives have `hdr[24..32] == 0100000000000000` byte-identical. A value of 1 is not a size; the `stream_pos + size > name_table_offset` malformed-header branch derived from reading it as one can never fire on real data.
+
+### Evidence
+129/129 archives byte-identical on this field.
+
+### Impact
+Documentation/diagnostic only.
+
+### Suggested Fix
+Rename to `unknown_1`/`unknown_2` (or `name_table_format`), recording the observed constant; drop or replace the dead heuristic.
+
+### Related
+#2360 (SF-BA2-02).
+
+### Completeness Checks
+- [ ] **TESTS**: N/A — doc/diagnostic-only change
+
+---
+
+## #2630 — SF-D1-05: no test covers v3-zlib path, LZ4 under-run, or real-data-derived BA2 header fixture
+
+**Severity**: LOW · **Dimension**: 1 (BA2 v2/v3 LZ4 Block Decompression)
+**Location**: `crates/bsa/src/ba2.rs:1009-1470` (`mod tests`)
+**Status**: NEW
+
+### Description
+`compression_method == 0` on a v3 archive (v3+zlib) has zero test coverage and does not occur in vanilla; no under-run test exists (see SF-D1-01); the header-offset tests build their fixture to mirror the parser's own layout assumption, so a wrong offset would move in lockstep with the bug rather than being caught.
+
+### Evidence
+No v3+zlib fixture; no LZ4 under-run test; header-offset fixtures are generated from the parser's own assumed layout rather than an independent byte-literal spec.
+
+### Impact
+A future header-layout edit could pass the whole suite while breaking every v3 archive, surfacing only on a manual run against game data.
+
+### Suggested Fix
+Synthesize a v3+method-0 fixture; add the LZ4 under-run test (see SF-D1-01); add a byte-literal fixture built from the documented v3 header layout with post-parse content assertions.
+
+### Related
+SF-D1-01.
+
+### Completeness Checks
+- [ ] **TESTS**: This finding IS the test-coverage fix — add the three fixtures described above
+
+---
+
+## #2631 — SF2D2-D2-03: BSGeometryMeshData lods/meshlets/cull_data and slot LOD index decoded and dropped by importer
+
+**Severity**: LOW · **Dimension**: 2 (BSGeometry Mesh Extraction)
+**Location**: `crates/nif/src/import/mesh/bs_geometry.rs:140-144,325`, `crates/nif/src/blocks/bs_geometry.rs:107-112`
+**Status**: NEW
+
+### Description
+Three signals are parsed and discarded: (1) `mesh_data.lods` — full reduced triangle lists per LOD level (importer reads only LOD 0); (2) `meshlets`/`cull_data` — cluster-culling primitives; (3) the slot loop index itself is lost at parse time (`BSGeometry::parse`'s `for _ in 0..4` loop discards its own counter), so `meshes[0]` is the first *present* slot, not necessarily LOD 0 — combined with the sentinel-slot skip, a future LOD selector has no way to know which level it actually loaded.
+
+### Evidence
+`BSGeometry::parse`'s slot loop (`crates/nif/src/blocks/bs_geometry.rs:107-112`) discards its own loop counter; `mesh_data.lods`/`meshlets`/`cull_data` are parsed but never read by the importer (`bs_geometry.rs:140-144,325`).
+
+### Impact
+No LOD switching possible for Starfield content today (missing-feature, nothing renders wrong) — but item (3) is cheap now, expensive to retrofit later.
+
+### Suggested Fix
+Store the loop index as `BSGeometryMesh.lod_slot: u32` at parse time and carry it into `ImportedMesh` alongside `bs_lod_cutoffs`. `lods`/`meshlets` consumption itself is fine as EXAL follow-up work.
+
+### Completeness Checks
+- [ ] **TESTS**: A multi-slot fixture asserts `lod_slot` matches the actual authored slot index, not the post-skip array position
+
+---
+
+## #2632 — SF2D2-D2-04: UDEC3-decoded normals feed unnormalized into tangent synthesis Gram-Schmidt
+
+**Severity**: LOW · **Dimension**: 2 (BSGeometry Mesh Extraction)
+**Location**: `crates/nif/src/import/mesh/bs_geometry.rs:150-162,217`, `crates/nif/src/blocks/bs_geometry.rs:569-580`, `crates/nif/src/import/mesh/tangent.rs:442-505`
+**Status**: NEW
+
+### Description
+UDEC3-decoded normals feed unnormalized into `synthesize_tangents_yup`'s Gram-Schmidt, which assumes unit N. `unpack_udec3_xyzw`'s raw remap has no normalization (unit-length only to 10-bit quantization); the Gram-Schmidt projection is only correct for `|n| == 1`, and the degenerate fallback branch (`t_y = [n[1], n[2], n[0]]`) is neither normalized nor orthogonalized against `n`.
+
+### Evidence
+`unpack_udec3_xyzw` (`crates/nif/src/blocks/bs_geometry.rs:569-580`) performs no normalization; `synthesize_tangents_yup`'s Gram-Schmidt (`crates/nif/src/import/mesh/tangent.rs:442-505`) assumes unit-length input.
+
+### Impact
+Quantization error (~0.1%) is visually negligible on the non-degenerate path (shader renormalizes); the degenerate branch's non-orthogonality is a pre-existing shared divergence (AUDIT_INCREMENTAL_2026-05-22 ID-4), sub-pixel in practice.
+
+### Suggested Fix
+`normalize_inplace` the copy fed to `synthesize_tangents_yup`; orthogonalize the degenerate `t_y` against `n` with Gram-Schmidt + normalize before the cross product.
+
+### Related
+AUDIT_INCREMENTAL_2026-05-22 ID-4 (the pre-existing shared divergence this overlaps with).
+
+### Completeness Checks
+- [ ] **TESTS**: A degenerate-normal fixture asserts the fallback tangent is normalized and orthogonal to N

--- a/crates/bsa/src/ba2.rs
+++ b/crates/bsa/src/ba2.rs
@@ -429,46 +429,45 @@ impl Ba2Archive {
 }
 
 /// Defense-in-depth header sanity log for the Starfield v2 / v3 trailing
-/// 8 bytes (community-RE'd as `compressed_name_table_size: u32` +
-/// `reserved: u32`). Logs both fields at trace level so a malformed
-/// archive's failure surfaces here at the header boundary instead of
-/// 50 records deep inside `read_general_records` (where the symptom
-/// is the confusing `failed to fill whole buffer`).
-///
-/// Emits a debug-level warning when the size field claims more bytes
-/// before the name table than physically exist (`stream_pos + size >
-/// name_table_offset` — the gap can't be larger than the gap). The
-/// check is intentionally loose: well-formed archives commonly write a
-/// size smaller than the gap (the field is "compressed name-table
-/// size", not "remaining bytes"), so a true value-shape mismatch only
-/// fires when the field is wildly out of bounds.
+/// 8 bytes. Originally community-RE'd as `compressed_name_table_size: u32`
+/// + `reserved: u32`, but #2629 / SF-D1-04 found all 129 sampled vanilla
+/// archives byte-identical on this field (`0100000000000000` LE — i.e.
+/// `unknown_1 == 1`, `unknown_2 == 0`): a constant tag, not a size. The
+/// original "compressed name-table size" reading was never actually
+/// exercised — the `stream_pos + size > name_table_offset` malformed-
+/// header heuristic built on it was dead code (a constant `1` can never
+/// project past `name_table_offset`) and has been dropped. Logs both
+/// fields at trace level purely as a header-boundary sanity record, so a
+/// future archive that DOES vary here surfaces at the header boundary
+/// instead of 50 records deep inside `read_general_records` (where the
+/// symptom is the confusing `failed to fill whole buffer`).
 ///
 /// Models the `padding != 0xBAADF00D` debug-log inside
 /// [`read_general_records`] — cheap header-boundary sanity check.
-/// See #1186.
+/// See #1186, #2629.
 fn log_v2_v3_extra_bytes(label: &str, extra: &[u8; 8], name_table_offset: u64, stream_pos: u64) {
-    let size = u32::from_le_bytes(extra[0..4].try_into().unwrap());
-    let reserved = u32::from_le_bytes(extra[4..8].try_into().unwrap());
+    let unknown_1 = u32::from_le_bytes(extra[0..4].try_into().unwrap());
+    let unknown_2 = u32::from_le_bytes(extra[4..8].try_into().unwrap());
     log::trace!(
-        "BA2 {} extra header bytes: compressed_name_table_size={} \
-         reserved={:#x} (stream_pos={:#x}, name_table_offset={:#x})",
+        "BA2 {} extra header bytes: unknown_1={} unknown_2={:#x} \
+         (stream_pos={:#x}, name_table_offset={:#x})",
         label,
-        size,
-        reserved,
+        unknown_1,
+        unknown_2,
         stream_pos,
         name_table_offset,
     );
-    let projected_end = stream_pos.saturating_add(size as u64);
-    if projected_end > name_table_offset {
+    if unknown_1 != 1 || unknown_2 != 0 {
         log::debug!(
-            "BA2 {} compressed_name_table_size={} would project past \
-             name_table_offset={:#x} (stream_pos={:#x}, projected_end={:#x}); \
-             header likely malformed",
+            "BA2 {} extra header bytes deviate from the observed-constant \
+             {{unknown_1=1, unknown_2=0}}: unknown_1={} unknown_2={:#x} \
+             (stream_pos={:#x}, name_table_offset={:#x}); worth a closer \
+             look, though the format may simply vary here",
             label,
-            size,
-            name_table_offset,
+            unknown_1,
+            unknown_2,
             stream_pos,
-            projected_end,
+            name_table_offset,
         );
     }
 }
@@ -1378,6 +1377,137 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         let msg = format!("{err}");
         assert!(msg.contains("unsupported compression method"), "got: {msg}");
+    }
+
+    /// SF-D1-05 (#2630) — `compression_method == 0` (zlib) on a v3
+    /// archive has zero prior test coverage: every other v3 fixture in
+    /// this module exercises method 3 (LZ4) or an outright-rejected
+    /// unknown method. v3+zlib doesn't occur in vanilla Starfield
+    /// content (v3 is DX10-only there, and DX10 zlib is covered
+    /// elsewhere), but the reader accepts it (`0 => Ba2Compression::Zlib`
+    /// at the header-parse match), so a mod-authored or future-game v3
+    /// GNRL+zlib archive is a real reachable path that was silently
+    /// untested.
+    ///
+    /// Also serves as the "byte-literal fixture built from the
+    /// documented v3 header layout" the finding asked for: every offset
+    /// below is a literal constant annotated against the module's own
+    /// `# Version mapping` doc table (top of file) and the 36-byte GNRL
+    /// record layout in `read_general_records`, rather than being
+    /// generated through any of the parser's own encoding helpers (this
+    /// module doesn't have a BA2 *writer*, so there is no shared code
+    /// path that could drift in lockstep with a parser bug the way a
+    /// round-trip-through-the-same-helpers fixture would).
+    #[test]
+    fn v3_zlib_gnrl_header_literal_fixture_roundtrips() {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let payload = b"Starfield v3+zlib GNRL payload - SF-D1-05";
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(payload).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        // v3 header: 24-byte base + 8-byte v2/v3 extra + 4-byte
+        // compression_method = 36 bytes, immediately followed by one
+        // 36-byte GNRL record (72 bytes total), then the compressed
+        // payload, then the 1-entry name table.
+        const HEADER_LEN: u64 = 36;
+        const RECORD_LEN: u64 = 36;
+        let payload_offset = HEADER_LEN + RECORD_LEN; // 72
+        let name_table_offset = payload_offset + compressed.len() as u64;
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"BTDX"); // magic
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version = 3 (Starfield)
+        buf.extend_from_slice(b"GNRL"); // type_tag
+        buf.extend_from_slice(&1u32.to_le_bytes()); // file_count = 1
+        buf.extend_from_slice(&name_table_offset.to_le_bytes());
+        // v2/v3 extra 8 bytes — observed-constant {unknown_1=1, unknown_2=0}
+        // per #2629 / SF-D1-04, NOT the size the field was originally
+        // (mis-)documented as.
+        buf.extend_from_slice(&1u32.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        buf.extend_from_slice(&0u32.to_le_bytes()); // compression_method = 0 (zlib)
+        assert_eq!(buf.len() as u64, HEADER_LEN, "header layout drifted");
+
+        // GNRL record: name_hash/ext/dir_hash/flags (4×4=16, unused) +
+        // offset(8) + packed_size(4) + unpacked_size(4) + padding(4).
+        buf.extend_from_slice(&[0u8; 16]);
+        buf.extend_from_slice(&payload_offset.to_le_bytes());
+        buf.extend_from_slice(&(compressed.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&PADDING_BAADFOOD.to_le_bytes());
+        assert_eq!(buf.len() as u64, HEADER_LEN + RECORD_LEN, "record layout drifted");
+
+        buf.extend_from_slice(&compressed);
+        assert_eq!(buf.len() as u64, name_table_offset, "payload placement drifted");
+
+        // Name table: one 2-byte-length-prefixed name.
+        let name = b"meshes/sfd1_05.nif";
+        buf.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        buf.extend_from_slice(name);
+
+        let mut path = std::env::temp_dir();
+        path.push(format!("byroredux_ba2_v3_zlib_literal_{}.ba2", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&path).expect("create temp BA2");
+            f.write_all(&buf).expect("write header");
+        }
+        let archive = Ba2Archive::open(&path);
+        let _ = std::fs::remove_file(&path);
+        let archive = archive.expect("byte-literal v3+zlib fixture must open cleanly");
+
+        assert_eq!(archive.version(), 3);
+        assert_eq!(archive.variant(), Ba2Variant::General);
+        assert_eq!(archive.file_count(), 1);
+        assert!(archive.contains("meshes/sfd1_05.nif"));
+        let extracted = archive
+            .extract("meshes/sfd1_05.nif")
+            .expect("v3+zlib GNRL entry must extract");
+        assert_eq!(
+            extracted, payload,
+            "v3+zlib decompression must round-trip the exact authored payload"
+        );
+    }
+
+    /// SF-D1-05 (#2630) — pins the CURRENT LZ4 "under-run" behaviour:
+    /// `unpacked_size` declared LARGER than what the block actually
+    /// decompresses to. Per #2618 (SF-D1-01)'s measurement against the
+    /// pinned `lz4_flex 0.11.6`, `decompress_chunk` does NOT error here
+    /// — `lz4_flex::block::decompress`'s `min_uncompressed_size` is only
+    /// a capacity hint (`Vec::with_capacity`), and the returned buffer is
+    /// silently truncated to the block's real decoded length. This is
+    /// the opposite of what the (stale, pre-#2618) comment on the LZ4
+    /// arm used to claim ("hard-errors on the same condition") and the
+    /// opposite of `decompress_chunk_lz4_corrupt_data_fails`'s outright-
+    /// garbage-input case, which DOES error.
+    ///
+    /// This test intentionally pins the CURRENT silent-truncation
+    /// behaviour as coverage, not a correctness claim — #2618 (MEDIUM,
+    /// open, separate from this LOW-severity test-coverage issue)
+    /// tracks making this warn/error like the zlib arm already does
+    /// (`decompress_chunk_zlib_short_stream_returns_actual_length`).
+    /// Once #2618 lands, this assertion should flip.
+    #[test]
+    fn decompress_chunk_lz4_undersized_declared_size_currently_truncates_silently() {
+        let actual_payload = b"short lz4 payload, well under the declared size";
+        let compressed = lz4_flex::block::compress(actual_payload);
+
+        // Declare an unpacked_size far larger than what the block
+        // actually decompresses to.
+        let result = decompress_chunk(
+            &compressed,
+            actual_payload.len() + 500,
+            Ba2Compression::Lz4Block,
+        )
+        .expect("current behaviour: an over-declared LZ4 unpacked_size does not error (#2618)");
+        assert_eq!(
+            result, actual_payload,
+            "current behaviour: the returned buffer is silently truncated to the block's \
+             real decoded length, not padded/erroring to match the declared unpacked_size"
+        );
     }
 
     /// Regression for #811 (FO4-D2-NEW-01) — a BA2 header with a

--- a/crates/nif/src/blocks/bs_geometry.rs
+++ b/crates/nif/src/blocks/bs_geometry.rs
@@ -104,10 +104,10 @@ impl BSGeometry {
         // boolean — present (1) or absent (0).
         let internal = (av.flags & FLAG_INTERNAL_GEOM_DATA) != 0;
         let mut meshes = Vec::new();
-        for _ in 0..4 {
+        for slot in 0..4u32 {
             let test_byte = stream.read_u8()?;
             if test_byte != 0 {
-                meshes.push(BSGeometryMesh::parse(stream, internal)?);
+                meshes.push(BSGeometryMesh::parse(stream, slot, internal)?);
             }
         }
 
@@ -185,6 +185,15 @@ impl traits::HasShaderRefs for BSGeometry {
 /// inline geometry body.
 #[derive(Debug)]
 pub struct BSGeometryMesh {
+    /// Which of the parent's 4 slot bytes this mesh occupied (0-3),
+    /// captured before `BSGeometry::parse`'s loop counter is discarded.
+    /// `meshes` only contains *present* slots (the `test_byte == 0` ones
+    /// are skipped, not pushed as placeholders), so a slot's position in
+    /// `BSGeometry::meshes` is NOT the same as its authored LOD index
+    /// once any earlier slot is absent or itself a sentinel — a future
+    /// LOD selector needs this to know which level it actually loaded.
+    /// See #2631 / SF2D2-D2-03.
+    pub lod_slot: u32,
     /// Triangle-index byte size hint (always present, regardless of
     /// internal/external).
     pub tri_size: u32,
@@ -213,9 +222,11 @@ pub enum BSGeometryMeshKind {
 }
 
 impl BSGeometryMesh {
-    /// Parse one mesh-LOD slot. `internal` is the parent's
-    /// `flags & 0x200`-derived gate.
-    pub fn parse(stream: &mut NifStream, internal: bool) -> io::Result<Self> {
+    /// Parse one mesh-LOD slot. `slot` is this slot's index (0-3) in the
+    /// parent's 4-byte test-byte array — the caller's own loop counter,
+    /// captured here so it survives the sentinel-slot skip (#2631). `internal`
+    /// is the parent's `flags & 0x200`-derived gate.
+    pub fn parse(stream: &mut NifStream, slot: u32, internal: bool) -> io::Result<Self> {
         let tri_size = stream.read_u32_le()?;
         let num_verts = stream.read_u32_le()?;
         let flags = stream.read_u32_le()?;
@@ -232,6 +243,7 @@ impl BSGeometryMesh {
         };
 
         Ok(Self {
+            lod_slot: slot,
             tri_size,
             num_verts,
             flags,

--- a/crates/nif/src/blocks/dispatch_tests/starfield.rs
+++ b/crates/nif/src/blocks/dispatch_tests/starfield.rs
@@ -127,6 +127,84 @@ fn starfield_bs_geometry_external_mesh_dispatches() {
     );
 }
 
+/// Regression for #2631 / SF2D2-D2-03: `BSGeometry::parse`'s slot loop
+/// used to discard its own loop counter, so `meshes[i]`'s position in
+/// the post-skip Vec silently stood in for the authored LOD index.
+/// Builds a sparse layout — slot 0 ABSENT, slot 1 present, slot 2
+/// ABSENT, slot 3 present — so array position and authored slot index
+/// diverge (`meshes[0]` is array position 0 but authored slot 1;
+/// `meshes[1]` is array position 1 but authored slot 3) and pins that
+/// `BSGeometryMesh::lod_slot` reports the TRUE authored index.
+#[test]
+fn starfield_bs_geometry_lod_slot_survives_absent_earlier_slots() {
+    let header = starfield_header();
+    let mut d = starfield_av_prefix(0); // external-mesh branch
+    for v in [0.0f32, 0.0, 0.0, 1.0] {
+        d.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in [-1.0f32, -1.0, -1.0, 1.0, 1.0, 1.0] {
+        d.extend_from_slice(&v.to_le_bytes());
+    }
+    d.extend_from_slice(&(-1i32).to_le_bytes());
+    d.extend_from_slice(&(-1i32).to_le_bytes());
+    d.extend_from_slice(&(-1i32).to_le_bytes());
+    // Slot 0: absent.
+    d.push(0u8);
+    // Slot 1: present.
+    d.push(1u8);
+    d.extend_from_slice(&11u32.to_le_bytes()); // tri_size
+    d.extend_from_slice(&22u32.to_le_bytes()); // num_verts
+    d.extend_from_slice(&64u32.to_le_bytes()); // flags
+    let name1 = b"slot1.mesh";
+    d.extend_from_slice(&(name1.len() as u32).to_le_bytes());
+    d.extend_from_slice(name1);
+    // Slot 2: absent.
+    d.push(0u8);
+    // Slot 3: present.
+    d.push(1u8);
+    d.extend_from_slice(&33u32.to_le_bytes()); // tri_size
+    d.extend_from_slice(&44u32.to_le_bytes()); // num_verts
+    d.extend_from_slice(&64u32.to_le_bytes()); // flags
+    let name3 = b"slot3.mesh";
+    d.extend_from_slice(&(name3.len() as u32).to_le_bytes());
+    d.extend_from_slice(name3);
+
+    let mut stream = NifStream::new(&d, &header);
+    let block = parse_block("BSGeometry", &mut stream, Some(d.len() as u32))
+        .expect("BSGeometry must dispatch");
+    let geo = block
+        .as_any()
+        .downcast_ref::<bs_geometry::BSGeometry>()
+        .expect("BSGeometry downcast");
+
+    assert_eq!(geo.meshes.len(), 2, "only the 2 present slots are pushed");
+    assert_eq!(
+        geo.meshes[0].lod_slot, 1,
+        "array position 0 must report authored slot 1, not 0"
+    );
+    assert_eq!(
+        geo.meshes[1].lod_slot, 3,
+        "array position 1 must report authored slot 3, not 1"
+    );
+    match &geo.meshes[0].kind {
+        bs_geometry::BSGeometryMeshKind::External { mesh_name } => {
+            assert_eq!(mesh_name, "slot1.mesh")
+        }
+        _ => panic!("expected external mesh kind"),
+    }
+    match &geo.meshes[1].kind {
+        bs_geometry::BSGeometryMeshKind::External { mesh_name } => {
+            assert_eq!(mesh_name, "slot3.mesh")
+        }
+        _ => panic!("expected external mesh kind"),
+    }
+    assert_eq!(
+        stream.position() as usize,
+        d.len(),
+        "BSGeometry must consume the whole block exactly"
+    );
+}
+
 /// Internal-geom-data branch: bit 0x200 of NiAVObject flags switches
 /// the per-mesh slot from external-name to inline `BSGeometryMeshData`.
 /// Build a minimal-version body (`version > 2` early-out) so the test

--- a/crates/nif/src/import/mesh/bs_geometry.rs
+++ b/crates/nif/src/import/mesh/bs_geometry.rs
@@ -25,9 +25,13 @@ pub fn extract_bs_geometry(
     // Try each LOD slot in order; use the first one that yields geometry.
     // Also carry the selected slot's `tri_size`/`num_verts` hints through so
     // they can be cross-checked against the resolved body below (SF2-03 /
-    // #1830) regardless of which stage resolved it.
+    // #1830) regardless of which stage resolved it, plus the slot's own
+    // authored index (#2631 / SF2D2-D2-03) — `meshes[0]`/the first entry
+    // that survives the sentinel-skip below is the first *present and
+    // non-sentinel* slot, not necessarily authored LOD 0.
     let mesh_data_owned: Option<BSGeometryMeshData>;
     let hint: (u32, u32); // (tri_size, num_verts)
+    let resolved_slot: u32;
     let mesh_data: &BSGeometryMeshData = if shape.has_internal_geom_data() {
         // Stage A: inline geometry embedded in the NIF. Iterate every LOD
         // slot — `meshes.first()` was a #982 short-circuit that silently
@@ -37,15 +41,16 @@ pub fn extract_bs_geometry(
         // SF2-02 / #1829: a slot's body can itself be the `scale<=0`
         // sentinel (empty `vertices`/`triangles`) — skip those so a
         // sentinel-first slot order doesn't hide a later populated slot.
-        let (tri_size, num_verts, data) = shape.meshes.iter().find_map(|m| match &m.kind {
+        let (tri_size, num_verts, slot, data) = shape.meshes.iter().find_map(|m| match &m.kind {
             BSGeometryMeshKind::Internal { mesh_data }
                 if !mesh_data.vertices.is_empty() && !mesh_data.triangles.is_empty() =>
             {
-                Some((m.tri_size, m.num_verts, mesh_data.as_ref()))
+                Some((m.tri_size, m.num_verts, m.lod_slot, mesh_data.as_ref()))
             }
             _ => None,
         })?;
         hint = (tri_size, num_verts);
+        resolved_slot = slot;
         data
     } else {
         // Stage B: external `.mesh` companion file. Try each LOD slot until
@@ -77,7 +82,7 @@ pub fn extract_bs_geometry(
                             // sentinel-first slot order doesn't hide a
                             // later populated slot.
                             if !data.vertices.is_empty() && !data.triangles.is_empty() {
-                                found = Some((m.tri_size, m.num_verts, data));
+                                found = Some((m.tri_size, m.num_verts, m.lod_slot, data));
                                 break;
                             }
                             log::debug!(
@@ -100,8 +105,9 @@ pub fn extract_bs_geometry(
                 }
             }
         }
-        let (tri_size, num_verts, data) = found?;
+        let (tri_size, num_verts, slot, data) = found?;
         hint = (tri_size, num_verts);
+        resolved_slot = slot;
         mesh_data_owned = Some(data);
         mesh_data_owned.as_ref().unwrap()
     };
@@ -319,6 +325,7 @@ pub fn extract_bs_geometry(
         flags: shape.av.flags,
         bs_lod_cutoffs: None,
         bs_sub_index: None,
+        bs_geometry_lod_slot: Some(resolved_slot),
         billboard_mode: None,
     })
 }

--- a/crates/nif/src/import/mesh/bs_geometry_sentinel_slot_tests.rs
+++ b/crates/nif/src/import/mesh/bs_geometry_sentinel_slot_tests.rs
@@ -116,6 +116,10 @@ fn stage_a_skips_sentinel_first_internal_slot_and_finds_populated_one() {
         FLAG_INTERNAL_GEOM_DATA,
         vec![
             BSGeometryMesh {
+                // #2631 / SF2D2-D2-03 — deliberately NOT the array position
+                // (0): stands in for an authored slot 1 whose slot-0
+                // sibling had an absent test-byte and was never pushed.
+                lod_slot: 1,
                 tri_size: 0,
                 num_verts: 0,
                 flags: 0,
@@ -124,6 +128,10 @@ fn stage_a_skips_sentinel_first_internal_slot_and_finds_populated_one() {
                 },
             },
             BSGeometryMesh {
+                // Array position 1, but authored slot 3 — proves the
+                // resolved mesh reports the TRUE authored index, not the
+                // post-skip array position (which would be 1 here).
+                lod_slot: 3,
                 tri_size: 0,
                 num_verts: 0,
                 flags: 0,
@@ -139,6 +147,12 @@ fn stage_a_skips_sentinel_first_internal_slot_and_finds_populated_one() {
         .expect("sentinel-first Internal slot order must not drop a later populated slot");
     assert_eq!(mesh.positions.len(), 3);
     assert_eq!(mesh.indices.len(), 3);
+    assert_eq!(
+        mesh.bs_geometry_lod_slot,
+        Some(3),
+        "resolved mesh must report the populated slot's authored index (3), \
+         not its array position (1) in the post-skip `meshes` vec"
+    );
 }
 
 #[test]
@@ -146,6 +160,7 @@ fn stage_a_all_sentinel_internal_slots_returns_none() {
     let shape = bs_geometry_with_meshes(
         FLAG_INTERNAL_GEOM_DATA,
         vec![BSGeometryMesh {
+            lod_slot: 0,
             tri_size: 0,
             num_verts: 0,
             flags: 0,
@@ -238,6 +253,9 @@ fn stage_b_skips_sentinel_first_external_slot_and_finds_populated_one() {
         0, // no FLAG_INTERNAL_GEOM_DATA — Stage B (external)
         vec![
             BSGeometryMesh {
+                // See the Stage-A sibling test above for why this is
+                // deliberately not the array position.
+                lod_slot: 1,
                 tri_size: 0,
                 num_verts: 0,
                 flags: 0,
@@ -246,6 +264,7 @@ fn stage_b_skips_sentinel_first_external_slot_and_finds_populated_one() {
                 },
             },
             BSGeometryMesh {
+                lod_slot: 3,
                 tri_size: 0,
                 num_verts: 0,
                 flags: 0,
@@ -267,6 +286,12 @@ fn stage_b_skips_sentinel_first_external_slot_and_finds_populated_one() {
     .expect("sentinel-first external slot order must not drop a later populated slot");
     assert_eq!(mesh.positions.len(), 3);
     assert_eq!(mesh.indices.len(), 3);
+    assert_eq!(
+        mesh.bs_geometry_lod_slot,
+        Some(3),
+        "resolved mesh must report the populated slot's authored index (3), \
+         not its array position (1) in the post-skip `meshes` vec"
+    );
 }
 
 #[test]
@@ -278,6 +303,7 @@ fn stage_b_all_sentinel_external_slots_returns_none() {
     let shape = bs_geometry_with_meshes(
         0,
         vec![BSGeometryMesh {
+            lod_slot: 0,
             tri_size: 0,
             num_verts: 0,
             flags: 0,

--- a/crates/nif/src/import/mesh/bs_geometry_skin_tests.rs
+++ b/crates/nif/src/import/mesh/bs_geometry_skin_tests.rs
@@ -87,6 +87,7 @@ fn bs_geometry_with_skin(skin_idx: u32) -> BSGeometry {
         shader_property_ref: BlockRef::NULL,
         alpha_property_ref: BlockRef::NULL,
         meshes: vec![BSGeometryMesh {
+            lod_slot: 0,
             tri_size: 0,
             num_verts: 0,
             flags: 0,

--- a/crates/nif/src/import/mesh/bs_geometry_tangent_tests.rs
+++ b/crates/nif/src/import/mesh/bs_geometry_tangent_tests.rs
@@ -185,6 +185,7 @@ fn placeholder_normals_with_uvs_do_not_trigger_tangent_synthesis() {
         shader_property_ref: BlockRef::NULL,
         alpha_property_ref: BlockRef::NULL,
         meshes: vec![BSGeometryMesh {
+            lod_slot: 0,
             tri_size: 3 * std::mem::size_of::<u16>() as u32,
             num_verts: 3,
             flags: 0,
@@ -249,6 +250,7 @@ fn empty_tangents_raw_and_empty_geometry_yields_empty_vec() {
 
 fn make_internal(version: u32) -> BSGeometryMesh {
     BSGeometryMesh {
+        lod_slot: 0,
         tri_size: 0,
         num_verts: 0,
         flags: 0,
@@ -275,6 +277,7 @@ fn make_internal(version: u32) -> BSGeometryMesh {
 
 fn make_external(name: &str) -> BSGeometryMesh {
     BSGeometryMesh {
+        lod_slot: 0,
         tri_size: 0,
         num_verts: 0,
         flags: 0,

--- a/crates/nif/src/import/mesh/bs_tri_shape.rs
+++ b/crates/nif/src/import/mesh/bs_tri_shape.rs
@@ -209,6 +209,7 @@ pub fn extract_bs_tri_shape(
             BsTriShapeKind::SubIndex(data) => Some((**data).clone()),
             _ => None,
         },
+        bs_geometry_lod_slot: None,
         billboard_mode: None,
     })
 }

--- a/crates/nif/src/import/mesh/ni_tri_shape.rs
+++ b/crates/nif/src/import/mesh/ni_tri_shape.rs
@@ -204,6 +204,7 @@ pub fn extract_mesh(
         flags: shape.av.flags,
         bs_lod_cutoffs: None,
         bs_sub_index: None,
+        bs_geometry_lod_slot: None,
         billboard_mode: None,
     })
 }

--- a/crates/nif/src/import/mesh/tangent.rs
+++ b/crates/nif/src/import/mesh/tangent.rs
@@ -441,7 +441,16 @@ pub fn synthesize_tangents_yup(
 
     let mut out = Vec::with_capacity(n);
     for i in 0..n {
-        let n_yup = normals_yup[i];
+        // #2632 / SF2D2-D2-04 — `normals_yup` is unit-length only to
+        // quantization for a UDEC3-decoded source (Starfield BSGeometry's
+        // `unpack_udec3_xyzw` performs no normalization); the Gram-Schmidt
+        // projection below (and the degenerate branch's permutation +
+        // cross product) is only correct for `|n| == 1`. Normalize the
+        // local copy once here rather than requiring every caller to
+        // pre-normalize — cheap, and a no-op for already-unit input
+        // (SSE-reconstructed BSTriShape normals).
+        let mut n_yup = normals_yup[i];
+        normalize_inplace(&mut n_yup);
         let tangent_in = tan_u[i];
         let bitangent_in = tan_v[i];
 
@@ -459,7 +468,23 @@ pub fn synthesize_tangents_yup(
                 // divergence (AUDIT_INCREMENTAL_2026-05-22 ID-4); both are
                 // acceptable since the degenerate case has no canonical
                 // tangent and any orthogonal-to-N direction is correct.
-                let t_y = [n_yup[1], n_yup[2], n_yup[0]];
+                //
+                // #2632 / SF2D2-D2-04 — a raw cyclic permutation of N's
+                // components is NOT generally orthogonal to N (e.g. any N
+                // with all-equal components permutes to itself), so
+                // `cross(N, t_y)` on the raw permutation could yield a
+                // non-orthogonal-to-N, non-unit bitangent. Gram-Schmidt
+                // the permuted vector against N and normalize before the
+                // cross product, matching the non-degenerate branch below.
+                let t_y_raw = [n_yup[1], n_yup[2], n_yup[0]];
+                let dot_nt =
+                    n_yup[0] * t_y_raw[0] + n_yup[1] * t_y_raw[1] + n_yup[2] * t_y_raw[2];
+                let mut t_y = [
+                    t_y_raw[0] - n_yup[0] * dot_nt,
+                    t_y_raw[1] - n_yup[1] * dot_nt,
+                    t_y_raw[2] - n_yup[2] * dot_nt,
+                ];
+                normalize_inplace(&mut t_y);
                 let b_y = [
                     n_yup[1] * t_y[2] - n_yup[2] * t_y[1],
                     n_yup[2] * t_y[0] - n_yup[0] * t_y[2],

--- a/crates/nif/src/import/mesh/tangent_convention_tests.rs
+++ b/crates/nif/src/import/mesh/tangent_convention_tests.rs
@@ -224,6 +224,63 @@ fn synthesize_tangents_yup_rejects_mismatched_inputs() {
     assert!(synthesize_tangents_yup(&positions, &normals, &uvs, &triangles).is_empty());
 }
 
+/// #2632 / SF2D2-D2-04 — the degenerate fallback (permute-N-components)
+/// branch must produce a UNIT tangent that is ORTHOGONAL to N, even when
+/// the input normal is non-unit-length (as a UDEC3-decoded Starfield
+/// `BSGeometry` normal is, to quantization) and not axis-aligned (so the
+/// permutation isn't already trivially orthogonal to N — this exercises
+/// the real Gram-Schmidt projection, not a no-op).
+///
+/// Degenerate branch trigger: every vertex shares the identical UV, so
+/// the per-triangle `sdir`/`tdir` UV-derivative accumulators are exactly
+/// zero for every vertex (`vec3_is_zero` fires), regardless of vertex
+/// positions.
+#[test]
+fn synthesize_tangents_yup_degenerate_fallback_normalizes_and_orthogonalizes_against_n() {
+    let positions: Vec<[f32; 3]> = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.3]];
+    // Non-unit (magnitude 5) and NOT axis-aligned, so a raw cyclic
+    // permutation of its components is not already orthogonal to it —
+    // pre-fix this would leave the tangent both non-unit AND
+    // non-orthogonal to N.
+    let raw_normal = [0.0f32, 4.0, 3.0];
+    let normals: Vec<[f32; 3]> = vec![raw_normal; 3];
+    // Identical UVs on every vertex → zero UV-derivative accumulation →
+    // every vertex takes the degenerate fallback branch.
+    let uvs = vec![[0.5, 0.5]; 3];
+    let triangles = vec![[0u16, 1u16, 2u16]];
+
+    let out = synthesize_tangents_yup(&positions, &normals, &uvs, &triangles);
+    assert_eq!(out.len(), 3);
+
+    // The same normalization the function must apply internally, computed
+    // independently here for the orthogonality check below.
+    let len = (raw_normal[0] * raw_normal[0]
+        + raw_normal[1] * raw_normal[1]
+        + raw_normal[2] * raw_normal[2])
+        .sqrt();
+    let n_unit = [raw_normal[0] / len, raw_normal[1] / len, raw_normal[2] / len];
+
+    for (i, t) in out.iter().enumerate() {
+        let tangent = [t[0], t[1], t[2]];
+        let mag2 = tangent[0] * tangent[0] + tangent[1] * tangent[1] + tangent[2] * tangent[2];
+        assert!(
+            (mag2 - 1.0).abs() < 1e-5,
+            "vertex {i} degenerate-fallback tangent must be unit length, got |T|^2={mag2}"
+        );
+        let dot_nt = n_unit[0] * tangent[0] + n_unit[1] * tangent[1] + n_unit[2] * tangent[2];
+        assert!(
+            dot_nt.abs() < 1e-5,
+            "vertex {i} degenerate-fallback tangent must be orthogonal to (normalized) N, \
+             got dot(N, T)={dot_nt}"
+        );
+        assert!(
+            (t[3].abs() - 1.0).abs() < 1e-5,
+            "vertex {i} bitangent_sign must be exactly +-1, got {}",
+            t[3]
+        );
+    }
+}
+
 #[test]
 fn synthesize_tangents_yup_empty_inputs_return_empty() {
     let empty_positions: Vec<[f32; 3]> = Vec::new();

--- a/crates/nif/src/import/types.rs
+++ b/crates/nif/src/import/types.rs
@@ -671,6 +671,17 @@ pub struct ImportedMesh {
     /// (deferred) has nothing to consume. `None` on every non-SubIndex
     /// BSTriShape and every NiTriShape / BSGeometry.
     pub bs_sub_index: Option<BsSubIndexTriShapeData>,
+    /// #2631 / SF2D2-D2-03 — which of the source `BSGeometry`'s 4 LOD
+    /// slots (0-3) this mesh was resolved from. `BSGeometry::meshes` only
+    /// contains *present* slots (absent test-byte slots are skipped, not
+    /// pushed as placeholders) and the importer additionally skips
+    /// `scale<=0` sentinel slots when picking the first populated one
+    /// (#1828/#1829), so `meshes[0]`/the resolved slot is the first
+    /// *present and non-sentinel* slot, not necessarily authored LOD 0.
+    /// Threaded through so a future LOD selector knows which level it
+    /// actually loaded. `None` on every non-`BSGeometry` mesh (the
+    /// concept doesn't exist for `NiTriShape`/`BSTriShape`).
+    pub bs_geometry_lod_slot: Option<u32>,
     /// #2206 / NIFAL-D4-02 — nearest-ancestor `NiBillboardNode` mode, set
     /// by `walk_node_flat` when this mesh sits anywhere beneath one.
     /// `ImportedNode::billboard_mode` (above) carries the same data on the
@@ -735,6 +746,7 @@ impl ImportedMesh {
             flags: 0,
             bs_lod_cutoffs: None,
             bs_sub_index: None,
+            bs_geometry_lod_slot: None,
             billboard_mode: None,
         }
     }

--- a/crates/spt/src/import/mod.rs
+++ b/crates/spt/src/import/mod.rs
@@ -317,6 +317,7 @@ fn placeholder_billboard_mesh(
         flags: 0,
         bs_lod_cutoffs: None,
         bs_sub_index: None,
+        bs_geometry_lod_slot: None,
         // Billboard mode for the .spt placeholder rides on the sibling
         // `ImportedNode` root (`CachedNifImport::placement_root_billboard`,
         // #994) — this is a different, per-mesh mechanism (#2206) for the


### PR DESCRIPTION
Four LOW-severity Starfield-audit findings across `byroredux-bsa` and `byroredux-nif`:

- **#2629** (SF-D1-04): `log_v2_v3_extra_bytes` documented the Starfield v2/v3 trailing 8 bytes as a "compressed name-table size" field, but all 129 sampled vanilla archives are byte-identical here — a constant tag, not a size. Renamed to `unknown_1`/`unknown_2`, dropped the dead malformed-header heuristic built on the wrong reading, replaced with a plain deviation check against the observed constant.
- **#2630** (SF-D1-05): added the three test-coverage gaps called out — a byte-literal v3+zlib GNRL header fixture (annotated against the module's own documented layout, not generated through any parser/writer helper) that opens/extracts/round-trips, and an LZ4 "under-run" test pinning the current silent-truncation behavior (per #2618's measurement — actually fixing that is #2618's separate issue, not this one).
- **#2631** (SF2D2-D2-03): `BSGeometry::parse`'s 4-slot loop discarded its own loop counter, so a mesh's position in the post-skip `meshes` Vec silently stood in for its authored LOD index — wrong once an earlier slot is absent or the importer's own sentinel-slot skip passes over one. Added `BSGeometryMesh::lod_slot`, threaded through to a new `ImportedMesh::bs_geometry_lod_slot`. New parse-level dispatch test with a sparse (absent/present/absent/present) slot layout proves it tracks the true index; existing sentinel-slot tests extended to assert the same at the `ImportedMesh` boundary.
- **#2632** (SF2D2-D2-04): `synthesize_tangents_yup`'s Gram-Schmidt (and its degenerate permute-N fallback) assumed a unit-length input normal, but a Starfield `BSGeometry` normal decoded via `unpack_udec3_xyzw` is unit-length only to 10-bit quantization. Normalized the per-vertex normal once inside the function (covers every caller) and fixed the degenerate fallback to properly project+normalize before the cross product. New property-based test with a non-unit, non-axis-aligned normal asserts the fallback tangent is unit-length and orthogonal to N.

`cargo test -q -p byroredux-bsa` and `-p byroredux-nif` pass clean; full workspace `cargo test -q` passes (80/80 test groups, 0 failed).