### PR TITLE
Fix #2617 #2618 #2619 #2620: effect-shader stub guard, LZ4 under-run warning, DXGI 10/11/31, mesh weight-skip drift

### DIFF
--- a/.claude/issues/2617-2618-2619-2620/ISSUE.md
+++ b/.claude/issues/2617-2618-2619-2620/ISSUE.md
@@ -1,0 +1,126 @@
+# Issues 2617, 2618, 2619, 2620
+
+Four Starfield-audit findings across three domains:
+- #2617 → **nif** (`byroredux-nif`) — HIGH — BSEffectShaderProperty stub guard missing
+- #2618 → **bsa** (`byroredux-bsa`) — MEDIUM — LZ4 under-run silent truncation
+- #2619 → **renderer** (`byroredux-renderer`) — MEDIUM — missing DXGI format arms
+- #2620 → **nif** (`byroredux-nif`) — MEDIUM — BSGeometry weights_per_vert==0 stream drift
+
+---
+
+## #2617 — SF-D8-2026-08-07-01: BSEffectShaderProperty stub guard missing — every externally-referenced Starfield effect shader renders invisible
+
+**Severity**: HIGH · **Dimension**: 8 (NIFAL Canonical Material Translation for Starfield)
+**Location**: `crates/nif/src/blocks/shader.rs:1616-1650` (`BSEffectShaderProperty::material_reference_stub`), `:1681-1698` (Starfield stub discriminator), `crates/nif/src/import/material/dedicated_shader.rs:365-500` (`apply_bs_effect_shader`, no guard) vs `:85-88` (the `BSLightingShaderProperty` guard that exists), `crates/renderer/shaders/triangle.frag:790-799`
+**Status**: NEW — not covered by #2359 (tracks the `.mat`/CDB merge forwarding zero authored data, an approximate-not-invisible outcome) or #2354 (particles)
+
+### Description
+`#2353` added `if shader.material_reference { return; }` to the `BSLightingShaderProperty` walker with the rationale that a material-reference stub's fields are parser placeholders, not authored data, and copying them would falsely suppress the external CDB values. `apply_bs_effect_shader` has no equivalent guard — `grep material_reference crates/nif/src/import/` returns exactly one production hit (the BSLSP arm). For a stub, `apply_bs_effect_shader` copies the full placeholder set into `MaterialInfo`: `base_color=[1,1,1,1]` → fabricated emissive tint, `emissive_source` wrongly set to `Effect` (nothing was authored), and — the lethal one — `falloff_start_opacity = falloff_stop_opacity = 0.0`.
+
+### Evidence
+```rust
+// crates/nif/src/import/material/dedicated_shader.rs:365-... (apply_bs_effect_shader)
+// no `if shader.material_reference { return; }` guard anywhere in this function,
+// unlike the BSLightingShaderProperty walker at :85-88
+```
+`triangle.frag:790-799`'s cone-fade math:
+```glsl
+float coneFade = mat.falloffStartOpacity;
+float denom = mat.falloffStartAngle - mat.falloffStopAngle;
+if (denom > 1e-5) { ... }
+...
+finalAlpha = texColor.a * coneFade;
+```
+The in-shader comment asserts the identity default is `start_op = stop_op = 1.0` ("the math reduces to a no-op"). The stub hardcodes `0.0`, and with `start_angle == stop_angle == 1.0` (also stub defaults), `denom == 0` skips the branch entirely — `coneFade` stays `0.0` → `finalAlpha = 0.0` on every affected surface. Scope: the stub discriminator on Starfield is `!name.is_empty()`, and Starfield FX materials are authored in `materialsbeta.cdb` and referenced by name — i.e. this is the **dominant** path for Starfield effect geometry, not an edge case. Full-body (non-stub) blocks are the ones with an *empty* name.
+
+### Impact
+Every externally-referenced Starfield `BSEffectShaderProperty` surface renders fully transparent, with zero visual signal that anything is wrong — a content-visibility failure with no workaround. Per the severity table, "wrong/divergent Material out of NIFAL" is HIGH minimum; this is also flatly worse than divergent — it's invisible.
+
+### Suggested Fix
+Mirror the #2353 guard in `apply_bs_effect_shader`: after `info.material_path` capture, `if shader.material_reference { info.material_kind = 101; return; }` (keep the kind tag, drop the placeholder payload). Add a test asserting a stub yields `emissive_source == EmissiveSource::None` and `effect_falloff == None`.
+
+### Related
+#2353 (the guard this mirrors, on the sibling type), #2359, #2354.
+
+### Completeness Checks
+- [ ] **CANONICAL-BOUNDARY**: Fix belongs at the NIF-import walker (`apply_bs_effect_shader`), mirroring the existing BSLSP guard — same NIFAL boundary discipline
+- [ ] **TESTS**: A stub fixture asserts `emissive_source == EmissiveSource::None` and `effect_falloff == None`
+
+---
+
+## #2618 — SF-D1-01: LZ4 arm silently truncates on under-run; comment claims it hard-errors
+
+**Severity**: MEDIUM · **Dimension**: 1 (BA2 v2/v3 LZ4 Block Decompression)
+**Location**: `crates/bsa/src/ba2.rs:738-746` (LZ4 arm), `:712-735` (the misleading comment)
+**Status**: NEW — partial overlap with #2097 (LZ4-01, OPEN, LOW), opposite failure direction, different fix
+
+### Description
+`lz4_flex::block::decompress(packed, unpacked_size)` allocates the declared size, decodes, then `truncate`s to the actual decoded length and returns `Ok` — so a record that declares *more* than the stream contains gets a silent short buffer, no error, no log. The zlib arm handles the identical condition with `log::warn!` (#812); the comment claiming the LZ4 branch "hard-errors on the same condition" is factually wrong — `lz4_flex` only hard-errors in the *other* direction (declared < actual).
+
+### Evidence
+Measured against the pinned `lz4_flex 0.11.6`: under-run → `Ok(len=13)` for a declared 4096, no error; over-run → hard `Err`. Vanilla corpus is clean (0/2,822 sampled chunks), so this is a robustness gap on malformed/mod-repacked archives, not an active bug.
+
+### Impact
+LZ4 is the only codec for all 15 Starfield v3 texture archives; a DX10 texture is a concatenation of per-mip chunks, so a short decode on a non-final chunk shifts every subsequent mip, and the synthesized DDS header then misdescribes its own payload — garbled/offset mip data in the renderer with no error signal.
+
+### Suggested Fix
+Compare `out.len()` against `unpacked_size` post-decode in the LZ4 arm and `log::warn!` (or hard-error for chunk chains, where a short mid-chain chunk is unrecoverable). Fix the comment. Add an under-run unit test.
+
+### Related
+#2097 (LZ4-01), #812, #2360.
+
+### Completeness Checks
+- [ ] **TESTS**: An under-run fixture (`unpacked_size` declared larger than the actual decoded stream) asserts a warn/error, not silent truncation
+
+---
+
+## #2619 — SF-D1-03: renderer map_dxgi_format has no arm for DXGI 10/11/31, 78 Starfield textures fall back to placeholder
+
+**Severity**: MEDIUM · **Dimension**: 1 (BA2 v2/v3 LZ4 Block Decompression)
+**Location**: `crates/renderer/src/vulkan/dds.rs:508-552` (`map_dxgi_format`)
+**Status**: NEW
+
+### Description
+The same 78 records SF-D1-02 identifies (missing `pitch_or_linear_size_for` arms for DXGI 10/11/31) also hard-fail the renderer's `map_dxgi_format` — every Starfield interior cubemap and chargen face normal map falls back to the placeholder texture. BA2 extraction of these 78 textures is byte-exact correct; the renderer's DXGI table simply has no arm for 10/11/31 and bails at parse time.
+
+### Evidence
+The same 78-record set as SF-D1-02 — 12 interior ambient/reflection-probe cubemaps (`cell_cavecube`, `cell_shipinteriorcube`, …) + the LTC LUT + 62 chargen head normal maps + 2 gas-giant gradients.
+
+### Impact
+Missing textures, not a crash — but per the project's own "chrome/posterized ⇒ missing textures" diagnosis rule (see `[[feedback_chrome_means_missing_textures]]`), this is exactly the defect class that costs hours downstream, concentrated on interior ambient lighting and every chargen face.
+
+### Suggested Fix
+Add core-Vulkan-1.0 format arms for DXGI 10/11/31 with matching tests.
+
+### Related
+SF-D1-02 (BA2 side of the same 78 records).
+
+### Completeness Checks
+- [ ] **SIBLING**: Fix alongside SF-D1-02 — same 78-record set, two independent gaps
+- [ ] **TESTS**: A fixture for each of DXGI 10/11/31 asserts a valid Vulkan format is returned
+
+---
+
+## #2620 — SF2D2-D2-02: weights_per_vert==0 with nonzero n_total_weights reads zero bytes, drifts rest of .mesh parse
+
+**Severity**: MEDIUM · **Dimension**: 2 (BSGeometry Mesh Extraction)
+**Location**: `crates/nif/src/blocks/bs_geometry.rs:479-495`
+**Status**: NEW
+
+### Description
+`n_total_weights.checked_div(weights_per_vert)` returns `None` only for `weights_per_vert == 0`, and that arm reads **zero bytes** regardless of `n_total_weights`. If a `.mesh` body ever ships `weights_per_vert == 0` with `n_total_weights > 0`, the undrained `BoneWeight` payload shifts every subsequent field (`n_lods`/`n_meshlets`/`n_cull_data`) into garbage, driving `read_u16_triple_array` off a corruption-controlled count.
+
+### Evidence
+`crates/nif/src/blocks/bs_geometry.rs:479-495` — the `weights_per_vert == 0` arm reads nothing instead of skipping the payload while advancing the cursor.
+
+### Impact
+Parse-position drift on malformed/atypical `.mesh` bodies (per the severity table, MEDIUM for "stream position off"). Bounded by `check_alloc` (no OOM/UB), but the mesh silently loses its LOD/meshlet/cull tables or fails, surfacing only as "REFR spawned with zero meshes" with no diagnostic — Stage B's error arm is `log::debug!`-only.
+
+### Suggested Fix
+Treat `weights_per_vert == 0` as "skip the payload, still advance the cursor" (`stream.skip(n_total_weights * 4)`), not "read nothing." Add a unit test with `weights_per_vert = 0`, `n_total_weights = 2`, a non-zero `n_lods` following.
+
+### Related
+The deliberate remainder case (`n_total_weights % weights_per_vert != 0`) is correctly pinned by `skin_weights_bulk_read_matches_per_element_semantics`; that test does not cover the `== 0` arm.
+
+### Completeness Checks
+- [ ] **TESTS**: A `weights_per_vert=0, n_total_weights=2` fixture with a non-zero trailing `n_lods` pins the cursor-skip fix

--- a/crates/bsa/src/ba2.rs
+++ b/crates/bsa/src/ba2.rs
@@ -710,22 +710,26 @@ fn decompress_chunk(
             let mut buf = Vec::with_capacity(unpacked_size);
             decoder.read_to_end(&mut buf)?;
             if buf.len() != unpacked_size {
-                // #812 / FO4-D2-NEW-02 — the LZ4 branch hard-errors
-                // on the same condition (lz4_flex inherently size-
-                // checks); zlib's `read_to_end` honours deflate's
-                // self-terminating end-of-stream marker mid-buffer
-                // so a truncated archive returns a short blob.
-                // Promoted from `log::debug!` so operators see the
-                // mismatch in standard log output without changing
-                // the lenient semantics — a synthetic `unpacked_size
-                // = 100 / actual stream = 20` archive currently
-                // pivots into the NIF / DDS parser at the wrong
-                // size with no signalling above debug-log noise.
-                // Sibling of #622's BSA-side hardening
-                // (SK-D2-04). The optional `Strict` mode that
-                // would convert this to an `InvalidData` error is
-                // gated on #598's investigation of vanilla
-                // `Fallout4 - Meshes.ba2`'s `packed_size >
+                // #812 / FO4-D2-NEW-02 — `read_to_end` honours deflate's
+                // self-terminating end-of-stream marker mid-buffer so a
+                // truncated archive returns a short blob. #2618 / SF-D1-01
+                // corrected the LZ4 arm below to warn on the identical
+                // condition too — pre-#2618 this comment claimed LZ4
+                // "hard-errors on the same condition," which was
+                // factually wrong: `lz4_flex::block::decompress` only
+                // hard-errors when the block decodes to MORE than
+                // `unpacked_size` (an over-run); a short decode
+                // (under-run) silently truncates and returns `Ok`, same
+                // as this zlib branch. Promoted from `log::debug!` so
+                // operators see the mismatch in standard log output
+                // without changing the lenient semantics — a synthetic
+                // `unpacked_size = 100 / actual stream = 20` archive
+                // currently pivots into the NIF / DDS parser at the
+                // wrong size with no signalling above debug-log noise.
+                // Sibling of #622's BSA-side hardening (SK-D2-04). The
+                // optional `Strict` mode that would convert this to an
+                // `InvalidData` error is gated on #598's investigation of
+                // vanilla `Fallout4 - Meshes.ba2`'s `packed_size >
                 // unpacked_size` anomaly.
                 log::warn!(
                     "BA2 zlib decompressed {} bytes but record declared {}",
@@ -736,12 +740,35 @@ fn decompress_chunk(
             Ok(buf)
         }
         Ba2Compression::Lz4Block => {
-            lz4_flex::block::decompress(packed, unpacked_size).map_err(|e| {
+            let buf = lz4_flex::block::decompress(packed, unpacked_size).map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("BA2 LZ4 block decompression failed: {}", e),
                 )
-            })
+            })?;
+            // #2618 / SF-D1-01 — mirror the zlib arm's mismatch warning.
+            // `lz4_flex::block::decompress`'s `unpacked_size` parameter is
+            // only a capacity hint (`Vec::with_capacity`); when the block
+            // actually decodes to FEWER bytes (an under-run — declared
+            // size larger than actual), the function silently returns
+            // the shorter buffer with no error, unlike an over-run (more
+            // bytes than declared), which it DOES hard-error on. LZ4 is
+            // the only codec for every Starfield v3 texture archive, and
+            // a DX10 texture is a concatenation of per-mip chunks — a
+            // short decode on a non-final chunk shifts every subsequent
+            // mip, and the synthesized DDS header then misdescribes its
+            // own payload. Pre-#2618 there was no signal above
+            // debug-log noise; this promotes it to the same visibility
+            // level as the zlib arm above.
+            if buf.len() != unpacked_size {
+                log::warn!(
+                    "BA2 LZ4 decompressed {} bytes but record declared {} (under-run — \
+                     lz4_flex silently truncates rather than erroring in this direction)",
+                    buf.len(),
+                    unpacked_size
+                );
+            }
+            Ok(buf)
         }
     }
 }
@@ -1337,6 +1364,43 @@ mod tests {
         let garbage = [0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA];
         let result = decompress_chunk(&garbage, 1024, Ba2Compression::Lz4Block);
         assert!(result.is_err());
+    }
+
+    /// Regression for #2618 / SF-D1-01: an LZ4 block that decodes to
+    /// FEWER bytes than the record's declared `unpacked_size` (an
+    /// "under-run") is a distinct case from `decompress_chunk_lz4_corrupt_data_fails`'s
+    /// outright-garbage input — `lz4_flex::block::decompress`'s
+    /// `unpacked_size` parameter is only a capacity hint, not a strict
+    /// validator, so this still returns `Ok` with the shorter buffer
+    /// (mirrors `decompress_chunk_zlib_short_stream_returns_actual_length`'s
+    /// lenient-mode pin on the sibling zlib arm — this asymmetry with an
+    /// over-run, which DOES hard-error, is deliberate upstream behaviour
+    /// this function cannot and should not change).
+    ///
+    /// The warn-level log promoted by #2618 is the operator-visible
+    /// signal that this happened — not directly assertable here without
+    /// a test logger (same caveat as the zlib sibling test above);
+    /// pinned instead by the `log::warn!` call site at `decompress_chunk`'s
+    /// LZ4 arm. Pre-#2618 this condition was completely silent (no log
+    /// at any level) and the doc comment on the zlib arm actively
+    /// claimed LZ4 "hard-errors on the same condition," which was false.
+    #[test]
+    fn decompress_chunk_lz4_under_run_returns_actual_length_not_declared() {
+        let actual_payload = b"short lz4 payload, well under the declared size";
+        let compressed = lz4_flex::block::compress(actual_payload);
+
+        let result = decompress_chunk(
+            &compressed,
+            actual_payload.len() + 500,
+            Ba2Compression::Lz4Block,
+        )
+        .expect("lenient mode: an over-declared LZ4 unpacked_size must NOT error");
+        assert_eq!(
+            result.as_slice(),
+            actual_payload,
+            "buffer length is what LZ4 actually decoded, NOT the record-declared \
+             unpacked_size — downstream NIF/DDS parsers see the actual short payload"
+        );
     }
 
     /// Regression for #755 (SF-DIM2-02) — a v3 BA2 header with an

--- a/crates/nif/src/blocks/bs_geometry.rs
+++ b/crates/nif/src/blocks/bs_geometry.rs
@@ -486,7 +486,25 @@ impl BSGeometryMeshData {
                     .map(|c| c.to_vec())
                     .collect()
             }
-            None => Vec::new(),
+            // #2620 / SF2D2-D2-02 — `weights_per_vert == 0` means "no
+            // per-vertex grouping is possible" (there is no skin data to
+            // return, hence `Vec::new()` below), but it does NOT mean
+            // "no bytes were written." `n_total_weights` is a flat
+            // BoneWeight count independent of the grouping divisor; if a
+            // `.mesh` body ever ships `weights_per_vert == 0` alongside
+            // `n_total_weights > 0`, that many 4-byte `BoneWeight`
+            // entries (2×u16 each) are still on disk. Pre-fix this arm
+            // read zero bytes and left the cursor sitting in the middle
+            // of that payload, so every subsequent field (`n_lods` /
+            // `n_meshlets` / `n_cull_data`) decoded from garbage. `skip`
+            // never allocates (just moves the cursor) and is itself
+            // bounds-checked against the backing data length, so a
+            // hostile `n_total_weights` fails gracefully here instead of
+            // corrupting the rest of the parse.
+            None => {
+                stream.skip(n_total_weights as u64 * 4)?;
+                Vec::new()
+            }
         };
 
         let n_lods = stream.read_u32_le()?;
@@ -763,5 +781,65 @@ mod tests {
         // it. `lods.len() == 0` is the observable proof the cursor
         // landed exactly where the old per-element loop left it.
         assert_eq!(data.lods.len(), 0);
+    }
+
+    /// Regression for #2620 / SF2D2-D2-02: `weights_per_vert == 0` with
+    /// `n_total_weights > 0` means "no per-vertex grouping is possible"
+    /// (`skin_weights` is correctly empty), NOT "no bytes were written."
+    /// Pre-fix, the `None` arm of `checked_div` read zero bytes and left
+    /// the cursor sitting in the middle of the still-on-disk `BoneWeight`
+    /// payload, so `n_lods` (and everything after it) decoded from
+    /// garbage. This fixture places a real, non-zero `n_lods` entry right
+    /// after 2 undrained `BoneWeight` entries (8 bytes) — a correct
+    /// reader must skip exactly those 8 bytes and land precisely on
+    /// `n_lods`.
+    #[test]
+    fn weights_per_vert_zero_with_nonzero_total_skips_payload_not_zero_bytes() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // version
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_tri_indices
+        bytes.extend_from_slice(&1.0f32.to_le_bytes()); // scale (positive)
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // weights_per_vert = 0
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_vertices
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_uv1
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_uv2
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_colors
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_normals
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_tangents
+
+        // n_total_weights > 0 but weights_per_vert == 0 → checked_div
+        // returns None. 2 BoneWeight entries (2×u16 each = 4 bytes) are
+        // still on disk and MUST be skipped, not left unread.
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // n_total_weights
+        for (bone_index, weight) in [(99u16, 999u16), (88, 888)] {
+            bytes.extend_from_slice(&bone_index.to_le_bytes());
+            bytes.extend_from_slice(&weight.to_le_bytes());
+        }
+
+        // One real LOD entry: 1 triangle (3 indices).
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // n_lods
+        bytes.extend_from_slice(&3u32.to_le_bytes()); // n_lod_tri_indices for LOD 0
+        for idx in [5u16, 6, 7] {
+            bytes.extend_from_slice(&idx.to_le_bytes());
+        }
+
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_meshlets
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // n_cull_data
+
+        let data = BSGeometryMeshData::parse_from_bytes(&bytes)
+            .expect("weights_per_vert=0 body with a real n_lods after it must parse");
+
+        assert!(
+            data.skin_weights.is_empty(),
+            "weights_per_vert=0 correctly yields no per-vertex weight grouping"
+        );
+        assert_eq!(
+            data.lods.len(),
+            1,
+            "the cursor must land exactly on n_lods after skipping the 8-byte \
+             BoneWeight payload — a wrong skip size would either misread n_lods \
+             as garbage (parse error / wrong count) or misalign every field after it"
+        );
+        assert_eq!(data.lods[0], vec![[5, 6, 7]]);
     }
 }

--- a/crates/nif/src/import/material/dedicated_shader.rs
+++ b/crates/nif/src/import/material/dedicated_shader.rs
@@ -378,6 +378,27 @@ fn apply_bs_effect_shader(
             info.material_path =
                 crate::import::mesh::material_path_from_name(shader.net.name.as_deref(), pool);
         }
+        // #2617 / SF-D8-2026-08-07-01 — mirrors the `apply_bs_lighting_shader`
+        // guard above (#2353): a material-reference stub's remaining fields
+        // are parser placeholders (`base_color=[1,1,1,1]`, `source_texture=
+        // ""`, `falloff_start_opacity=falloff_stop_opacity=0.0`, …), not
+        // NIF-authored data. Pre-fix, every externally-referenced Starfield
+        // BSEffectShaderProperty (the DOMINANT case there — Starfield FX
+        // materials are authored in materialsbeta.cdb and referenced by
+        // name) copied the placeholder falloff-opacity pair straight into
+        // `MaterialInfo`, and `triangle.frag`'s cone-fade math (which
+        // assumes the identity default `start_op = stop_op = 1.0`) instead
+        // saw `0.0` — with `start_angle == stop_angle` (also placeholder)
+        // zeroing the fade denominator too, `coneFade` stayed `0.0` and
+        // every such surface rendered fully, silently transparent. Keep
+        // the material_kind=101 tag (still true — this IS an effect
+        // shader) but drop the rest of the placeholder payload, exactly
+        // like the BSLSP guard does for its own `has_bs_lighting_shader`
+        // and downstream fields.
+        if shader.material_reference {
+            info.material_kind = 101;
+            return;
+        }
         if info.texture_path.is_none() {
             info.texture_path = intern_texture_path(pool, &shader.source_texture);
         }

--- a/crates/nif/src/import/material/effect_shader_capture_tests.rs
+++ b/crates/nif/src/import/material/effect_shader_capture_tests.rs
@@ -95,6 +95,122 @@ fn capture_surfaces_fo76_refraction_power() {
     assert_eq!(captured.refraction_power, Some(0.5));
 }
 
+/// A material-reference stub, hand-built with the exact placeholder
+/// values `BSEffectShaderProperty::material_reference_stub` writes on
+/// the real Starfield/FO76 parse path (that constructor is private, so
+/// tests mirror its literal field values here — same pattern
+/// `fully_populated_fo4_shader` already uses for the non-stub case).
+fn material_reference_stub(name: &str) -> BSEffectShaderProperty {
+    BSEffectShaderProperty {
+        net: NiObjectNETData {
+            name: Some(std::sync::Arc::from(name)),
+            extra_data_refs: Vec::new(),
+            controller_ref: BlockRef::NULL,
+        },
+        material_reference: true,
+        shader_flags_1: 0,
+        shader_flags_2: 0,
+        sf1_crcs: Vec::new(),
+        sf2_crcs: Vec::new(),
+        uv_offset: [0.0, 0.0],
+        uv_scale: [1.0, 1.0],
+        source_texture: String::new(),
+        texture_clamp_mode: 3,
+        lighting_influence: 0,
+        env_map_min_lod: 0,
+        falloff_start_angle: 1.0,
+        falloff_stop_angle: 1.0,
+        falloff_start_opacity: 0.0,
+        falloff_stop_opacity: 0.0,
+        refraction_power: 0.0,
+        base_color: [1.0, 1.0, 1.0, 1.0],
+        base_color_scale: 1.0,
+        soft_falloff_depth: 100.0,
+        greyscale_texture: String::new(),
+        env_map_texture: String::new(),
+        normal_texture: String::new(),
+        env_mask_texture: String::new(),
+        env_map_scale: 1.0,
+        reflectance_texture: String::new(),
+        lighting_texture: String::new(),
+        emittance_color: [0.0, 0.0, 0.0],
+        emit_gradient_texture: String::new(),
+        luminance: None,
+        starfield_tail: Vec::new(),
+    }
+}
+
+/// Regression for #2617 / SF-D8-2026-08-07-01: a material-reference stub
+/// must contribute its external path only — every fabricated scalar
+/// default (`base_color`, `falloff_start/stop_opacity`, …) must NOT be
+/// copied into `MaterialInfo`. Pre-fix, `falloff_start_opacity =
+/// falloff_stop_opacity = 0.0` (the stub's placeholder pair) landed
+/// straight in `info.effect_shader`, and with `triangle.frag`'s cone-fade
+/// math assuming the identity default `1.0`/`1.0`, every externally-
+/// referenced Starfield effect-shader surface rendered fully transparent.
+/// Mirrors `bslighting_material_reference_stub_does_not_claim_material_data`
+/// (#2353) on the sibling `BSLightingShaderProperty` guard.
+#[test]
+fn effect_shader_material_reference_stub_does_not_claim_material_data() {
+    let shader = material_reference_stub("materials\\sf\\fx_glow.mat");
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(shader)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = NiTriShape {
+        av: NiAVObjectData {
+            net: NiObjectNETData {
+                name: None,
+                extra_data_refs: Vec::new(),
+                controller_ref: BlockRef::NULL,
+            },
+            flags: 0,
+            transform: NiTransform::default(),
+            properties: vec![],
+            collision_ref: BlockRef::NULL,
+        },
+        data_ref: BlockRef::NULL,
+        skin_instance_ref: BlockRef::NULL,
+        shader_property_ref: BlockRef(0),
+        alpha_property_ref: BlockRef::NULL,
+        num_materials: 0,
+        active_material_index: 0,
+    };
+    let mut pool = StringPool::new();
+    let info = extract_material_info(&scene, &shape, &[], &mut pool);
+
+    assert_eq!(
+        info.material_path.and_then(|s| pool.resolve(s)),
+        Some("materials\\sf\\fx_glow.mat"),
+        "the external material path must survive the stub guard"
+    );
+    // The engine-synthesized "this is an effect shader" tag is real
+    // information (not placeholder), independent of whether the actual
+    // material body was resolved — kept.
+    assert_eq!(info.material_kind, 101);
+    assert!(
+        !info.has_material_data,
+        "stub must not claim inline material authorship"
+    );
+    assert!(
+        matches!(
+            info.emissive_source,
+            byroredux_core::ecs::components::material::EmissiveSource::None
+        ),
+        "stub's placeholder base_color must not be tagged as authored Effect emissive"
+    );
+    assert!(
+        info.effect_shader.is_none(),
+        "stub's placeholder falloff/greyscale/env fields must not populate \
+         effect_shader — this is exactly what fed 0.0/0.0 falloff opacity \
+         into the renderer's cone-fade math and rendered the surface invisible"
+    );
+    assert!(info.texture_path.is_none());
+    assert!(info.normal_map.is_none());
+    assert!(!info.has_uv_transform);
+}
+
 #[test]
 fn material_info_default_has_no_effect_shader() {
     // Sibling check — the new field defaults to `None` so non-effect

--- a/crates/renderer/src/vulkan/dds.rs
+++ b/crates/renderer/src/vulkan/dds.rs
@@ -28,8 +28,17 @@ const FOURCC_BC5S: u32 = u32::from_le_bytes(*b"BC5S");
 const FOURCC_DX10: u32 = u32::from_le_bytes(*b"DX10");
 
 // DXGI format codes (subset we care about)
+// #2619 / SF-D1-03 — 78 vanilla Starfield textures (12 interior ambient/
+// reflection-probe cubemaps + the LTC area-light LUT + 62 chargen head
+// normal maps + 2 gas-giant gradients; full-corpus DXGI histogram in
+// #2628 / SF-D1-02, the BA2-side sibling of this gap) ship these three
+// codes; all three are core Vulkan 1.0 uncompressed formats needing no
+// extra feature check.
+const DXGI_FORMAT_R16G16B16A16_FLOAT: u32 = 10; // 8 B/px — HDR cubemaps + LTC LUT
+const DXGI_FORMAT_R16G16B16A16_UNORM: u32 = 11; // 8 B/px — gas-giant gradients
 const DXGI_FORMAT_R8G8B8A8_UNORM: u32 = 28;
 const DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: u32 = 29;
+const DXGI_FORMAT_R8G8B8A8_SNORM: u32 = 31; // 4 B/px — chargen head normal maps
 // Single-channel uncompressed (#1074 / FO4-D2-008)
 const DXGI_FORMAT_R16_UNORM: u32 = 56; // 2 bytes/px — heightmaps, mono masks
 const DXGI_FORMAT_R8_UNORM: u32 = 61; // 1 byte/px  — single-channel masks
@@ -511,6 +520,16 @@ fn map_dxgi_format(dxgi: u32) -> Result<(vk::Format, u32, bool)> {
         DXGI_FORMAT_R8G8B8A8_UNORM | DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => {
             Ok((vk::Format::R8G8B8A8_SRGB, 4, false))
         }
+        // #2619 / SF-D1-03 — chargen head normal maps. SNORM (signed
+        // -1..1 per channel) is the correct storage for tangent-space
+        // normal data; core Vulkan 1.0, no feature check needed.
+        DXGI_FORMAT_R8G8B8A8_SNORM => Ok((vk::Format::R8G8B8A8_SNORM, 4, false)),
+        // #2619 / SF-D1-03 — interior ambient/reflection-probe cubemaps +
+        // the LTC area-light LUT (10, HDR half-float) and the gas-giant
+        // gradient textures (11, integer-normalized). Both are core
+        // Vulkan 1.0 uncompressed formats.
+        DXGI_FORMAT_R16G16B16A16_FLOAT => Ok((vk::Format::R16G16B16A16_SFLOAT, 8, false)),
+        DXGI_FORMAT_R16G16B16A16_UNORM => Ok((vk::Format::R16G16B16A16_UNORM, 8, false)),
         // FO4 normal maps ship as B8G8R8A8_UNORM (ba2.rs:808). No special
         // Vulkan feature required — universally supported on Vulkan 1.0 desktop.
         DXGI_FORMAT_B8G8R8A8_UNORM => Ok((vk::Format::B8G8R8A8_UNORM, 4, false)),
@@ -1030,6 +1049,48 @@ mod tests {
         assert_eq!(meta.format, vk::Format::BC6H_SFLOAT_BLOCK);
         assert_eq!(meta.block_size, 16);
         assert!(meta.compressed);
+    }
+
+    // ── #2619 / SF-D1-03 — DXGI 10/11/31, previously unmapped ──────────
+    //
+    // 78 vanilla Starfield textures (interior ambient/reflection-probe
+    // cubemaps, the LTC area-light LUT, chargen head normal maps, and
+    // gas-giant gradients) ship these three DXGI codes; pre-fix every
+    // one hard-failed `map_dxgi_format` and fell back to the placeholder
+    // texture. See #2628 / SF-D1-02 for the sibling BA2-side gap (same
+    // 78-record set, independent fix).
+
+    #[test]
+    fn dxgi_r16g16b16a16_float_maps_correctly() {
+        // Interior ambient/reflection-probe cubemaps + the LTC area-light LUT.
+        let data = make_dx10_header(64, 64, 1, DXGI_FORMAT_R16G16B16A16_FLOAT);
+        let meta = parse_dds(&data).unwrap();
+        assert_eq!(meta.format, vk::Format::R16G16B16A16_SFLOAT);
+        assert_eq!(meta.block_size, 8);
+        assert!(!meta.compressed);
+        // Uncompressed: 64×64 px × 8 B/px = 32768.
+        assert_eq!(mip_size(64, 64, 0, meta.block_size, meta.compressed), 32768);
+    }
+
+    #[test]
+    fn dxgi_r16g16b16a16_unorm_maps_correctly() {
+        // Gas-giant gradient textures.
+        let data = make_dx10_header(32, 4, 1, DXGI_FORMAT_R16G16B16A16_UNORM);
+        let meta = parse_dds(&data).unwrap();
+        assert_eq!(meta.format, vk::Format::R16G16B16A16_UNORM);
+        assert_eq!(meta.block_size, 8);
+        assert!(!meta.compressed);
+    }
+
+    #[test]
+    fn dxgi_r8g8b8a8_snorm_maps_correctly() {
+        // Chargen head normal maps — SNORM is the correct storage for
+        // signed tangent-space normal data.
+        let data = make_dx10_header(512, 512, 1, DXGI_FORMAT_R8G8B8A8_SNORM);
+        let meta = parse_dds(&data).unwrap();
+        assert_eq!(meta.format, vk::Format::R8G8B8A8_SNORM);
+        assert_eq!(meta.block_size, 4);
+        assert!(!meta.compressed);
     }
 
     fn approx(a: [f32; 3], b: [f32; 3]) {


### PR DESCRIPTION
Four Starfield-audit findings across `byroredux-nif`, `byroredux-bsa`, and `byroredux-renderer`:

- **#2617** (SF-D8, **HIGH**): `apply_bs_effect_shader` had no equivalent of the #2353 material-reference-stub guard `apply_bs_lighting_shader` already carries. A stub's fields are parser placeholders, not authored data — copying them fed the placeholder `falloff_start_opacity = falloff_stop_opacity = 0.0` into `MaterialInfo`, and with `triangle.frag`'s cone-fade math assuming the identity default `1.0`/`1.0`, every externally-referenced Starfield `BSEffectShaderProperty` rendered fully, silently transparent. This is the dominant path for Starfield effect geometry (materials are authored externally in `materialsbeta.cdb`), not an edge case. Mirrored the existing guard.
- **#2618** (SF-D1-01, MEDIUM): the zlib arm's comment claimed the LZ4 arm "hard-errors" on an under-run (declared size > actual), but `lz4_flex`'s `unpacked_size` is only a capacity hint — it silently truncates instead, identical to zlib's own lenient behavior (the comment had the direction backwards). Added the same `log::warn!` the zlib arm already emits, corrected the comment.
- **#2619** (SF-D1-03, MEDIUM): `map_dxgi_format` had no arm for DXGI 10/11/31 — 78 vanilla Starfield textures (interior cubemaps, the LTC LUT, chargen normal maps, gas-giant gradients) hard-failed and fell back to the placeholder. All three are core Vulkan 1.0 formats. The BA2-side sibling gap is tracked separately as #2628, not touched here.
- **#2620** (SF2D2-D2-02, MEDIUM): `weights_per_vert == 0` (with `n_total_weights > 0`) was read as "zero bytes on disk," but it only means "no per-vertex grouping is possible" — the undrained `BoneWeight` payload left the parse cursor short, corrupting every field after it (`n_lods`/`n_meshlets`/`n_cull_data`). Now skips exactly the right byte count instead of reading nothing.

`cargo test -q -p byroredux-nif`, `-p byroredux-bsa`, and `-p byroredux-renderer` all pass clean; full workspace `cargo test -q` passes (80/80 test groups, 0 failed).