### PR TITLE
Fix #2524 #2525 #2530 #2531: clip-handle leak, NIF bulk-read idiom, loose-load light spawn, skinned Havok proxy

### DIFF
--- a/.claude/issues/2524-2525-2530-2531/ISSUE.md
+++ b/.claude/issues/2524-2525-2530-2531/ISSUE.md
@@ -1,0 +1,147 @@
+# Issues 2524, 2525, 2530, 2531
+
+Four audit findings across two domains:
+- #2524 → **binary** (`byroredux`) — MEDIUM — NifImportRegistry LRU eviction drops freed clip handles in precombined path
+- #2525 → **nif** (`byroredux-nif`) — MEDIUM — 3 sites bypass the bulk-read-then-map idiom
+- #2530 → **binary** (`byroredux`) — HIGH — loose-NIF load path never extracts/spawns lights
+- #2531 → **binary** (`byroredux`) — MEDIUM — packed-Havok proxy unions skinned bind-pose geometry
+
+---
+
+## #2524 — PERF-D3-NEW-01: NifImportRegistry LRU eviction drops freed AnimationClipRegistry handles in the precombined-mesh insert path
+
+**Severity**: MEDIUM · **Dimension**: GPU Memory Pressure & Eviction Thrash
+**Location**: `byroredux/src/cell_loader/precombined.rs:313-316`
+**Status**: NEW (fresh reintroduction of the #863 bug class at a call site added 2026-08-04, `9e5540899` — not a regression of the original fix, whose three original call sites remain correct)
+
+### Description
+`NifImportRegistry::insert` returns `Vec<u32>` — the `AnimationClipRegistry` handles of any entries the 2048-cap LRU sweep evicted as a side effect of this insert — and is marked `#[must_use = "evicted clip handles must be released into AnimationClipRegistry to free their keyframe arrays — see #863"]`. Four of the five production call sites forward the returned handles to `AnimationClipRegistry::release`. The precombined-mesh commit path does not:
+```rust
+// byroredux/src/cell_loader/precombined.rs:313-316
+{
+    let mut reg = world.resource_mut::<NifImportRegistry>();
+    let _freed = reg.insert(path.clone(), parsed.clone());
+}
+```
+Binding the `#[must_use]` return to a named variable (`_freed`, not the bare `_` discard) satisfies both the `must_use` and `unused_variables` lints, so the compiler gives no warning — the exact silent-drop shape #863's original bug had before the `Vec<u32>` contract was added.
+
+### Evidence
+Confirmed directly at `precombined.rs:313-316`. `AnimationClipRegistry::release` is what actually clears a slot's channel collections — skipping it leaves those collections (and their backing allocations) resident indefinitely. The precombine path's own inserted entry never itself owns a clip handle, but the LRU sweep triggered by *this* insert can evict any other cache entry once the registry is at cap (2048 default, or `BYRO_NIF_CACHE_MAX`), including animated NIFs registered via the three correctly-forwarding call sites — whichever victim the sweep picks, if it owned a clip handle, that handle is silently dropped here instead of released.
+
+### Impact
+A slow CPU-RAM leak (not VRAM) — bounded by `AnimationClipRegistry`'s slot count growing without corresponding frees, gated on (a) FO4 precombined-mesh content being loaded (M49), (b) the `NifImportRegistry` LRU cache being at its cap, and (c) the evicted victim happening to be an animated NIF with a registered clip handle. In a long FO4 session that revisits precombine-heavy cells repeatedly, this compounds the same way #863 originally did, just through a narrower door.
+
+### Related
+#863 (original fix, three-of-four-then-correct call sites), #544 (clip_handles map cleanup on eviction).
+
+### Suggested Fix
+Mirror `partial.rs:69`'s pattern — capture the returned `Vec<u32>` as `freed` (not `_freed`), and after the block, if non-empty, forward each handle to `world.resource_mut::<AnimationClipRegistry>().release(h)`.
+
+### Completeness Checks
+- [ ] **TESTS**: A regression test forces an LRU eviction during a precombine-path insert and confirms the evicted entry's clip handle is released
+- [ ] **SIBLING**: All five `NifImportRegistry::insert` call sites forward the returned handles consistently
+
+---
+
+## #2525 — PERF-D8-NEW-02: Three per-element decode loops bypass the crate's own established bulk-read-then-map idiom for half-float/quaternion arrays
+
+**Severity**: MEDIUM · **Dimension**: NIF Parse Performance
+**Location**: `crates/nif/src/blocks/extra_data.rs:377-385` (`BsPositionData::parse`), `crates/nif/src/blocks/node.rs:1080-1088` (`BsDistantObjectInstancedNode::parse`, transforms), `crates/nif/src/blocks/legacy_particle.rs:624-638` (`NiLegacyParticlesData::parse`, rotations)
+**Status**: NEW
+
+### Description
+#1263 (NIF-D5-NEW-03) and #2032 (PERF-D8-01) both established the same fix shape for "array needs a per-element transform the raw bytes don't carry" (half-float decode, byte-swizzle, etc.): bulk-read the raw fixed-width values in one `read_*_array` call, then `.chunks_exact(k).map(transform).collect()`. Three call sites never got the memo and still do `allocate_vec` + a per-element loop of individual `read_u16_le()`/`read_f32_le()` calls: `BsPositionData::parse` (per-vertex half-float blend-factor array, FO4/FO76 cloth/dismemberment), `BsDistantObjectInstancedNode::parse` transforms (`Vec<[f32; 16]>`, 16 individual `read_f32_le()` calls per transform instead of one bulk read + `chunks_exact(16)`), and `NiLegacyParticlesData::parse` rotations (reads `w,x,y,z` and reorders to `[x,y,z,w]` per quaternion, could bulk-read + swizzle in the `.map()`). None of these are per-frame (all are one-time import-side parses, cached after first load), so the impact is bounded CPU overhead on cell-load / streaming-worker latency, not steady-state frame time.
+
+### Evidence
+Confirmed directly at all three locations — each still does a per-element read loop instead of the bulk-read-then-map idiom established at `crates/nif/src/blocks/bs_geometry.rs:410-446`.
+
+### Impact
+Extra per-element call overhead on the NIF-parse critical path for cell load / exterior streaming (a budget-bound path). Scales with vertex/instance count on FO4/FO76 cloth meshes and Starfield distant-object-instancing nodes; bounded by real-world content sizes, so this is a throughput/latency inefficiency rather than a correctness or memory-safety issue. dhat allocation-bound tests can't catch this class (allocation *count* is identical either way — the difference is N extra function-call/bounds-check/cursor-advance round trips instead of one bulk `read_exact`).
+
+### Related
+#1263 (NIF-D5-NEW-03, the original 3-site fix in `bs_geometry.rs`), #2032 (PERF-D8-01, the `BoneWeight` sibling fix in this exact dimension); the `node.rs` transforms site is also cited under PERF-D8-NEW-01 (this session) for its separate allocation-bound issue — fixing the bulk-read shape here does not by itself fix that finding, both changes are complementary.
+
+### Suggested Fix
+Apply the same `read_*_array(count * k)?.chunks_exact(k).map(transform).collect()` shape at all three sites, mirroring `bs_geometry.rs:421-446`. For `node.rs`'s `[f32;16]` case, use `read_f32_array(count * 16)?.chunks_exact(16).map(|c| c.try_into().unwrap())`. Since dhat bounds can't catch this class, propose a wall-clock or read-call-count regression test alongside the fix.
+
+### Completeness Checks
+- [ ] **TESTS**: A wall-clock or read-call-count regression test pins the bulk-read shape at all three sites (dhat allocation-count tests can't catch this class)
+- [ ] **SIBLING**: All three sites converted consistently to the established idiom
+
+---
+
+## #2530 — NIFAL-D3-NEW-01: Loose-NIF load path never extracts or spawns any of a mesh's authored lights
+
+**Severity**: HIGH · **Dimension**: Lights · **Tier Violated**: single-boundary / no-fabrication (the extraction call is *absent* on one of the two production load paths, not a bad translation of present data)
+**Game Affected**: All (Oblivion → Starfield) — every loose-loaded NIF carrying an embedded `NiPointLight` / `NiSpotLight` / `NiAmbientLight` / `NiDirectionalLight`
+**Location**: `byroredux/src/scene/nif_loader.rs` (entire file, 1165 lines — `parse_import_and_merge` / `load_nif_bytes_with_skeleton`)
+**Status**: NEW — `gh issue list` search for "light"/"nif_loader" found only closed `#156`, which added the extraction+spawn path used by the cell loader only, not this one. Not a duplicate.
+
+### Description
+`byroredux_nif::import::import_nif_lights` — the sole function that walks a parsed `NifScene` and produces `Vec<ImportedLight>` — has exactly three call sites in the whole tree: `crates/nif/examples/import_probe.rs:47` (debug example), `byroredux/src/streaming.rs:895` (exterior grid pre-parse), and `byroredux/src/cell_loader/references/import.rs:116` (cell-loader ref import). `byroredux/src/scene/nif_loader.rs` — the module backing `cargo run -- path/to/mesh.nif` (documented in `CLAUDE.md`'s Quick Reference/Usage as a primary invocation, and the cache path behind *all* skeleton/body/hand NPC-part loading) — calls neither `import_nif_lights` nor a light-populating path. `grep -in light byroredux/src/scene/nif_loader.rs` returns zero matches across the full file, and `world.insert(entity, LightSource ...)` never appears in it — the only `LightSource` insertion site in the whole repo is `byroredux/src/cell_loader/spawn.rs:779`, unreachable from the loose loader.
+
+### Evidence
+```
+$ grep -rn "import_nif_lights\b" --include='*.rs' crates/nif byroredux
+crates/nif/src/import/mod.rs:483:pub fn import_nif_lights(scene: &NifScene) -> Vec<ImportedLight>
+crates/nif/examples/import_probe.rs:47:    let lights = byroredux_nif::import::import_nif_lights(&scene);
+byroredux/src/streaming.rs:895:        let lights = byroredux_nif::import::import_nif_lights(&scene);
+byroredux/src/cell_loader/references/import.rs:116:    let lights = byroredux_nif::import::import_nif_lights(&scene);
+
+$ grep -in "light" byroredux/src/scene/nif_loader.rs
+(no output)
+```
+
+### Impact
+A torch, candle, lantern, or streetlamp NIF loaded standalone (`cargo run -- <mesh>.nif`) renders its flame/bulb geometry but contributes zero light to the scene — visible content loss, not cosmetic. Since `load_nif_bytes_with_skeleton`'s cache path backs *every* skeleton/body/hand NPC-part load (not just the standalone entry point, per that function's own doc comment), the blast radius extends to normal cell-loaded NPC rendering wherever NPC-part NIFs carry lights, though the most directly observable case is the documented loose-load workflow.
+
+### Related
+Sibling gap to closed `#156` (which fixed the cell-loader path only). Not a duplicate of any open issue.
+
+### Suggested Fix
+Call `byroredux_nif::import::import_nif_lights(&scene)` in `parse_import_and_merge`, store the result on the loader's cache-entry struct, and add a light-spawn loop in `load_nif_bytes_with_skeleton` mirroring `cell_loader/spawn.rs::spawn_nif_lights` — widen `is_spawnable_nif_light`/`light_radius_or_default` to `pub(crate)`-shared (they already are `pub(crate)` in `spawn.rs`) or lift them to a shared helper rather than re-deriving the sanitization logic a third time.
+
+### Completeness Checks
+- [ ] **CANONICAL-BOUNDARY**: The loose-loader's light spawn goes through the same `LightSource` construction shape as the cell-loader path, not a fourth divergent one
+- [ ] **TESTS**: A regression test loads a standalone NIF with an embedded light and confirms a `LightSource` entity spawns
+
+---
+
+## #2531 — NIFAL-D6-NEW-01: synthesize_packed_havok_proxy unions skinned-mesh bind-pose geometry into the compatibility AABB, unlike its Architecture-trimesh sibling
+
+**Severity**: MEDIUM · **Dimension**: Collision · **Tier Violated**: NIFAL translate boundary (canonical-fallback tier — the compatibility-proxy consumer introduced this cycle by `716b7ee9`/`8ee151e0`, not the raw/translate tiers proper)
+**Game Affected**: FO4 / FO76 / Starfield — any `RenderLayer::Actor` (CREA — creature) or `RenderLayer::Clutter` placement with packed (`BhkNPCollisionObject`) collision authoring and a skinned render mesh
+**Location**: `byroredux/src/cell_loader/spawn.rs:118-135` (`synthesize_packed_havok_proxy`'s mesh filter), contrasted with `byroredux/src/cell_loader/spawn.rs:1680-1687` (the sibling `ArchitectureTriMesh` gate, which requires `mesh.skin.is_none()`)
+**Status**: NEW — brand-new code path (landed `8ee151e0`, this delta window). Not a duplicate; sibling of the same-cycle-fixed `#2355` (that issue was "no proxy at all" for Clutter/Actor; this is "proxy built from the wrong pose data" once the sibling fix landed).
+
+### Description
+The Architecture trimesh fallback (`synthesize_static_trimesh`) explicitly excludes skinned meshes (`mesh.skin.is_none()`, "never synthesize for animated bodies"). `synthesize_packed_havok_proxy` has no equivalent check:
+```rust
+let geometry = meshes
+    .iter()
+    .filter(|mesh| {
+        !mesh.material.is_decal
+            && !mesh.material.alpha_test
+            && mesh.material.material_kind
+                != byroredux_renderer::MATERIAL_KIND_FIRE_REFRACTION
+            && !mesh.positions.is_empty()
+    })
+    .map(|mesh| ProxyMeshGeometry { positions: &mesh.positions, ... });
+```
+`mesh.positions` on a skinned `ImportedMesh` is bind-pose (T-pose/rest-pose) local geometry — the same array GPU skinning deforms at render time, not a runtime-posed shape. Creature (CREA) REFRs on FO4+/FO76/Starfield reach `spawn_placed_instances` through the generic REFR path (`npcs: &HashMap<u32, NpcRecord>` is keyed by NPC_ only — CREA is absent, so it falls through to `spawn_synth_child` → `spawn_placed_instances` with `base_layer = RenderLayer::Actor`), so a creature whose model is a skinned mesh and whose NIF authors only packed Havok gets its collision cuboid built from bind-pose vertex positions.
+
+### Evidence
+No test in either commit constructs an `ImportedMesh` with `skin: Some(...)` through this path — both new tests (`packed_proxy_bakes_outer_scale_into_cuboid_extent`, `packed_proxy_is_keyframed_and_parented_to_visual_placement`) use `ImportedMesh::from_geometry(...)`, which defaults `skin: None`. The gap is untested as well as unguarded.
+
+### Impact
+A bind-pose T-pose skeleton for many creature/character rigs has limbs splayed far wider than the resting silhouette, so the resulting `Cuboid` half-extents can be substantially oversized relative to the creature's visible footprint — an invisible collision block extending well beyond the rendered model, obstructing movement in open space around the creature. The proxy is `Keyframed` and parented to `placement_root` (not any bone), so it never reflects animated posture — the mis-sizing is permanent for the creature's lifetime, not a spawn-frame transient. Scoped to skinned creature/actor content on FO4+/FO76/Starfield, exactly the population most likely to lack decoded classic collision.
+
+### Related
+Sibling of fixed `#2355`.
+
+### Suggested Fix
+Either (a) add a `mesh.skin.is_none()` filter to the closure, matching the Architecture precedent, and fall back to each mesh's already-computed `local_bound_center`/`local_bound_radius` (pose-independent, mesh-local) for skinned submeshes instead of dropping the creature to "unresolved"; or (b) use the authored `local_bound_center`/`local_bound_radius` directly for skinned submeshes rather than raw bind-pose vertex positions — preserves the "conservative coarse box" intent without trusting bind-pose extremities as representative.
+
+### Completeness Checks
+- [ ] **TESTS**: A regression test constructs an `ImportedMesh` with `skin: Some(...)` through `synthesize_packed_havok_proxy` and confirms it either falls back to the local bound or is excluded
+- [ ] **CANONICAL-BOUNDARY**: The fallback fix stays a spawn-time decision (per-REFR, once), not re-derived per-draw

--- a/byroredux/src/cell_loader.rs
+++ b/byroredux/src/cell_loader.rs
@@ -70,7 +70,7 @@ mod placement_lod;
 pub(crate) mod precombined;
 pub(crate) mod references;
 mod refr;
-mod spawn;
+pub(crate) mod spawn;
 mod terrain;
 mod terrain_lod;
 mod terrain_lod_btr;
@@ -134,7 +134,7 @@ pub(crate) use work_budget::FrameTimeBudget;
 pub(crate) use load::{register_cell_root, stamp_cell_root, stamp_cell_root_range};
 #[cfg(test)]
 pub(crate) use spawn::{
-    count_spawnable_nif_lights, is_spawnable_nif_light, light_radius_or_default,
+    count_spawnable_nif_lights, is_spawnable_nif_light, light_radius_or_default, spawn_nif_lights,
 };
 #[cfg(test)]
 pub(crate) use unload::collect_victim_gpu_handles;
@@ -475,6 +475,8 @@ mod nif_light_spawn_gate_tests;
 mod pkin_expansion_tests;
 #[cfg(test)]
 mod placement_root_subtree_tests;
+#[cfg(test)]
+mod precombined_clip_handle_tests;
 #[cfg(test)]
 mod rapier_release_tests;
 #[cfg(test)]

--- a/byroredux/src/cell_loader/nif_light_spawn_gate_tests.rs
+++ b/byroredux/src/cell_loader/nif_light_spawn_gate_tests.rs
@@ -28,6 +28,68 @@ fn light_with_color(rgb: [f32; 3]) -> ImportedLight {
     }
 }
 
+/// Regression for #2530 / NIFAL-D3-NEW-01: `spawn_nif_lights` (widened
+/// to `pub(crate)` so `scene::nif_loader::load_nif_bytes_with_skeleton`
+/// — the loose-NIF / NPC-part load path — can call the exact same
+/// construction the cell loader uses) must spawn a real `LightSource`
+/// entity for a spawnable authored light. `spawn_nif_lights` takes no
+/// `VulkanContext`, so this exercises the full parse-to-ECS contract
+/// without standing up a GPU device — the one piece of #2530's fix that
+/// `load_nif_bytes_with_skeleton` itself can't be unit-tested through
+/// (mesh GPU upload requires a real Vulkan device).
+#[test]
+fn spawn_nif_lights_attaches_light_source_for_spawnable_light() {
+    let mut world = World::new();
+    let lights = vec![ImportedLight {
+        translation: [10.0, 20.0, 30.0],
+        direction: [0.0, 0.0, -1.0],
+        color: [0.8, 0.2, 0.1],
+        radius: 512.0,
+        kind: LightKind::Point,
+        outer_angle: 0.0,
+        affected_node_names: Vec::new(),
+        name: None,
+    }];
+
+    // No REFR / ESM context (the loose-loader case): identity ref
+    // transform, no LightData to prefer a radius from.
+    spawn_nif_lights(&mut world, &lights, Vec3::ZERO, Quat::IDENTITY, 1.0, None);
+
+    let q = world.query::<LightSource>().expect("LightSource query");
+    let spawned: Vec<_> = q.iter().collect();
+    assert_eq!(
+        spawned.len(),
+        1,
+        "spawn_nif_lights must attach exactly one LightSource for the one spawnable light"
+    );
+    let (_, light_source) = spawned[0];
+    assert_eq!(light_source.color, [0.8, 0.2, 0.1]);
+    assert_eq!(light_source.radius, 512.0, "authored radius (no ESM override) must survive");
+}
+
+/// Companion: a NIF authoring only zero-colour placeholder lights must
+/// spawn NO `LightSource` entity through this path either — same
+/// `is_spawnable_nif_light` gate the cell loader's own light spawn
+/// already respects.
+#[test]
+fn spawn_nif_lights_skips_zero_color_placeholder() {
+    let mut world = World::new();
+    let lights = vec![light_with_color([0.0, 0.0, 0.0])];
+
+    spawn_nif_lights(&mut world, &lights, Vec3::ZERO, Quat::IDENTITY, 1.0, None);
+
+    // `query::<T>()` returns `None` when no entity has EVER had `T` — the
+    // expected outcome here, since nothing should spawn at all.
+    let count = world
+        .query::<LightSource>()
+        .map(|q| q.iter().count())
+        .unwrap_or(0);
+    assert_eq!(
+        count, 0,
+        "a zero-colour placeholder light must not spawn a LightSource"
+    );
+}
+
 /// Pure-zero RGB → not spawnable. The audit's exact case: an
 /// authored-off `NiPointLight` placeholder.
 #[test]

--- a/byroredux/src/cell_loader/precombined.rs
+++ b/byroredux/src/cell_loader/precombined.rs
@@ -310,9 +310,25 @@ impl PrecombinedSpawnJob {
                     }
                 };
                 // Commit to registry so a re-load of this cell hits the cache.
-                {
+                let freed = {
                     let mut reg = world.resource_mut::<NifImportRegistry>();
-                    let _freed = reg.insert(path.clone(), parsed.clone());
+                    reg.insert(path.clone(), parsed.clone())
+                };
+                // #2524 / PERF-D3-NEW-01 — release any LRU-evicted clip
+                // handles. This insert's own entry never owns a clip
+                // handle, but the 2048-cap sweep it can trigger may evict
+                // a DIFFERENT, animated cache entry registered via one of
+                // the other four `NifImportRegistry::insert` call sites —
+                // whichever victim the sweep picks, if it owned a clip
+                // handle, that handle must be released here or it leaks
+                // (the exact #863 bug class, reintroduced at this newer
+                // call site).
+                if !freed.is_empty() {
+                    let mut clip_reg =
+                        world.resource_mut::<byroredux_core::animation::AnimationClipRegistry>();
+                    for h in freed {
+                        clip_reg.release(h);
+                    }
                 }
                 match parsed {
                     Some(c) => c,

--- a/byroredux/src/cell_loader/precombined_clip_handle_tests.rs
+++ b/byroredux/src/cell_loader/precombined_clip_handle_tests.rs
@@ -1,0 +1,34 @@
+//! Regression test for #2524 / PERF-D3-NEW-01 — the precombined-mesh
+//! commit-to-registry step must forward `NifImportRegistry::insert`'s
+//! `#[must_use]` `Vec<u32>` return to `AnimationClipRegistry::release`,
+//! mirroring the other four production call sites (`partial.rs`,
+//! `streaming_helpers.rs`, `references/mod.rs`).
+//!
+//! `precombined::advance` pulls in a full `VulkanContext` + CSG/BSA
+//! archive set and can't run in a unit test — same constraint as
+//! `unload_cell` (see `sky_params_cleanup_tests.rs`'s source-scan
+//! precedent for the identical problem). Pinned at the source level
+//! instead, from a SEPARATE file: binding to `_freed` (the bare-
+//! discard-with-an-underscore-prefix shape) satisfies BOTH the
+//! `must_use` and `unused_variables` lints simultaneously, so the
+//! compiler gives no warning on a silent drop — exactly the shape this
+//! bug had. Scanning `precombined.rs`'s source from a sibling file
+//! (rather than from a `#[cfg(test)] mod` inside `precombined.rs`
+//! itself) avoids the self-reference trap where the test's own
+//! assertion string would trivially match its own `include_str!`.
+
+#[test]
+fn precombined_insert_forwards_freed_clip_handles_to_release() {
+    let src = include_str!("precombined.rs");
+    assert!(
+        !src.contains("let _freed = reg.insert("),
+        "the LRU-eviction return from NifImportRegistry::insert must be \
+         bound to a real variable and forwarded to \
+         AnimationClipRegistry::release, not silently discarded (#2524)"
+    );
+    assert!(
+        src.contains("clip_reg.release(h)"),
+        "advance() must release every LRU-evicted clip handle its own \
+         NifImportRegistry::insert call may produce (#2524)"
+    );
+}

--- a/byroredux/src/cell_loader/spawn.rs
+++ b/byroredux/src/cell_loader/spawn.rs
@@ -127,10 +127,29 @@ fn synthesize_packed_havok_proxy(
     if !ref_scale.is_finite() {
         return None;
     }
-    let geometry = meshes
+
+    // #2531 / NIFAL-D6-NEW-01 — `mesh.positions` on a skinned mesh is
+    // bind-pose (rest-pose) local geometry, the exact array GPU skinning
+    // deforms at render time — NOT a runtime-posed shape. A T-pose
+    // skeleton's splayed limbs would union into a substantially
+    // oversized, permanently-wrong box (this proxy is `Keyframed` and
+    // parented to `placement_root`, never re-derived per-pose). Mirrors
+    // the Architecture-trimesh fallback's `mesh.skin.is_none()` gate —
+    // but unlike that per-submesh loop (where skipping one skinned
+    // submesh still leaves colliders from the rest), creature content is
+    // commonly skinned end-to-end, so an outright skip here would
+    // silently regress back to #2355's "no proxy at all" for exactly the
+    // population most likely to need one. Skinned submeshes instead
+    // contribute their own pose-independent local bounding sphere
+    // (already computed at import time from bind-pose extent, but
+    // consumed as a SPHERE rather than raw extremity positions, so
+    // rotation can't amplify it into something larger than the mesh
+    // actually occupies).
+    let rigid_geometry = meshes
         .iter()
         .filter(|mesh| {
-            !mesh.material.is_decal
+            mesh.skin.is_none()
+                && !mesh.material.is_decal
                 && !mesh.material.alpha_test
                 && mesh.material.material_kind
                     != byroredux_renderer::MATERIAL_KIND_FIRE_REFRACTION
@@ -142,7 +161,50 @@ fn synthesize_packed_havok_proxy(
             rotation: Quat::from_array(mesh.rotation),
             scale: mesh.scale,
         });
-    let (min, max) = transformed_mesh_aabb(geometry)?;
+
+    let mut min = Vec3::splat(f32::INFINITY);
+    let mut max = Vec3::splat(f32::NEG_INFINITY);
+    let mut any = false;
+    if let Some((rigid_min, rigid_max)) = transformed_mesh_aabb(rigid_geometry) {
+        min = min.min(rigid_min);
+        max = max.max(rigid_max);
+        any = true;
+    }
+
+    for mesh in meshes.iter().filter(|m| m.skin.is_some()) {
+        let translation = Vec3::from_array(mesh.translation);
+        let rotation = Quat::from_array(mesh.rotation);
+        if !translation.is_finite()
+            || !rotation.is_finite()
+            || rotation.length_squared() <= f32::EPSILON
+            || !mesh.scale.is_finite()
+        {
+            continue;
+        }
+        let local_center = Vec3::from_array(mesh.local_bound_center);
+        if !local_center.is_finite() || !mesh.local_bound_radius.is_finite() {
+            continue;
+        }
+        // A sphere's shape is rotation-invariant, so its world AABB
+        // contribution is exact (not an approximation the way unioning
+        // rotated cube corners would need multiple sample points to
+        // bound) — transform the center through the mesh's local TRS and
+        // scale the radius by the (uniform) mesh scale only.
+        let rotation = rotation.normalize();
+        let world_center = translation + rotation * (local_center * mesh.scale);
+        let world_radius = mesh.local_bound_radius * mesh.scale.abs();
+        if world_radius <= 0.0 {
+            continue;
+        }
+        let r = Vec3::splat(world_radius);
+        min = min.min(world_center - r);
+        max = max.max(world_center + r);
+        any = true;
+    }
+
+    if !any {
+        return None;
+    }
     let center = (min + max) * 0.5;
     // Thin render cards still need a non-zero physical thickness. Half a
     // Gamebryo unit is small relative to clutter and actor bounds, while
@@ -725,8 +787,13 @@ fn spawn_placement_root(
 
 /// Spawn a `LightSource` entity per authored NIF light with a
 /// non-trivial diffuse contribution. Split out of
-/// `spawn_placed_instances` (#2057).
-fn spawn_nif_lights(
+/// `spawn_placed_instances` (#2057). Widened to `pub(crate)` by #2530 /
+/// NIFAL-D3-NEW-01 so `scene::nif_loader::load_nif_bytes_with_skeleton`
+/// (the loose-NIF / NPC-part load path, which has no REFR and therefore
+/// no `esm::cell::LightData` — pass `None`) can spawn lights through the
+/// exact same construction + sanitization the cell loader uses, instead
+/// of re-deriving it a third time.
+pub(crate) fn spawn_nif_lights(
     world: &mut World,
     nif_lights: &[byroredux_nif::import::ImportedLight],
     ref_pos: Vec3,
@@ -1953,6 +2020,95 @@ mod synthesize_trimesh_tests {
         match shape {
             CollisionShape::Cuboid { half_extents } => {
                 assert_eq!(half_extents, Vec3::new(2.0, 4.0, 6.0));
+            }
+            other => panic!("expected Cuboid, got {other:?}"),
+        }
+    }
+
+    /// Regression for #2531 / NIFAL-D6-NEW-01: a skinned mesh's bind-pose
+    /// `positions` (splayed T-pose-wide) must NOT be unioned directly into
+    /// the proxy AABB — the mesh's own pose-independent `local_bound_*`
+    /// (deliberately tight here) must be used instead. Proves the fix by
+    /// using positions wide enough that, if they leaked through unfiltered,
+    /// the resulting cuboid would be far larger than the tight bound allows.
+    #[test]
+    fn packed_proxy_uses_local_bound_not_bind_pose_positions_for_skinned_mesh() {
+        let mut mesh = byroredux_nif::import::ImportedMesh::from_geometry(
+            // T-pose-wide bind-pose positions — splayed limbs, ±50 units.
+            vec![[-50.0, 0.0, 0.0], [50.0, 0.0, 0.0]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        mesh.skin = Some(byroredux_nif::import::ImportedSkin::default());
+        // Tight, pose-independent local bound — what the fix must use instead.
+        mesh.local_bound_center = [0.0, 0.0, 0.0];
+        mesh.local_bound_radius = 2.0;
+
+        let (center, shape) = synthesize_packed_havok_proxy(&[mesh], 1.0)
+            .expect("a skinned-only mesh set must still produce a proxy (not #2355's regression)");
+        assert_eq!(center, Vec3::ZERO);
+        match shape {
+            CollisionShape::Cuboid { half_extents } => {
+                assert!(
+                    half_extents.x <= 2.0 && half_extents.y <= 2.0 && half_extents.z <= 2.0,
+                    "half_extents {half_extents:?} must come from the tight local_bound_radius \
+                     (2.0), not the ±50 bind-pose positions — a T-pose leaking through would \
+                     produce half_extents around 50.0"
+                );
+            }
+            other => panic!("expected Cuboid, got {other:?}"),
+        }
+    }
+
+    /// Companion: a rigid (non-skinned) mesh and a skinned mesh together
+    /// must union BOTH contributions — the rigid mesh's real positions and
+    /// the skinned mesh's local bound sphere — into one proxy, proving the
+    /// skin filter doesn't silently drop the rigid geometry it sits
+    /// alongside (e.g. a creature's non-skinned prop/weapon submesh).
+    #[test]
+    fn packed_proxy_unions_rigid_positions_and_skinned_local_bound() {
+        let rigid = byroredux_nif::import::ImportedMesh::from_geometry(
+            vec![[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut skinned = byroredux_nif::import::ImportedMesh::from_geometry(
+            vec![[-50.0, -50.0, -50.0], [50.0, 50.0, 50.0]],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        skinned.skin = Some(byroredux_nif::import::ImportedSkin::default());
+        skinned.translation = [10.0, 0.0, 0.0];
+        skinned.local_bound_center = [0.0, 0.0, 0.0];
+        skinned.local_bound_radius = 1.0;
+
+        let (_, shape) = synthesize_packed_havok_proxy(&[rigid, skinned], 1.0)
+            .expect("mixed rigid + skinned mesh set must produce a proxy");
+        match shape {
+            CollisionShape::Cuboid { half_extents } => {
+                // Rigid mesh spans x in [0, 1]; skinned sphere (radius 1,
+                // translated +10) spans x in [9, 11] — union half-extent
+                // on X must reach at least (11 - 0) / 2 = 5.5, and must NOT
+                // reach anywhere near the skinned mesh's raw ±50 extent
+                // (which would push it to ~30).
+                assert!(
+                    half_extents.x >= 5.0,
+                    "union must include both meshes' contributions: {half_extents:?}"
+                );
+                assert!(
+                    half_extents.x < 15.0,
+                    "the skinned mesh's raw ±50 bind-pose positions must not leak into \
+                     the union: {half_extents:?}"
+                );
             }
             other => panic!("expected Cuboid, got {other:?}"),
         }

--- a/byroredux/src/scene.rs
+++ b/byroredux/src/scene.rs
@@ -1180,6 +1180,8 @@ mod climate_tod_hours_tests;
 #[cfg(test)]
 mod cloud_tile_scale_tests;
 #[cfg(test)]
+mod nif_loader_light_tests;
+#[cfg(test)]
 mod procedural_fallback_tests;
 #[cfg(test)]
 mod radius_parse_tests;

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -226,6 +226,20 @@ pub(super) fn parse_import_and_merge(
         &mut pool,
         Some(tex_provider),
     );
+    // #2530 / NIFAL-D3-NEW-01 — extract authored lights while `scene`
+    // (the raw parsed NifScene) is still in scope. `import_nif_scene_
+    // with_resolver` doesn't populate `ImportedScene::lights` itself
+    // (see that field's doc comment), and by the time this function
+    // returns, the raw `scene` this walk needs is gone — a caller that
+    // only retains the returned `ImportedScene` (this loader's
+    // `SceneImportCache`, unlike the cell loader's own `CachedNifImport`)
+    // has nowhere else to source them from on a cache hit. Pre-fix, the
+    // two other `import_nif_lights` call sites (`streaming.rs`,
+    // `cell_loader/references/import.rs`) meant every cell-loaded NIF's
+    // lights spawned correctly, but a loose-loaded NIF (`cargo run --
+    // <mesh>.nif`, and every skeleton/body/hand NPC-part load behind
+    // `load_nif_bytes_with_skeleton`'s cache) never got this call at all.
+    imported.lights = byroredux_nif::import::import_nif_lights(&scene);
     // FO4+ external material resolution (#493). NIF fields take
     // precedence; only empty slots fill in from the resolved
     // BGSM/BGEM chain. The merge interns through the same pool so
@@ -1125,6 +1139,24 @@ pub(crate) fn load_nif_bytes_with_skeleton(
         }
     }
 
+    // #2530 / NIFAL-D3-NEW-01 — spawn a `LightSource` per authored NIF
+    // light. Mirrors `cell_loader/spawn.rs::spawn_nif_lights` exactly
+    // (same function, widened to `pub(crate)`) rather than re-deriving
+    // the sanitization logic a third time. No REFR wraps a loose-loaded
+    // NIF, so there's no `esm::cell::LightData` to prefer a radius from
+    // (`None`) and no outer placement transform to compose against
+    // (identity) — the light's own NIF-local position IS the final
+    // world position, exactly like the root node itself.
+    let light_count = imported.lights.len();
+    crate::cell_loader::spawn::spawn_nif_lights(
+        world,
+        &imported.lights,
+        Vec3::ZERO,
+        Quat::IDENTITY,
+        1.0,
+        None,
+    );
+
     // #261 — mesh-embedded controller chains (water UV scroll, torch
     // flame visibility, lava emissive pulse). `import_nif_scene`
     // collected every NiObjectNET.controller_ref chain into a single
@@ -1181,10 +1213,11 @@ pub(crate) fn load_nif_bytes_with_skeleton(
     }
 
     log::info!(
-        "Imported {} nodes + {} meshes from '{}'",
+        "Imported {} nodes + {} meshes + {} lights from '{}'",
         imported.nodes.len(),
         count,
+        light_count,
         label
     );
-    (count + imported.nodes.len(), root, node_by_name)
+    (count + imported.nodes.len() + light_count, root, node_by_name)
 }

--- a/byroredux/src/scene/nif_loader_light_tests.rs
+++ b/byroredux/src/scene/nif_loader_light_tests.rs
@@ -1,0 +1,51 @@
+//! Regression test for #2530 / NIFAL-D3-NEW-01 — the loose-NIF load
+//! path (`parse_import_and_merge`, backing every `load_nif_bytes` /
+//! `load_nif_bytes_with_skeleton` call including standalone `cargo run
+//! -- <mesh>.nif` and every skeleton/body/hand NPC-part load) never
+//! called `byroredux_nif::import::import_nif_lights`, so a torch /
+//! candle / lantern / streetlamp NIF loaded through this path rendered
+//! its geometry but contributed zero light to the scene.
+//!
+//! The ECS half of the fix (`ImportedLight` → spawned `LightSource`) is
+//! covered by `cell_loader::nif_light_spawn_gate_tests`'s
+//! `spawn_nif_lights_attaches_light_source_for_spawnable_light` — that
+//! test exercises the exact function `load_nif_bytes_with_skeleton` now
+//! calls. What's missing from THAT coverage is proof `parse_import_and_
+//! merge` actually makes the call at all; `import_nif_lights` has no
+//! byte-level NIF fixture elsewhere in the tree to build a full parse-
+//! through-spawn integration test from (and `load_nif_bytes_with_
+//! skeleton` itself needs a real Vulkan device for the GPU-upload half
+//! regardless — the established "can't unit test this function
+//! directly" constraint seen throughout this crate). Pinned at the
+//! source level instead, from a SEPARATE file to avoid the self-
+//! reference trap where the assertion's own string would match its own
+//! `include_str!` (see `cell_loader/precombined_clip_handle_tests.rs`
+//! for the identical technique on a different fix).
+
+#[test]
+fn parse_import_and_merge_extracts_lights_from_the_raw_scene() {
+    let src = include_str!("nif_loader.rs");
+    assert!(
+        src.contains("imported.lights = byroredux_nif::import::import_nif_lights(&scene)"),
+        "parse_import_and_merge must extract authored lights from the raw NifScene \
+         while it's still in scope and store them on the returned ImportedScene \
+         (#2530) — without this, every loose-loaded / NPC-part-loaded NIF's \
+         embedded lights are silently dropped"
+    );
+}
+
+#[test]
+fn load_nif_bytes_with_skeleton_spawns_the_extracted_lights() {
+    let src = include_str!("nif_loader.rs");
+    assert!(
+        src.contains("cell_loader::spawn::spawn_nif_lights("),
+        "load_nif_bytes_with_skeleton must spawn a LightSource for each of \
+         imported.lights (#2530) — extracting them in parse_import_and_merge \
+         alone is not sufficient if nothing ever spawns them"
+    );
+    assert!(
+        src.contains("&imported.lights"),
+        "the spawn call must be fed the lights parse_import_and_merge \
+         extracted, not an empty/unrelated array"
+    );
+}

--- a/byroredux/src/scene_import_cache.rs
+++ b/byroredux/src/scene_import_cache.rs
@@ -154,6 +154,7 @@ mod tests {
             furniture_markers: Vec::new(),
             embedded_clip: None,
             ragdoll: None,
+            lights: Vec::new(),
         })
     }
 

--- a/crates/nif/src/blocks/dispatch_tests/legacy_particle.rs
+++ b/crates/nif/src/blocks/dispatch_tests/legacy_particle.rs
@@ -194,6 +194,85 @@ fn ni_auto_normal_particles_data_at_v4_0_0_2_skips_all_structurally_unreachable_
     assert!(m.rotation_axes.is_empty());
 }
 
+/// Regression for #2525 / PERF-D8-NEW-02: `Has Rotations`' single-point
+/// valid window is exactly `version == V10_0_1_0` (see the sibling
+/// `has_shader` tests above for why). This is the ONLY version at which
+/// `rotations` can ever decode a non-empty array through this parser —
+/// zero prior test coverage exercised the `has_rotations = true` path at
+/// all, let alone after #2525's conversion from a 4-`read_f32_le()`-
+/// calls-per-particle loop to a bulk `read_f32_array` + `chunks_exact(4)`
+/// + swizzle. Two distinguishable particles prove both the stream
+/// position AND the on-disk `w,x,y,z` → `[x,y,z,w]` reorder survived the
+/// conversion.
+#[test]
+fn ni_auto_normal_particles_data_at_v10_0_1_0_decodes_rotations() {
+    let header = header_at(NifVersion::V10_0_1_0);
+    let mut data = Vec::new();
+    data.extend_from_slice(&0u32.to_le_bytes()); // groupID (#688, has_object_group_id band)
+
+    // parse_geometry_data_base at exactly V10_0_1_0: no keep/compress
+    // flags (< V10_1_0_0), has_vertices=true with 2 real vertices (so
+    // num_vertices downstream is 2, not 0), data_flags=0 (no material
+    // CRC — bsver=0), no normals, zero bounding sphere, no vertex
+    // colors, num_uv_sets=0 from data_flags so no UV reads, consistency
+    // flags present (>= V10_0_1_0), no additional_data_ref (< V20_0_0_4).
+    data.extend_from_slice(&2u16.to_le_bytes()); // num_vertices_raw
+    data.push(1u8); // has_vertices = true
+    for v in [[0.0f32, 0.0, 0.0], [1.0, 1.0, 1.0]] {
+        for c in v {
+            data.extend_from_slice(&c.to_le_bytes());
+        }
+    }
+    data.extend_from_slice(&0u16.to_le_bytes()); // data_flags
+    data.push(0u8); // has_normals = false
+    for _ in 0..3 {
+        data.extend_from_slice(&0.0f32.to_le_bytes()); // bounding sphere center
+    }
+    data.extend_from_slice(&0.0f32.to_le_bytes()); // bounding sphere radius
+    data.push(0u8); // has_vertex_colors = false
+    data.extend_from_slice(&0u16.to_le_bytes()); // consistency_flags (>= V10_0_1_0)
+
+    // NiParticlesData tail: num_active, has_sizes (false), has_rotations
+    // (true) + 2 quaternions in Gamebryo's on-disk w,x,y,z order.
+    data.extend_from_slice(&2u16.to_le_bytes()); // num_active
+    data.push(0u8); // has_sizes = false
+    data.push(1u8); // has_rotations = true
+    for wxyz in [[0.1f32, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]] {
+        for c in wxyz {
+            data.extend_from_slice(&c.to_le_bytes());
+        }
+    }
+
+    let mut stream = NifStream::new(&data, &header);
+    let block = parse_block(
+        "NiAutoNormalParticlesData",
+        &mut stream,
+        Some(data.len() as u32),
+    )
+    .expect("must parse cleanly with has_rotations gated on at exactly V10_0_1_0");
+    assert_eq!(
+        stream.position() as usize,
+        data.len(),
+        "must consume exactly the fixture's bytes, including the bulk-read rotations array"
+    );
+    let m = block
+        .as_any()
+        .downcast_ref::<crate::blocks::legacy_particle::NiLegacyParticlesData>()
+        .unwrap();
+    assert_eq!(m.rotations.len(), 2);
+    // On-disk w,x,y,z (0.1,0.2,0.3,0.4) must decode to [x,y,z,w].
+    let r0 = m.rotations[0];
+    assert!((r0[0] - 0.2).abs() < 1e-6, "particle 0 x: {r0:?}");
+    assert!((r0[1] - 0.3).abs() < 1e-6, "particle 0 y: {r0:?}");
+    assert!((r0[2] - 0.4).abs() < 1e-6, "particle 0 z: {r0:?}");
+    assert!((r0[3] - 0.1).abs() < 1e-6, "particle 0 w: {r0:?}");
+    let r1 = m.rotations[1];
+    assert!((r1[0] - 0.6).abs() < 1e-6, "particle 1 x: {r1:?}");
+    assert!((r1[1] - 0.7).abs() < 1e-6, "particle 1 y: {r1:?}");
+    assert!((r1[2] - 0.8).abs() < 1e-6, "particle 1 z: {r1:?}");
+    assert!((r1[3] - 0.5).abs() < 1e-6, "particle 1 w: {r1:?}");
+}
+
 fn niparticlebomb_prefix_and_scalars() -> Vec<u8> {
     let mut d = Vec::new();
     d.extend_from_slice(&(-1i32).to_le_bytes()); // next_modifier

--- a/crates/nif/src/blocks/extra_data.rs
+++ b/crates/nif/src/blocks/extra_data.rs
@@ -369,24 +369,23 @@ impl BsPositionData {
         // FO76 = 20.2.0.7) sits well past the boundary, so name is
         // always present in shipped content. See #329.
         let name = stream.read_extra_data_name()?;
-        // Num Vertices: u32 — file-driven count, route through
-        // `allocate_vec` so a corrupt 0xFFFFFFFF can't OOM-allocate
-        // a 12 GB Vec before the inner half-float reads fail. See
-        // #764 (the `allocate_vec` budget guard) and the issue's
-        // explicit ALLOCATE_VEC completeness check.
+        // Num Vertices: u32 — file-driven count.
         let num_vertices = stream.read_u32_le()?;
-        // #2523 — on-disk elements are 2-byte half-floats, decoded to
-        // 4-byte f32 in memory; size_of::<f32>() would overstate the true
-        // minimum and false-positive-reject legitimate dense arrays, so
-        // this bounds on the real 2-byte-per-element wire size instead.
-        let mut vertex_data = stream.allocate_vec_min_bytes::<f32>(num_vertices, 2)?;
-        for _ in 0..num_vertices {
-            // Half Float (16-bit IEEE-754) — same encoding as the
-            // FO4 / FO76 vertex-stream UV / position halfs decoded
-            // by `tri_shape::half_to_f32`.
-            let h = stream.read_u16_le()?;
-            vertex_data.push(crate::blocks::tri_shape::half_to_f32(h));
-        }
+        // #2525 / PERF-D8-NEW-02 — bulk-read the raw u16 half-float
+        // stream in one call, then decode in a tight `.map()` loop,
+        // mirroring the idiom #1263 established at
+        // `bs_geometry.rs:434-444`. `read_u16_array` bottoms out in
+        // `read_pod_vec`, which bounds-checks the requested count
+        // against the real remaining stream bytes — at least as safe
+        // against a hostile `num_vertices` as the previous
+        // `allocate_vec_min_bytes::<f32>(num_vertices, 2)` heuristic
+        // (#2523), and no longer needed once the bulk read itself
+        // rejects an over-large count before any per-element work runs.
+        let vertex_data: Vec<f32> = stream
+            .read_u16_array(num_vertices as usize)?
+            .into_iter()
+            .map(crate::blocks::tri_shape::half_to_f32)
+            .collect();
         Ok(Self { name, vertex_data })
     }
 }

--- a/crates/nif/src/blocks/legacy_particle.rs
+++ b/crates/nif/src/blocks/legacy_particle.rs
@@ -676,17 +676,17 @@ impl NiLegacyParticlesData {
         } else {
             false
         };
-        let rotations = if has_rotations {
-            let mut v = stream.allocate_vec(num_vertices as u32)?;
-            for _ in 0..num_vertices {
-                // Gamebryo Quaternion serialization is w, x, y, z.
-                let w = stream.read_f32_le()?;
-                let x = stream.read_f32_le()?;
-                let y = stream.read_f32_le()?;
-                let z = stream.read_f32_le()?;
-                v.push([x, y, z, w]);
-            }
-            v
+        // #2525 / PERF-D8-NEW-02 — bulk-read the raw f32 stream in one
+        // call then swizzle w,x,y,z (Gamebryo's on-disk quaternion
+        // order) to [x,y,z,w] in the `.map()`, mirroring the idiom
+        // #1263 established at `bs_geometry.rs:434-444` instead of 4
+        // individual `read_f32_le()` calls per particle.
+        let rotations: Vec<[f32; 4]> = if has_rotations {
+            stream
+                .read_f32_array(num_vertices as usize * 4)?
+                .chunks_exact(4)
+                .map(|c| [c[1], c[2], c[3], c[0]])
+                .collect()
         } else {
             Vec::new()
         };

--- a/crates/nif/src/blocks/node.rs
+++ b/crates/nif/src/blocks/node.rs
@@ -1089,15 +1089,22 @@ impl BsDistantObjectInstancedNode {
             // match for size_of::<[f32; 16]>() (#2523 — the worst-case
             // amplification site this fix was written for: a corrupt
             // num_transforms could otherwise request up to 19.2 GB).
+            //
+            // #2525 / PERF-D8-NEW-02 — bulk-read the raw f32 stream in
+            // one call then reshape via `chunks_exact`, mirroring the
+            // idiom #1263 established at `bs_geometry.rs:434-444`,
+            // instead of 16 individual `read_f32_le()` calls per
+            // transform. `read_f32_array` bottoms out in `read_pod_vec`,
+            // whose `check_alloc` byte-count guard (`num_transforms *
+            // 16` f32s = the same 64 B/transform `allocate_vec_sized`
+            // used to bound) supersedes the old pre-check, so the #2523
+            // hostile-count protection is unchanged.
             let num_transforms = stream.read_u32_le()?;
-            let mut transforms: Vec<[f32; 16]> = stream.allocate_vec_sized(num_transforms)?;
-            for _ in 0..num_transforms {
-                let mut m = [0.0f32; 16];
-                for cell in &mut m {
-                    *cell = stream.read_f32_le()?;
-                }
-                transforms.push(m);
-            }
+            let transforms: Vec<[f32; 16]> = stream
+                .read_f32_array(num_transforms as usize * 16)?
+                .chunks_exact(16)
+                .map(|c| c.try_into().unwrap())
+                .collect();
 
             instances.push(BsDistantObjectInstance {
                 resource_file_hash,

--- a/crates/nif/src/import/mod.rs
+++ b/crates/nif/src/import/mod.rs
@@ -141,6 +141,8 @@ fn import_nif_scene_impl(
         furniture_markers: extract_furniture_markers(scene),
         embedded_clip: crate::anim::import_embedded_animations(scene),
         ragdoll: collision::extract_ragdoll(scene),
+        // Not auto-populated here — see the field doc on `ImportedScene::lights`.
+        lights: Vec::new(),
     };
 
     // A truncated scene means at least one block was lost to a mid-parse

--- a/crates/nif/src/import/types.rs
+++ b/crates/nif/src/import/types.rs
@@ -970,6 +970,18 @@ pub struct ImportedScene {
     /// decodable). Consumed by the engine to build a Rapier multibody and
     /// drive Bethesda ragdolls on our own solver (M41.x).
     pub ragdoll: Option<ImportedRagdoll>,
+    /// Authored `NiPointLight` / `NiSpotLight` / `NiAmbientLight` /
+    /// `NiDirectionalLight` blocks, extracted via [`crate::import::import_nif_lights`].
+    /// Empty unless the caller explicitly populates it — `import_nif_scene*`
+    /// does NOT call `import_nif_lights` itself (each of this crate's three
+    /// existing consumers has its own reason to call it separately, at a
+    /// point where it still holds the raw `NifScene` borrow this field's
+    /// producer needs). This field exists so a caller that already computed
+    /// the lights at parse time (see `byroredux::scene::nif_loader::
+    /// parse_import_and_merge`) has somewhere to stash them for a caching
+    /// layer that only retains `ImportedScene`, not the raw scene. See
+    /// #2530 / NIFAL-D3-NEW-01.
+    pub lights: Vec<ImportedLight>,
 }
 
 /// A Havok ragdoll articulation, engine-native (Y-up, havok-scaled).

--- a/crates/nif/src/import/walk/tests.rs
+++ b/crates/nif/src/import/walk/tests.rs
@@ -585,6 +585,7 @@ mod recursion_depth_tests {
             furniture_markers: Vec::new(),
             embedded_clip: None,
             ragdoll: None,
+            lights: Vec::new(),
         }
     }
 
@@ -771,6 +772,7 @@ mod particle_local_transform_tests {
             furniture_markers: Vec::new(),
             embedded_clip: None,
             ragdoll: None,
+            lights: Vec::new(),
         };
         let mut pool = StringPool::new();
         let mut props_stack: Vec<BlockRef> = Vec::new();

--- a/crates/spt/src/import/mod.rs
+++ b/crates/spt/src/import/mod.rs
@@ -186,6 +186,8 @@ pub fn import_spt_scene(
         embedded_clip: None,
         // SpeedTree placeholder billboards carry no Havok ragdoll.
         ragdoll: None,
+        // SpeedTree placeholder billboards author no lights.
+        lights: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Four audit findings across `byroredux` and `byroredux-nif`:

- **#2524** (PERF-D3-NEW-01): the precombined-mesh commit path bound `NifImportRegistry::insert`'s `#[must_use]` return to `_freed`, silently dropping any clip handle an LRU eviction freed — the exact #863 bug class, reintroduced at a call site added after that fix landed. Now forwards to `AnimationClipRegistry::release`, mirroring the other four call sites.
- **#2525** (PERF-D8-NEW-02): three NIF parse sites (`BsPositionData`, `BsDistantObjectInstancedNode` transforms, `NiLegacyParticlesData` rotations) still did N individual per-element reads instead of the bulk-read-then-map idiom established elsewhere in the crate. Converted all three; added a regression test for the previously-uncovered `has_rotations=true` decode path (only reachable at exactly NIF version V10_0_1_0).
- **#2530** (NIFAL-D3-NEW-01, **HIGH**): the loose-NIF load path (`scene::nif_loader`, backing `cargo run -- <mesh>.nif` AND every skeleton/body/hand NPC-part load) never called `import_nif_lights` — a torch/candle/lantern NIF loaded through this path rendered its geometry but contributed zero light. Added `ImportedScene::lights` so the loader's cache can retain lights extracted at parse time, widened `spawn_nif_lights` to `pub(crate)` so the loose loader reuses the cell loader's exact spawn logic instead of a third re-derivation.
- **#2531** (NIFAL-D6-NEW-01): the packed-Havok collision compatibility proxy for Actor/Clutter placements had no equivalent of the Architecture-trimesh fallback's skinned-mesh guard, so a creature's bind-pose (T-pose) vertex positions unioned directly into its collision AABB — a permanently oversized invisible collision box. Skinned submeshes now contribute their pose-independent local bounding sphere instead (an exact AABB contribution, since a sphere is rotation-invariant), avoiding both the bad-geometry bug and a regression back to #2355's "no proxy at all."

`cargo test -q -p byroredux-nif` and `-p byroredux` (bin) pass clean; full workspace `cargo test -q` passes (80/80 test groups, 0 failed).