### PR TITLE
Fix #2791 #2792 #2793 #2794: bind-inverse staging comment, water subm…

### DIFF
--- a/.claude/issues/2791 2792 2793 2794/ISSUE.md
+++ b/.claude/issues/2791 2792 2793 2794/ISSUE.md
@@ -1,0 +1,64 @@
+# Batch: #2791 #2792 #2793 #2794
+
+## #2791 — REN-D5-04: allocate_scene_render_buffers bind-inverse staging comment understates size by 87x (144 KB vs ~12.6 MB)
+
+**Labels**: documentation, renderer, low
+**Location**: `crates/renderer/src/vulkan/scene_buffer/buffers.rs` (`allocate_scene_render_buffers`)
+
+The bind-inverse staging comment computes "16 × 144 × 64 ≈ 144 KB"; the
+constant is 1366, making it ≈ 12.6 MB — an 87× understatement next to
+the second-largest host-visible allocation the renderer makes.
+`constants.rs` and `memory-budget.md` are both correct; only this site
+is stale.
+
+Filed from docs/audits/AUDIT_RENDERER_2026-08-12b.md (finding REN-D5-04).
+
+---
+
+## #2792 — REN-D15-09: submersion_system WaterVolume-absent exit leaves stale submersion state
+
+**Labels**: bug, renderer, low
+**Location**: `byroredux/src/systems/water.rs` (`submersion_system`)
+
+Two "no water data" exits with opposite behaviour: the `WaterPlane`-absent
+exit resets `SubmersionState` to default with a comment explaining why;
+the `WaterVolume`-absent exit twenty lines later is a bare `return`, so
+the camera keeps `head_submerged: true` and a stale `material` that
+`compute_underwater_params` then feeds indefinitely. Only separable via
+`spawn_lod_water_plane` (#2449), which inserts `WaterPlane` without
+`WaterVolume` — a state in which the camera cannot already be submerged,
+so today's outcome is "no reset needed". Defence-in-depth gap.
+
+Filed from docs/audits/AUDIT_RENDERER_2026-08-12b.md (finding REN-D15-09).
+
+---
+
+## #2793 — REN-D5-05: collect_image_health writes through mapped_slice_mut with no invalidate/flush primitive documented
+
+**Labels**: bug, renderer, low, memory
+**Location**: `crates/renderer/src/vulkan/context/resources.rs` (`collect_image_health`), `crates/renderer/src/vulkan/buffer.rs`
+
+The health counter is read and rewritten through `mapped_slice_mut` with
+neither invalidate nor the flush `mapped_slice_mut`'s own doc mandates;
+`GpuBuffer` has no invalidate primitive at all. Benign only because
+gpu-allocator 0.27 puts `HOST_COHERENT` in the required flag set for
+`CpuToGpu` — and nothing in the source says so.
+
+Documentation half of REN-D4-04 / REN-D4-05.
+
+Filed from docs/audits/AUDIT_RENDERER_2026-08-12b.md (finding REN-D5-05).
+
+---
+
+## #2794 — REN-D5-06: deferred_destroy.rs module doc claims two production users, there are three (pending_destroy_scratch omitted)
+
+**Labels**: documentation, renderer, low
+**Location**: `crates/renderer/src/deferred_destroy.rs`
+
+Module doc claims "two production users"; there are three —
+`pending_destroy_scratch` (#1782's fix) is omitted, so a reader auditing
+deferred-destroy coverage concludes the shared BLAS scratch is *not* on
+the countdown path, which is the exact wrong conclusion that produced
+#1782. Both `DEFAULT_COUNTDOWN` cross-references are rotted.
+
+Filed from docs/audits/AUDIT_RENDERER_2026-08-12b.md (finding REN-D5-06).

--- a/byroredux/src/systems/water.rs
+++ b/byroredux/src/systems/water.rs
@@ -84,6 +84,20 @@ pub(crate) fn submersion_system(world: &World, _dt: f32) {
         return;
     };
     let Some(vq) = world.query::<WaterVolume>() else {
+        // #2792 (REN-D15-09) — mirror the WaterPlane-absent branch above:
+        // no `WaterVolume` component anywhere means no water can submerge
+        // the camera this frame, so any stale `head_submerged` / `material`
+        // from a prior frame must be cleared, not left to feed
+        // `compute_underwater_params` indefinitely. Today `WaterPlane`
+        // always ships with a matching `WaterVolume` except transiently via
+        // `spawn_lod_water_plane` (#2449), a state the camera can't already
+        // be submerged in — but that's an invariant of the current spawn
+        // path, not something this function should assume holds forever.
+        if let Some(mut sq) = world.query_mut::<SubmersionState>() {
+            if let Some(state) = sq.get_mut(cam_entity) {
+                *state = SubmersionState::default();
+            }
+        }
         return;
     };
     for (entity, plane) in wq.iter() {
@@ -216,7 +230,11 @@ pub fn compute_underwater_params(world: &World) -> [f32; 4] {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_head_submerged, WATERLINE_HYSTERESIS};
+    use super::{resolve_head_submerged, submersion_system, WATERLINE_HYSTERESIS};
+    use byroredux_core::ecs::components::water::{
+        SubmersionState, WaterKind, WaterMaterial, WaterPlane,
+    };
+    use byroredux_core::ecs::{ActiveCamera, GlobalTransform, World};
 
     const EPS: f32 = WATERLINE_HYSTERESIS;
 
@@ -258,5 +276,57 @@ mod tests {
         assert!(!resolve_head_submerged(false, Some(mid))); // dry stays dry
         assert!(resolve_head_submerged(true, Some(mid))); // wet stays wet
         assert!(std::hint::black_box(EPS) > 0.0);
+    }
+
+    /// Regression for #2792 (REN-D15-09): a `WaterPlane` entity with no
+    /// matching `WaterVolume` component must clear stale submersion state
+    /// exactly like the "no `WaterPlane` at all" branch above it does —
+    /// not bare-`return` and leave a prior frame's `head_submerged: true`
+    /// / `material` feeding `compute_underwater_params` indefinitely.
+    #[test]
+    fn water_volume_absent_clears_stale_submersion_state() {
+        let mut world = World::new();
+
+        let camera = world.spawn();
+        world.insert_resource(ActiveCamera(camera));
+        world.insert(camera, GlobalTransform::IDENTITY);
+        // Stale state from a prior frame — must be cleared, not preserved.
+        world.insert(
+            camera,
+            SubmersionState {
+                depth: 5.0,
+                head_submerged: true,
+                material: Some(WaterMaterial::default()),
+            },
+        );
+
+        // A WaterPlane entity exists (so the WaterPlane-absent early
+        // return above does NOT fire) but carries no WaterVolume — the
+        // transient state `spawn_lod_water_plane` (#2449) produces.
+        let water = world.spawn();
+        world.insert(
+            water,
+            WaterPlane {
+                kind: WaterKind::River,
+                material: WaterMaterial::default(),
+            },
+        );
+
+        submersion_system(&world, 0.0);
+
+        let sq = world
+            .query::<SubmersionState>()
+            .expect("SubmersionState query");
+        let state = sq.get(camera).copied().expect("camera state");
+        assert_eq!(state.depth, 0.0, "depth must reset to default");
+        assert!(
+            !state.head_submerged,
+            "head_submerged must reset to default, not stay stuck true"
+        );
+        assert!(
+            state.material.is_none(),
+            "material must reset to default, not keep feeding \
+             compute_underwater_params a stale value"
+        );
     }
 }

--- a/crates/renderer/src/deferred_destroy.rs
+++ b/crates/renderer/src/deferred_destroy.rs
@@ -2,14 +2,20 @@
 //! must be delayed until any in-flight command buffer that references
 //! them has retired (typically MAX_FRAMES_IN_FLIGHT frames).
 //!
-//! Two production users today, both on the countdown variant:
+//! Three production users today, all on the countdown variant:
 //!   * [`crate::mesh::MeshRegistry::deferred_destroy`] — pairs of
 //!     vertex / index `GpuBuffer`s queued by `drop_mesh` (#372 /
 //!     #879).
 //!   * [`crate::vulkan::acceleration::AccelerationManager::pending_destroy_blas`]
 //!     — `BlasEntry` queued by `drop_blas` (#372 / #495).
+//!   * [`crate::vulkan::acceleration::AccelerationManager::pending_destroy_scratch`]
+//!     — retired shared BLAS-build `GpuBuffer` scratch allocations,
+//!     queued alongside `pending_destroy_blas` and ticked/drained in
+//!     lockstep with it (#1782 — a prior fix moved this queue onto
+//!     this same countdown path after a use-after-free surfaced from
+//!     freeing scratch buffers immediately instead of deferring them).
 //!
-//! Both predate this primitive and reimplemented the same
+//! The first two predate this primitive and reimplemented the same
 //! `Vec<(T, u32)>` + per-frame `retain_mut` decrement loop +
 //! shutdown drain shape. Consolidating them here keeps the countdown
 //! semantics + safety contract in one place.
@@ -29,8 +35,14 @@
 /// instead of silently lagging behind. Items pushed at frame N are
 /// safe to destroy at frame N+`DEFAULT_COUNTDOWN` because every
 /// command buffer that could reference them has finished by then.
-/// Mirrors the correct pattern at `draw.rs:889` and
-/// `acceleration.rs::tick_pending_destroy_blas`.
+/// Mirrors the correct pattern at the deferred-destroy tick call site
+/// in `VulkanContext::draw_frame` (`vulkan::context::draw`, run
+/// immediately after `wait_for_fences` — see the comment there for
+/// why ordering matters, #418) and
+/// [`crate::vulkan::acceleration::AccelerationManager::tick_deferred_destroy`]
+/// (#2794 — both cross-references had rotted to a stale line number
+/// and a since-renamed function after the `acceleration.rs` →
+/// `acceleration/` module split).
 pub(crate) const DEFAULT_COUNTDOWN: u32 = crate::vulkan::sync::MAX_FRAMES_IN_FLIGHT as u32;
 
 /// Queue of items waiting `countdown` more frames before destruction.

--- a/crates/renderer/src/vulkan/buffer.rs
+++ b/crates/renderer/src/vulkan/buffer.rs
@@ -747,6 +747,19 @@ impl GpuBuffer {
 
     /// Get the mapped memory slice for direct writes (no intermediate Vec).
     /// Call `flush_if_needed()` after writing to ensure GPU visibility.
+    ///
+    /// #2793 (REN-D5-05) — this type has no `vkInvalidateMappedMemoryRanges`
+    /// counterpart to `flush_if_needed()`. That's fine for the write-then-
+    /// flush usage this doc comment describes, but a caller that instead
+    /// READS GPU-written bytes back through this same slice (e.g. an
+    /// atomic-counter buffer the shader writes and the host later drains)
+    /// gets no equivalent visibility guarantee from this type — it's
+    /// correct today only because every current `mapped_slice_mut` caller's
+    /// buffer is `create_host_visible` (`CpuToGpu`), and gpu-allocator
+    /// 0.27's `CpuToGpu` preset requires (not merely prefers)
+    /// `HOST_COHERENT`, so `is_coherent` is always `true` in practice. Add
+    /// an `invalidate_if_needed()` sibling to `flush_if_needed()` before
+    /// this type is ever used with a non-coherent-eligible allocation.
     pub fn mapped_slice_mut(&mut self) -> Result<&mut [u8]> {
         let alloc = self
             .allocation

--- a/crates/renderer/src/vulkan/context/resources.rs
+++ b/crates/renderer/src/vulkan/context/resources.rs
@@ -95,6 +95,22 @@ impl VulkanContext {
     /// appears for the frames a bad material or a degenerate light is on
     /// screen and then goes. A gate that only sampled the current frame would
     /// miss it; the total is what makes the smoke check reliable.
+    ///
+    /// #2793 (REN-D5-05) — this reads GPU-written data through
+    /// `mapped_slice_mut()` with no `vkInvalidateMappedMemoryRanges` call
+    /// (`GpuBuffer` has no invalidate primitive at all), then writes the
+    /// reset-to-zero bytes back through the same mapping with no
+    /// `flush_if_needed()` — despite `mapped_slice_mut`'s own doc mandating
+    /// one after writes. Both omissions are visibility gaps on paper. They
+    /// are benign in practice ONLY because `image_health_buffers` is a
+    /// `create_host_visible` (`MemoryLocation::CpuToGpu`) allocation, and
+    /// gpu-allocator 0.27's `CpuToGpu` preset puts `HOST_COHERENT` in the
+    /// *required* (not just preferred) memory-property flags — so
+    /// `is_coherent` is always `true` here and both the GPU write and this
+    /// host read/write stay automatically visible to each other with no
+    /// explicit barrier. That's a property of this specific allocator
+    /// version, not a Vulkan-spec guarantee; it doesn't hold if this buffer
+    /// is ever changed to a non-coherent-eligible allocation.
     pub(super) fn collect_image_health(&mut self, frame: usize) {
         let Some(buffer) = self.image_health_buffers.get_mut(frame) else {
             return;

--- a/crates/renderer/src/vulkan/scene_buffer/buffers.rs
+++ b/crates/renderer/src/vulkan/scene_buffer/buffers.rs
@@ -82,10 +82,12 @@ pub struct SceneBuffers {
     /// M29.6 — HOST_VISIBLE staging buffer for first-sight
     /// `bind_inverses` uploads. Sized for
     /// `MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME × MAX_BONES_PER_MESH
-    /// × mat4 ≈ 144 KB`. The renderer writes up to this many pending
-    /// uploads into consecutive slots here, then records one
-    /// `cmd_copy_buffer` per upload (each targeting a different slot
-    /// offset in [`bind_inverses_persistent`]).
+    /// × mat4 ≈ 12.6 MB` (#2791 — was stale at "144 KB", 87× too small,
+    /// from before the constant's #1284 re-bump to 1366). The renderer
+    /// writes up to this many pending uploads into consecutive slots
+    /// here, then records one `cmd_copy_buffer` per upload (each
+    /// targeting a different slot offset in
+    /// [`bind_inverses_persistent`]).
     pub(super) bind_inverse_upload_staging: GpuBuffer,
     /// M29.5 — bytes most recently written into the bone-world
     /// staging buffer by [`upload_bone_worlds`]. [`record_bone_world_copy`]
@@ -576,9 +578,14 @@ fn allocate_scene_render_buffers(
         bone_buf_size,
         vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
     )?;
-    // M29.6 — small HOST_VISIBLE staging that holds up to
-    // MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME × MAX_BONES_PER_MESH ×
-    // mat4 bytes of pending first-sight uploads. 16 × 144 × 64 ≈ 144 KB.
+    // M29.6 — small (relative to `bind_inverses_persistent`) HOST_VISIBLE
+    // staging that holds up to MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME ×
+    // MAX_BONES_PER_MESH × mat4 bytes of pending first-sight uploads.
+    // #2791 (REN-D5-04) — this was stale at "16 × 144 × 64 ≈ 144 KB", from
+    // before `MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME`'s #1284 re-bump.
+    // At the current constant (1366): 1366 × 144 × 64 B ≈ 12.6 MB — the
+    // second-largest host-visible allocation this function makes. See the
+    // constant's own doc in `constants.rs` for the sizing history.
     let bind_inverse_staging_size = (MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME
         * MAX_BONES_PER_MESH
         * std::mem::size_of::<[[f32; 4]; 4]>())


### PR DESCRIPTION
…ersion reset, mapped-buffer coherency docs, deferred-destroy user count

REN-D5-04 (#2791): `allocate_scene_render_buffers`'s bind-inverse staging size comment computed "16 × 144 × 64 ≈ 144 KB" against a constant that is actually 1366, an 87x understatement of the real ~12.6 MB allocation — the second-largest host-visible allocation this function makes. `constants.rs` already had the correct math; only this site (and an identical stale figure on the field's own doc comment) had drifted. Fixed both to the correct ~12.6 MB figure.

REN-D15-09 (#2792): `submersion_system` had two "no water data" exits with opposite behaviour — the `WaterPlane`-absent exit reset `SubmersionState` to default, but the `WaterVolume`-absent exit twenty lines later was a bare `return`, leaving a stale `head_submerged: true` / `material` feeding `compute_underwater_params` indefinitely. Made the `WaterVolume`-absent exit mirror the `WaterPlane`-absent one. Added a regression test constructing a `WaterPlane`-without-`WaterVolume` world (the state `spawn_lod_water_plane` / #2449 transiently produces) with pre-existing stale submerged state, confirming it resets.

REN-D5-05 (#2793, documentation half of REN-D4-04/REN-D4-05): `collect_image_health` reads and rewrites a GPU-written buffer through `mapped_slice_mut` with neither an invalidate before the read nor the flush `mapped_slice_mut`'s own doc mandates after the write — and `GpuBuffer` has no invalidate primitive at all. Currently benign only because gpu-allocator 0.27's `CpuToGpu` preset requires (not just prefers) `HOST_COHERENT`, which nothing in the source said. Documented the gap and its current safety condition at both sites; no behavior change (the actual invalidate-primitive / allocation-location fixes are tracked separately as REN-D4-04/REN-D4-05).

REN-D5-06 (#2794): `deferred_destroy.rs`'s module doc claimed "two production users" of `DeferredDestroyQueue`; there are three — `AccelerationManager::pending_destroy_scratch` (the shared BLAS-build scratch buffer, moved onto this countdown path by #1782 after a use-after-free) was omitted, which is exactly the wrong conclusion that produced #1782 in the first place. Also fixed both rotted `DEFAULT_COUNTDOWN` cross-references (a stale line number that now points into an unrelated test module, and a function name that no longer exists post the `acceleration.rs` → `acceleration/` module split) to point at the actual current call sites.