### PR TITLE
Fix #2705 #2706 #2707 #2708: cache Starfield CDB bytes, correct stale…

### DIFF
--- a/.claude/issues/2705 2706 2707 2708/ISSUE.md
+++ b/.claude/issues/2705 2706 2707 2708/ISSUE.md
@@ -1,0 +1,135 @@
+# Batch: #2705 #2706 #2707 #2708
+
+## #2705 — SF-2026-08-12-D3-01: The 105 MB `materialsbeta.cdb` is fully decompressed and immediately discarded on every `build_material_provider` call
+
+**Severity**: MEDIUM · **Labels**: bug, import-pipeline, medium, performance
+**Location**: `byroredux/src/asset_provider/material.rs:44-52` (`discover_starfield_cdbs`), `:352-384` (`register_starfield_cdb`)
+
+`discover_starfield_cdbs` calls `archive.extract(&path)` for every discovered
+CDB, which for a BA2 GNRL entry runs the full zlib inflate into an owned
+`Vec<u8>`. `register_starfield_cdb` then reads exactly the 4-byte magic and
+the 12-byte header (`probe_header`), bumps a counter, and the `Vec` is
+dropped at the end of the loop iteration. Nothing retains the bytes. Phase 1
+needs 16 bytes; it pays 105 MB of inflate + allocation for them, per CDB, per
+provider build.
+
+Measured — `materials\materialsbeta.cdb` extracts to 105,037,616 bytes from
+the 17.6 MB `Starfield - Materials.ba2`. `MaterialProvider` has no field
+holding CDB bytes (only `sf_cdb_count: usize`, `material.rs:277`).
+`build_material_provider` runs fresh at boot, at every door/cell transition,
+at save-load, and at debug-load — the same call-site set #2615 was filed
+against.
+
+Impact: ~105 MB transient allocation + a multi-hundred-ms inflate on every
+cell transition on Starfield, for a presence bit.
+
+Related: #2615 (SF-D3-03, fixed sibling), #2039 / PERF-D7-02, #2359 (Phase 2
+— which *will* need the bytes, so the fix should be a cache, not a narrower
+read).
+
+Suggested Fix: Either (a) add a bounded `Vec<u8>`/`Arc<[u8]>` hold keyed by
+archive+path so the Phase-2 parse and cross-cell rebuilds reuse it — the
+shape `csg_cache` next to it already uses — or (b) short-circuit discovery
+when the same (archive path, CDB path) pair was already registered this
+session.
+
+Source: `docs/audits/AUDIT_STARFIELD_2026-08-12.md` (finding `SF-D3-01`)
+
+---
+
+## #2706 — SF-2026-08-12-D3-02: Three doc comments cite a `MaterialProvider::sf_cdbs` `Arc` cache that does not exist, and the claim actively contradicts the code
+
+**Severity**: LOW · **Labels**: documentation, low
+**Location**: `byroredux/src/asset_provider/material.rs:280`, `:311`, `byroredux/src/app_step.rs:450`
+
+`csg_cache`'s field doc says it "mirrors the `sf_cdbs` `Arc` hold";
+`geometry_csg`'s doc repeats "mirrors the `sf_cdbs` `Arc` caching`;
+`app_step.rs`'s caching design note lists "`MaterialProvider::sf_cdbs`"
+among the caches discarded on rebuild. `grep -rn sf_cdbs byroredux/src/`
+returns only those three doc hits — the field was replaced by
+`sf_cdb_count: usize` and no CDB bytes are cached anywhere.
+
+Impact: Documentation-only, but the false claim is load-bearing in the
+wrong direction: a reader auditing provider-rebuild cost would conclude the
+CDB is already `Arc`-cached and stop, which is exactly how
+SF-2026-08-12-D3-01 stayed unnoticed.
+
+Suggested Fix: Reword all three to reference the real `csg_cache`
+precedent, or land the cache and make the comments true.
+
+Source: `docs/audits/AUDIT_STARFIELD_2026-08-12.md` (finding `SF-D3-02`)
+
+---
+
+## #2707 — SF-2026-08-12-D8-01: `classify_legacy_pbr` stamps a fabricated `Some(0.0)/Some(0.85)` PBR pair onto 97.9% of Starfield meshes from an input set that is empty by construction, permanently disabling the NaN-sentinel fallback
+
+**Severity**: MEDIUM · **Labels**: bug, nif-parser, medium, legacy-compat
+**Location**: `crates/nif/src/import/material/mod.rs:1194-1218` (`classify_legacy_pbr`), `:1269-1270` (the unconditional `Some(...)` write), `crates/core/src/ecs/components/material.rs:816-842` (`resolve_pbr`), `byroredux/src/asset_provider/material.rs:726-739` (the `.mat` early return)
+
+Status: NEW — distinct from #2359, which is about the *merge* forwarding
+nothing; this is about the *importer* asserting a resolved value it did not
+derive from anything.
+
+On a Starfield material-reference stub the walker returns at
+`dedicated_shader.rs:86` before writing a single `MaterialInfo` field, so
+`into_imported_material` calls `classify_legacy_pbr` on an all-defaults
+`MaterialInfo`: `texture_path = None` → `path = ""` (no keyword can match),
+`specular_authored = false`, `has_normal_map = false`, `has_gloss_map =
+false`, `env_map_scale = 0.0` (the `MaterialInfo::default`, `mod.rs:1061`,
+which fails the `> 0.3` arm). Every classifier arm falls through to the
+terminal `PbrMaterial { roughness: 0.85, metalness: 0.0 }`
+(`material.rs:757-759`). That constant is then written as
+`metalness_override: Some(0.0)`, `roughness_override: Some(0.85)` —
+indistinguishable downstream from an authored value.
+
+Evidence: 38,120 of 38,930 sampled Starfield meshes (97.9%) take this exact
+path. Because both overrides are `Some`, `translate_material` never seeds
+the NaN sentinel, so `Material::resolve_pbr`'s backstop (`material.rs:817`)
+is unreachable for Starfield.
+
+Impact: (a) Today: a single invented matte-dielectric constant on
+essentially all Starfield content, presented to the Disney BSDF lobe as
+resolved data. (b) After #2359 Phase 2 lands: any `.mat` the CDB index
+*misses* will silently keep the fabricated `0.0/0.85` instead of falling
+back to the sentinel. This is the NIFAL no-fabrication rule
+(`docs/engine/nifal.md`) applied at the boundary.
+
+Related: #2359, #2353, #2330.
+
+Suggested Fix: When `MaterialInfo` carries no authored signal at all (the
+stub-guard case), leave `metalness_override`/`roughness_override` as `None`
+so `translate_material` seeds the NaN sentinel and `resolve_pbr` owns the
+default — one code path for "unknown", instead of a fabricated `Some` that
+outranks Phase 2's own miss-detection.
+
+Source: `docs/audits/AUDIT_STARFIELD_2026-08-12.md` (finding `SF-D8-01`)
+
+---
+
+## #2708 — SF-2026-08-12-D9-02: The REFR-overlay material resolver is a second, parallel external-material path that knows only `.bgsm`/`.bgem`, so Starfield `.mat` overlays resolve to nothing even after CDB Phase 2 lands
+
+**Severity**: LOW · **Labels**: bug, import-pipeline, low
+**Location**: `byroredux/src/cell_loader/refr.rs:192-233` (`fill_from_bgsm`)
+
+`fill_from_bgsm` dispatches on `path.ends_with(".bgsm")` / `".bgem")` and
+returns silently for anything else. Its own doc says "No-op when the path
+isn't a `.bgsm` / `.bgem`", so the omission is deliberate — but it means the
+engine has **two** external-material resolvers with divergent format
+coverage: `merge_external_material` (BGSM + BGEM + a `.mat` arm) and this
+one (BGSM + BGEM only). A Starfield REFR whose XATO/MSWP supplies a `.mat`
+path gets the path propagated into `ov.material_path` (and thence onto the
+spawned material) but no role fills, and there is no place for a future CDB
+lookup to hook in on this side.
+
+Impact: Zero today — Starfield content resolves no textures from either
+path (#2359), and `.mat` overlays on vanilla Starfield REFRs are rare. It
+becomes a real, silent per-REFR divergence the moment #2359 Phase 2 lands
+and the two resolvers disagree about what a `.mat` yields.
+
+Related: #2359, #2594, SF-2026-08-12-D9-01.
+
+Suggested Fix: Note the format gap in the doc comment now, and route both
+resolvers through one shared "resolve external material → roles" helper
+when Phase 2 lands, rather than adding a second `.mat` arm here.
+
+Source: `docs/audits/AUDIT_STARFIELD_2026-08-12.md` (finding `SF-D9-02`)

--- a/byroredux/src/app_step.rs
+++ b/byroredux/src/app_step.rs
@@ -508,12 +508,21 @@ impl App {
     ///
     /// `build_texture_provider`/`build_material_provider` (called fresh
     /// here, and identically in [`crate::save_io::execute_pending_save_loads`])
-    /// discard the BGSM/BGEM template cache, `MaterialProvider::csg_cache`,
-    /// and `MaterialProvider::sf_cdbs` on every call — each rebuild
-    /// re-opens and re-parses the same BSA/BA2 archives the previous
-    /// provider already warmed. Fine for a single console-triggered
-    /// transition; becomes a real per-door cost once Stage 4 interactive
-    /// door activation ships (every door use pays the rebuild).
+    /// discard the BGSM/BGEM template cache and `MaterialProvider::csg_cache`
+    /// on every call — each rebuild re-opens and re-parses the same
+    /// BSA/BA2 archives the previous provider already warmed. Fine for a
+    /// single console-triggered transition; becomes a real per-door cost
+    /// once Stage 4 interactive door activation ships (every door use pays
+    /// the rebuild).
+    ///
+    /// #2706 (SF-D3-02) — this note previously also listed
+    /// `MaterialProvider::sf_cdbs` among the discarded caches; no such
+    /// field ever existed (`MaterialProvider::sf_cdb_count: usize` is
+    /// presence-only). The real Starfield CDB byte cache
+    /// (`asset_provider::material::sf_cdb_cache`, #2705) is deliberately
+    /// NOT provider-scoped — it lives at module scope precisely so it
+    /// keeps working across every rebuild this note describes, without
+    /// waiting on the whole-provider caching below.
     ///
     /// Not implemented yet — not urgent before Stage 4 — but the shape
     /// this should take when it lands:

--- a/byroredux/src/asset_provider/material.rs
+++ b/byroredux/src/asset_provider/material.rs
@@ -5,7 +5,7 @@ use byroredux_bgsm::{BgemFile, TemplateCache, TemplateResolver};
 use byroredux_nif::import::ImportedMaterial;
 use byroredux_sfmaterial::ComponentDatabaseFile;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// True for a Starfield component-database path — the base
 /// `materials\materialsbeta.cdb` or any DLC/Creation-namespaced
@@ -21,6 +21,25 @@ pub(crate) fn is_materialsbeta_cdb_path(path: &str) -> bool {
 /// PBR provenance signal.
 pub(crate) fn bgsm_uses_pbr_bsdf(resolved: &ResolvedMaterial) -> bool {
     resolved.walk().any(|step| step.file.pbr)
+}
+
+/// Process-lifetime cache of extracted Starfield CDB bytes, keyed by
+/// `"<archive source>|<in-archive path>"`. #2705 (SF-D3-01) —
+/// `build_material_provider` constructs a brand-new `MaterialProvider` (and
+/// therefore a brand-new, empty `csg_cache`-shaped per-instance cache) on
+/// every cell transition / save-load / debug-load, so caching *inside*
+/// `MaterialProvider` wouldn't help here: the same CDB would still get
+/// `archive.extract()`'d — a full zlib inflate of a multi-hundred-MB blob
+/// for the vanilla `materialsbeta.cdb` (105 MB measured) — on every single
+/// rebuild, even though `register_starfield_cdb` only reads the file's
+/// 16-byte header and on-disk content never changes mid-session. Living at
+/// module scope (outside `MaterialProvider`) lets this survive across
+/// provider rebuilds instead of being discarded with the provider — the
+/// same shape #2359 Phase 2's full CDB parse will also want to reuse
+/// (`Arc<[u8]>` so a clone is a refcount bump, not a copy).
+pub(super) fn sf_cdb_cache() -> &'static Mutex<HashMap<String, Arc<[u8]>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<[u8]>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Scan one archive for Starfield component databases and load each into
@@ -42,13 +61,41 @@ pub(crate) fn discover_starfield_cdbs(
         .map(|p| p.to_owned())
         .collect();
     for path in cdb_paths {
-        match archive.extract(&path) {
-            Ok(bytes) => {
-                log::info!("Discovered Starfield CDB '{path}' in '{source}'");
-                provider.register_starfield_cdb(&bytes);
+        let cache_key = format!("{source}|{path}");
+        let cached = sf_cdb_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&cache_key)
+            .cloned();
+        let bytes: Arc<[u8]> = match cached {
+            Some(bytes) => {
+                log::info!(
+                    "Discovered Starfield CDB '{path}' in '{source}' (cached, {} bytes, \
+                     skipped re-extract)",
+                    bytes.len()
+                );
+                bytes
             }
-            Err(e) => log::warn!("Failed to extract CDB '{path}' from '{source}': {e}"),
-        }
+            None => match archive.extract(&path) {
+                Ok(raw) => {
+                    log::info!(
+                        "Discovered Starfield CDB '{path}' in '{source}' ({} bytes, extracted)",
+                        raw.len()
+                    );
+                    let bytes: Arc<[u8]> = Arc::from(raw);
+                    sf_cdb_cache()
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .insert(cache_key, Arc::clone(&bytes));
+                    bytes
+                }
+                Err(e) => {
+                    log::warn!("Failed to extract CDB '{path}' from '{source}': {e}");
+                    continue;
+                }
+            },
+        };
+        provider.register_starfield_cdb(&bytes);
     }
 }
 
@@ -275,14 +322,26 @@ pub(crate) struct MaterialProvider {
     /// per-game material path (CANONICAL-BOUNDARY). Archive order is
     /// preserved in `self.archives`, so re-discovery reproduces load order.
     pub(crate) sf_cdb_count: usize,
-    /// #1585 / F6 — process-lifetime cache of the `<Plugin> - Geometry.csg`
-    /// companion blob, keyed by the cell's master plugin path. Mirrors the
-    /// `sf_cdbs` `Arc` hold: the CSG owns a warm zlib `ChunkCache`, so
-    /// re-opening it per precombine cell-load (the pre-fix behaviour)
-    /// re-read and re-parsed the ~3700-entry chunk table every tile and
-    /// discarded all inter-cell chunk reuse. The negative (`None`) result
-    /// is cached too, so a non-FO4 / no-CSG plugin isn't re-stat'd on
+    /// #1585 / F6 — per-`MaterialProvider`-instance cache of the
+    /// `<Plugin> - Geometry.csg` companion blob, keyed by the cell's master
+    /// plugin path. The CSG owns a warm zlib `ChunkCache`, so re-opening it
+    /// per precombine cell-load (the pre-fix behaviour) re-read and
+    /// re-parsed the ~3700-entry chunk table every tile and discarded all
+    /// inter-cell chunk reuse; this cache amortises that cost across every
+    /// tile loaded under the SAME provider build. The negative (`None`)
+    /// result is cached too, so a non-FO4 / no-CSG plugin isn't re-stat'd on
     /// every precombine cell.
+    ///
+    /// #2706 (SF-D3-02) — this field previously described itself as
+    /// "mirrors the `sf_cdbs` `Arc` hold"; no such field ever existed
+    /// (`sf_cdb_count: usize` below is presence-only). Unlike this field,
+    /// [`sf_cdb_cache`] (added by #2705) lives at module scope and is
+    /// genuinely process-lifetime — it survives across the provider
+    /// rebuilds that `build_material_provider` performs on every cell
+    /// transition / save-load / debug-load, whereas `csg_cache` here is
+    /// discarded along with the rest of `MaterialProvider` on every such
+    /// rebuild (see the #2039 / PERF-D7-02 caching design note in
+    /// `app_step.rs`) — the two are NOT lifetime-equivalent.
     pub(crate) csg_cache: HashMap<String, Option<Arc<byroredux_bsa::CsgArchive>>>,
 }
 
@@ -307,12 +366,19 @@ impl MaterialProvider {
     }
 
     /// Resolve + open the `<Plugin> - Geometry.csg` companion blob once per
-    /// session (keyed by `plugin_path`) and hand back a shared handle.
-    /// #1585 / F6 — mirrors the `sf_cdbs` `Arc` caching: precombine cell-loads
-    /// re-opened this ~240 MB blob every tile, re-parsing the chunk table and
-    /// throwing away the warm zlib `ChunkCache` that amortises inflate across
-    /// adjacent tiles sharing PSG regions. The negative result is cached so a
-    /// plugin with no companion CSG isn't re-probed per cell.
+    /// PROVIDER BUILD (keyed by `plugin_path`) and hand back a shared handle
+    /// — NOT once per session; `self.csg_cache` is discarded along with the
+    /// rest of `MaterialProvider` on every `build_material_provider` rebuild
+    /// (#2706 / SF-D3-02 corrected the prior "mirrors the `sf_cdbs` `Arc`
+    /// caching" claim here — no such field exists; the real process-lifetime
+    /// CDB cache is [`sf_cdb_cache`], added by #2705, which lives at module
+    /// scope specifically because it needs to outlive provider rebuilds).
+    /// #1585 / F6 — precombine cell-loads re-opened this ~240 MB blob every
+    /// tile, re-parsing the chunk table and throwing away the warm zlib
+    /// `ChunkCache` that amortises inflate across adjacent tiles sharing PSG
+    /// regions; this cache fixes that WITHIN one provider build. The
+    /// negative result is cached too, so a plugin with no companion CSG
+    /// isn't re-probed per cell.
     pub(crate) fn geometry_csg(
         &mut self,
         plugin_path: &str,
@@ -729,12 +795,32 @@ pub(crate) fn merge_external_material(
         // spec-glossiness translation (FO4-specific format convention).
         // Starfield .mat authors metalness/roughness directly, but this
         // `.mat` arm returns early without touching them — NIF import
-        // (`bs_geometry.rs`) already set `metalness_override`/
-        // `roughness_override` to `Some(classify_legacy_pbr(...))` before
-        // this function ever runs, so the NaN-sentinel path in
-        // `Material::resolve_pbr` never fires for Starfield content.
-        // Phase 2 must *overwrite* those `Some` values with CDB-authored
-        // ones rather than relying on that unreachable fallback.
+        // (`bs_geometry.rs` / `bs_tri_shape.rs` /
+        // `import::material::classify_legacy_pbr`) already ran the
+        // keyword classifier on `metalness_override`/`roughness_override`
+        // before this function ever runs.
+        //
+        // #2707 (SF-D8-01) fixed what those overrides actually are for
+        // the DOMINANT Starfield case (a `material_reference` stub — 97.9%
+        // of sampled meshes): pre-fix, `classify_legacy_pbr` ran on an
+        // all-defaults `MaterialInfo` (the walker returns before writing
+        // any field for a stub) and unconditionally stamped its terminal
+        // `Some(0.0)/Some(0.85)` fallback anyway, permanently disabling
+        // `Material::resolve_pbr`'s NaN-sentinel backstop. Post-fix, a
+        // stub with no classifier signal at all leaves both overrides
+        // `None`, so the NaN sentinel DOES reach `resolve_pbr` — which
+        // re-runs the same classifier against whatever real texture /
+        // normal-map / env-map-scale data has been merged in BY THEN
+        // (this function's own BGSM/BGEM/`.mat` resolution included),
+        // rather than the empty snapshot the importer saw. Non-stub
+        // Starfield meshes (inline shader data present) still arrive with
+        // real `Some(...)` overrides, unchanged.
+        //
+        // Phase 2 (CDB per-field extraction) should still *overwrite*
+        // whichever value is present here with CDB-authored data when a
+        // lookup succeeds; a lookup MISS now correctly falls through to
+        // the sentinel/classifier fallback instead of silently keeping a
+        // fabricated constant.
         return true;
     }
 

--- a/byroredux/src/asset_provider/tests/starfield_mat.rs
+++ b/byroredux/src/asset_provider/tests/starfield_mat.rs
@@ -190,6 +190,56 @@ fn unresolved_material_warning_generic_for_non_mat_path() {
     assert!(!msg.contains("CDB"));
 }
 
+/// #2705 (SF-D3-01) — `sf_cdb_cache()` is the process-lifetime cache that
+/// lets `discover_starfield_cdbs` skip the ~105 MB zlib inflate on the
+/// second and later `build_material_provider` rebuild for the same
+/// (archive source, CDB path) pair. Exercises the cache primitive directly,
+/// in the same spirit as this file's other `register_starfield_cdb`-direct
+/// tests that bypass `Archive` entirely (the `bsa` crate has no synthetic
+/// in-memory BA2 fixture builder to drive `discover_starfield_cdbs`'s own
+/// `archive.list_files()` / `archive.extract()` calls end-to-end).
+#[test]
+fn sf_cdb_cache_returns_the_same_bytes_for_a_repeated_key_and_misses_a_different_one() {
+    let key = "sf_cdb_cache_test_key_2705_unique_marker".to_string();
+    let other_key = "sf_cdb_cache_test_key_2705_never_inserted".to_string();
+    let bytes: std::sync::Arc<[u8]> = std::sync::Arc::from(minimal_cdb_bytes());
+
+    assert!(
+        sf_cdb_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&key)
+            .is_none(),
+        "fresh key must miss before any insert"
+    );
+
+    sf_cdb_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(key.clone(), std::sync::Arc::clone(&bytes));
+
+    let cached = sf_cdb_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&key)
+        .cloned();
+    assert_eq!(
+        cached.as_deref(),
+        Some(bytes.as_ref()),
+        "a cached key must return the same bytes — this is what lets \
+         `discover_starfield_cdbs` skip re-extracting on a provider rebuild"
+    );
+
+    assert!(
+        sf_cdb_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&other_key)
+            .is_none(),
+        "a different (archive, path) key must still miss"
+    );
+}
+
 /// A `.bgsm` path must NOT enter the Starfield arm even when the
 /// CDB is loaded — the FO4 BGSM dispatch wins, preserving
 /// spec-glossiness translation.

--- a/byroredux/src/cell_loader/refr.rs
+++ b/byroredux/src/cell_loader/refr.rs
@@ -189,6 +189,23 @@ impl RefrTextureOverlay {
     /// first-wins policy so REFR overlays and per-mesh imports agree on
     /// precedence for MNAM-only TXSTs. No-op when the path isn't a
     /// `.bgsm` / `.bgem` or the provider can't resolve it.
+    ///
+    /// #2708 (SF-D9-02) — this is a SECOND, parallel external-material
+    /// resolver alongside `asset_provider::merge_external_material`, and
+    /// the two have diverged in format coverage: `merge_external_material`
+    /// also has a Starfield `.mat` arm (`is_pbr`-only today, pending #2359
+    /// Phase 2), this one does not. A Starfield REFR whose XATO/MSWP
+    /// supplies a `.mat` path falls through both branches here as a silent
+    /// no-op — the path still reaches `ov.material_path` (and thence the
+    /// spawned material) via the caller, but no role fills happen and
+    /// there is no per-role hook for a future CDB lookup. Harmless today
+    /// (Starfield content resolves no textures from either resolver, and
+    /// `.mat` overlays on vanilla Starfield REFRs are rare) but becomes a
+    /// real, silent divergence between the two resolvers the moment Phase
+    /// 2 gives `merge_external_material`'s `.mat` arm real per-role data.
+    /// Do NOT add a second one-off `.mat` arm here when that lands — route
+    /// both resolvers through one shared "resolve external material →
+    /// roles" helper instead.
     fn fill_from_bgsm(&mut self, provider: &mut MaterialProvider, pool: &mut StringPool) {
         let Some(path_sym) = self.material_path else {
             return;

--- a/crates/nif/src/import/material/legacy_pbr_translation_tests.rs
+++ b/crates/nif/src/import/material/legacy_pbr_translation_tests.rs
@@ -157,3 +157,65 @@ fn classifier_effect_shader_arm_shape_does_not_chrome() {
         "must stay above the RT reflection gate"
     );
 }
+
+// #2707 (SF-D8-01) — `into_imported_material` must leave
+// `metalness_override`/`roughness_override` as `None` (deferring to
+// `Material::resolve_pbr`'s NaN-sentinel backstop) rather than stamping
+// the classifier's terminal fallback as a fabricated `Some(...)`, when
+// `MaterialInfo` carries no PBR classifier signal at all — exactly the
+// state a Starfield material-reference stub is left in (the walker
+// returns before writing a single field). Any real signal, however
+// partial, must still stamp `Some(...)` unchanged from before this fix.
+
+#[test]
+fn has_no_pbr_classifier_signal_is_true_on_an_untouched_material_info() {
+    let info = MaterialInfo::default();
+    assert!(
+        info.has_no_pbr_classifier_signal(),
+        "a completely untouched MaterialInfo (the Starfield stub case) \
+         must report no classifier signal"
+    );
+}
+
+#[test]
+fn has_no_pbr_classifier_signal_is_false_once_any_signal_is_present() {
+    let mut pool = StringPool::new();
+    // Just a texture path — the FO3/FNV BSShaderPPLightingProperty-only
+    // shape, which never sets `has_material_data` (#2457) but DOES carry
+    // a real signal the classifier can use.
+    let mut info = MaterialInfo::default();
+    info.texture_path = Some(pool.intern("textures/clutter/barrel/barrel01.dds"));
+    assert!(
+        !info.has_no_pbr_classifier_signal(),
+        "a real texture path is a classifier signal even without has_material_data"
+    );
+}
+
+#[test]
+fn into_imported_material_leaves_overrides_none_for_an_empty_stub() {
+    let mut pool = StringPool::new();
+    let info = MaterialInfo::default();
+    let imported = info.into_imported_material(&mut pool, None);
+    assert_eq!(
+        imported.metalness_override, None,
+        "an empty stub must leave metalness_override unset so \
+         Material::resolve_pbr's NaN-sentinel backstop can classify \
+         from whatever real data merges in later, instead of a value \
+         fabricated from an input set that was empty by construction"
+    );
+    assert_eq!(imported.roughness_override, None);
+}
+
+#[test]
+fn into_imported_material_keeps_overrides_some_when_any_signal_present() {
+    let mut pool = StringPool::new();
+    let mut info = MaterialInfo::default();
+    info.texture_path = Some(pool.intern(r"Textures\Weapons\Iron\IronSword.dds"));
+    let imported = info.into_imported_material(&mut pool, None);
+    assert!(
+        imported.metalness_override.is_some(),
+        "real classifier signal (even partial) must still stamp Some(...), \
+         unchanged from before this fix"
+    );
+    assert!(imported.roughness_override.is_some());
+}

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -1231,6 +1231,36 @@ impl MaterialInfo {
         )
     }
 
+    /// #2707 (SF-D8-01) — true when every one of the five signals
+    /// [`Self::classify_legacy_pbr`]'s classifier reads is absent: no
+    /// texture path (so no keyword can match), no authored specular, no
+    /// normal map, no gloss map, and `env_map_scale` at or below
+    /// `classify_pbr_keyword`'s own `> 0.3` gate. This is exactly the
+    /// state a Starfield material-reference stub is left in — the walker
+    /// returns at `dedicated_shader.rs` (`apply_bs_lighting_shader` /
+    /// `apply_bs_effect_shader`) before writing a single `MaterialInfo`
+    /// field when `shader.material_reference` is set — so every
+    /// classifier arm falls through to the terminal
+    /// `PbrMaterial { roughness: 0.85, metalness: 0.0 }` for a reason
+    /// indistinguishable from "nothing was ever parsed," not because any
+    /// of those five inputs was genuinely authored-and-absent.
+    ///
+    /// Deliberately NOT `!self.has_material_data`: that flag is set only
+    /// by the dedicated-shader / legacy `NiMaterialProperty` arms and
+    /// exists to resolve walker-arm PRECEDENCE (#2457), not to detect
+    /// "no signal at all" — the FO3/FNV `BSShaderPPLightingProperty`-only
+    /// path (common, texture-bound content with a real `texture_path`)
+    /// never sets `has_material_data`, so gating on it here would ALSO
+    /// suppress a real, meaningfully-derived classification for ordinary
+    /// legacy content, not just the empty Starfield stub this targets.
+    pub(super) fn has_no_pbr_classifier_signal(&self) -> bool {
+        self.texture_path.is_none()
+            && !self.specular_authored
+            && self.normal_map.is_none()
+            && self.gloss_map.is_none()
+            && self.env_map_scale <= 0.3
+    }
+
     /// Project this `MaterialInfo`'s shader-type fields into the core-owned
     /// `ShaderTypeFields` bundle carried by `ImportedMaterial`. See #430.
     pub(super) fn shader_type_fields(&self) -> ShaderTypeFields {
@@ -1259,6 +1289,9 @@ impl MaterialInfo {
         mesh_name: Option<&str>,
     ) -> super::types::ImportedMaterial {
         let legacy_pbr = self.classify_legacy_pbr(pool);
+        // #2707 (SF-D8-01) — must be read before any field it inspects is
+        // moved out of `self` below.
+        let no_pbr_signal = self.has_no_pbr_classifier_signal();
         let has_alpha = self.effective_alpha_blend(mesh_name, pool);
         let textures = self.texture_set(pool);
         let shader_type_fields = self.shader_type_fields();
@@ -1280,8 +1313,16 @@ impl MaterialInfo {
             from_bgsm: false,
             bgem_glass: false,
             thin_glass: false,
-            metalness_override: Some(legacy_pbr.metalness),
-            roughness_override: Some(legacy_pbr.roughness),
+            // #2707 (SF-D8-01) — `None` when `classify_legacy_pbr` had
+            // literally no signal to classify from (the Starfield
+            // material-reference stub case), so `translate_material` seeds
+            // the NaN sentinel and `Material::resolve_pbr`'s backstop
+            // classifier owns the fallback instead of this importer
+            // fabricating one from an empty input set. Every other case —
+            // any real signal present, however partial — keeps its
+            // derived `Some(...)`, unchanged from before.
+            metalness_override: (!no_pbr_signal).then_some(legacy_pbr.metalness),
+            roughness_override: (!no_pbr_signal).then_some(legacy_pbr.roughness),
             translucency_subsurface_color: [0.0; 3],
             translucency_transmissive_scale: 0.0,
             translucency_turbulence: 0.0,


### PR DESCRIPTION
… sf_cdbs docs, stop fabricating PBR overrides on empty material stubs, note REFR resolver format gap

SF-D3-01 (#2705): discover_starfield_cdbs called archive.extract() on every Starfield materialsbeta.cdb for every build_material_provider call (boot, every cell/door transition, save-load, debug-load) even though register_starfield_cdb only reads a 16-byte header. The vanilla CDB extracts to ~105 MB, so every rebuild paid a full zlib inflate for a presence bit. Added a process-lifetime cache (module-scope OnceLock<Mutex<HashMap<String, Arc<[u8]>>>>, keyed by archive source + in-archive path) so only the FIRST discovery of a given CDB pays the inflate; every subsequent provider rebuild this session reuses the cached Arc. Deliberately NOT cached inside MaterialProvider itself — that struct (and its existing csg_cache) is discarded and rebuilt from scratch on every single build_material_provider call, so an in-struct cache would never survive to the second rebuild. Sets up the byte hold #2359 Phase 2's full CDB parse will also want. Added a regression test exercising the cache primitive directly (register_starfield_cdb is already tested the same way, bypassing Archive — the bsa crate has no synthetic in-memory BA2 fixture builder to drive discovery end-to-end).

SF-D3-02 (#2706): three doc comments (MaterialProvider::csg_cache, MaterialProvider::geometry_csg, and app_step.rs's #2039 caching design note) claimed csg_cache "mirrors the sf_cdbs Arc hold/caching" — no such field ever existed (sf_cdb_count: usize is presence-only), and the false claim is exactly what let SF-D3-01 stay unnoticed: a reader auditing provider-rebuild cost would see "already cached" and stop looking. Corrected all three to describe what's actually there, and to point at the real process-lifetime cache #2705 added instead.

SF-D8-01 (#2707): on a Starfield material-reference stub the walker returns before writing a single MaterialInfo field, so classify_legacy_pbr ran its keyword classifier against an all-defaults input and — same as any unknown/no-signal input — landed on the terminal PbrMaterial { roughness: 0.85, metalness: 0.0 } fallback. into_imported_material then stamped that as
metalness_override/roughness_override: Some(...) unconditionally, indistinguishable downstream from a real classification. Because both overrides arrived non-NaN, Material::resolve_pbr's NaN-sentinel backstop never fired for Starfield content (97.9% of sampled meshes take this exact path) — permanently disabling the one mechanism that could let a LATER classification (once real texture/normal-map/ env-map-scale data has merged in from BGSM/BGEM/.mat resolution) win over the importer's uninformed snapshot.

Added MaterialInfo::has_no_pbr_classifier_signal(), checking the exact five inputs the classifier reads (texture_path, specular_authored, normal_map, gloss_map, env_map_scale) — deliberately NOT has_material_data, which is set only by the dedicated-shader/ NiMaterialProperty arms for walker-precedence purposes (#2457) and would also suppress real classifications for ordinary FO3/FNV BSShaderPPLightingProperty-only content that never touches that flag. into_imported_material now leaves both overrides None when no signal is present at all, so translate_material seeds the NaN sentinel and resolve_pbr's backstop re-runs the classifier later against whatever real data has merged in by then. Any real signal, however partial, still stamps Some(...) exactly as before. Updated the now-stale merge_external_material .mat-arm comment that described the old "NaN-sentinel path never fires for Starfield" behavior as a benign fact. Added regression tests for both the new predicate and the end-to-end None/Some split.

SF-D9-02 (#2708): cell_loader::refr's fill_from_bgsm is a second, parallel external-material resolver alongside
merge_external_material, and the two have diverged in format coverage — merge_external_material also resolves a Starfield .mat arm, this one only knows .bgsm/.bgem. Harmless today (Starfield content resolves no textures from either path), but becomes a silent per-REFR divergence the moment #2359 Phase 2 gives the .mat arm real per-role data. Documented the gap and the intended fix shape (route both resolvers through one shared helper, not a second one-off .mat arm here) rather than adding partial coverage now.