### PR TITLE
Fix #2589 #2590 #2591: Skyrim BSLSP zeroed FO4-only fields, stale par…

### DIFF
--- a/.claude/issues/2588 2589 2590 2591/ISSUE.md
+++ b/.claude/issues/2588 2589 2590 2591/ISSUE.md
@@ -1,0 +1,110 @@
+# Batch: #2588 #2589 #2590 #2591
+
+## #2588 — SK-D6-03: BSTreeNode wind-bone lists are imported but have no consumer outside the NIF crate
+
+**Severity**: LOW · **Status**: NEW (informational — forward scope)
+**Location**: `crates/nif/src/import/walk/mod.rs:1589-1600`; `import/types.rs:161`
+
+`BSTreeNode`'s two trailing `NiNode` ref lists (SpeedTree wind rig) are
+parsed correctly and surfaced onto `ImportedNode.tree_bones` by both
+walkers, but nothing outside `crates/nif`/`crates/spt` reads the field.
+
+Impact: None today (Skyrim trees render static). Recorded so the
+parse-vs-consume gap is on record rather than rediscovered as "the
+parser drops it."
+
+Suggested Fix: None required now — ready hook for when SpeedTree wind
+lands.
+
+Completeness Checks: TESTS N/A — forward-scope note, no action required.
+
+---
+
+## #2589 — SKY-D7-01: Skyrim's parser arm zeroes two FO4-only BSLSP scalars, and the importer copies them un-gated -- canonical Material.fresnel_power is 0.0 instead of 5.0
+
+**Severity**: MEDIUM
+**Location**: producer `crates/nif/src/blocks/shader.rs:938-939` (`parse_skyrim`); un-gated copy `dedicated_shader.rs:321-322`; neutral defaults `import/material/mod.rs:1033-1034`, `import/types.rs:562,565`, `crates/core/src/ecs/components/material.rs:408`; boundary `byroredux/src/material_translate.rs:200`
+
+`grayscale_to_palette_scale`/`fresnel_power` are FO4+ wire fields
+(BSVER ≥ 130); every default site in the pipeline agrees on the
+neutral fallback (`1.0`/`5.0`) **except** `parse_skyrim`, which
+constructs the block with literal `0.0`/`0.0` for fields Skyrim never
+serializes. `apply_bs_lighting_shader` copies both unconditionally
+with no BSVER gate, so the Skyrim-arm `0.0` survives
+`into_imported_material` and lands in canonical
+`Material.fresnel_power = 0.0` for essentially all lit Skyrim
+geometry — while Oblivion/FO3/FNV (no BSLSP) keep `5.0` and FO4+ get
+their authored value.
+
+Evidence: `shader.rs:938-939` — `grayscale_to_palette_scale: 0.0,
+fresnel_power: 0.0,` inside `parse_skyrim`; `dedicated_shader.rs:321-322`
+— unconditional copy. The guard test
+`material_info_default_matches_bslsp_parser_stub_defaults` only
+compares `MaterialInfo::default()` against the FO76+ stopcond stub,
+never against `parse_skyrim`.
+
+Impact: Latent today (no GPU consumer for `fresnel_power` yet). The
+moment a `triangle.frag` consumer lands (#2284 follow-up), Skyrim gets
+Schlick exponent 0.0 → full Fresnel at every angle, uniform
+edge-bright/washed shading vs correct FO4 rendering.
+
+Related: #2284, #1241, SKY-D7-02.
+
+Suggested Fix: Make `parse_skyrim` construct both fields with the same
+neutral literals every other default site uses (`1.0`/`5.0`).
+Extend the guard test to assert the invariant against all three parser
+arms.
+
+---
+
+## #2590 — SKY-D7-02: MaterialInfo default docs cite a BSLSP parser stub default that the Skyrim parser arm contradicts, at line numbers stale since the #1279 parser split
+
+**Severity**: LOW
+**Location**: `import/material/mod.rs:588-598,1029-1031`; `lighting_shader_pbr_tests.rs:205-209`
+
+Three sites anchor the neutral-default doc to specific `shader.rs`
+line numbers that, since the #1279 three-arm parser split, land in
+unrelated code (the `starfield_tail` doc, not the stub). The docs also
+assert a single "parser stub default" exists when there are two
+disagreeing ones (`material_reference_stub` = `1.0/5.0`,
+`parse_skyrim` = `0.0/0.0`).
+
+Impact: A reader following these anchors lands in unrelated code and
+concludes the default contract is upheld — the documentation half of
+why SKY-D7-01 went unnoticed.
+
+Related: SKY-D7-01.
+
+Suggested Fix: Anchor to the function name, not a line number; state
+plainly which parser arms honour the neutral default.
+
+---
+
+## #2591 — SKY-D7-03: EmissiveSource::None's documented contract is contradicted by the unconditional Lighting tag -- on Skyrim the discriminator degenerates to "has a BSLightingShaderProperty"
+
+**Severity**: LOW
+**Location**: contract `crates/core/src/ecs/components/material.rs:452-457`; Skyrim set-site `dedicated_shader.rs:298-300`
+
+`apply_bs_lighting_shader` sets `EmissiveSource::Lighting`
+unconditionally regardless of whether `emissive_color`/
+`emissive_multiple` are actually non-zero. Vanilla Skyrim ships the
+overwhelming majority of BSLSP blocks with an unauthored `[0,0,0]`/
+`1.0` emissive, all tagged `Lighting` anyway — the discriminator
+carries no emissive-authoring information on Skyrim, contrary to its
+own doc's parenthetical.
+
+Evidence: `dedicated_shader.rs:298-300` — set with no check on the
+emissive values.
+
+Impact: None at runtime today (no `GpuMaterial` field, no shader
+branch reads it yet). Cost is that the #1280 discriminator doesn't yet
+answer the question its doc promises.
+
+Related: #1280, #166.
+
+Suggested Fix: Either amend the doc to describe actual behavior, or
+gate the three set-sites on a non-zero emissive contribution.
+
+Completeness Checks: If gated, a regression test confirms
+`EmissiveSource::Lighting` is only set for non-zero emissive
+authoring.

--- a/crates/core/src/ecs/components/material.rs
+++ b/crates/core/src/ecs/components/material.rs
@@ -509,9 +509,30 @@ pub enum EmissiveSource {
     /// effect-shader path reads its visible "glow" from
     /// `base_color * base_color_scale`. A future BSEffect-proper render
     /// path should branch on this variant to drop the conflation; see
-    /// the walker site (`import/material/walker.rs`) for the
+    /// the set-site (`import/material/dedicated_shader.rs`) for the
     /// in-source #166 rename note.
     Effect,
+}
+
+/// Whether a captured `(color, multiplier)` pair is a genuine emissive
+/// (or, for [`EmissiveSource::Effect`], diffuse-tint) authoring —
+/// versus the unauthored struct default the source NIF block ships
+/// when nothing was actually set. Shared by all three
+/// `EmissiveSource::{Material,Lighting,Effect}` set-sites (#2591 /
+/// SKY-D7-03) so `EmissiveSource::None`'s own doc — "materials without
+/// any of the three shader-property classes **or** where none of them
+/// authored a non-zero emissive" — is actually true. Pre-fix, every
+/// BSLightingShaderProperty (the overwhelming majority of vanilla
+/// Skyrim content, almost none of which authors emissive) was tagged
+/// `Lighting` regardless, degenerating the discriminator to "has a
+/// BSLightingShaderProperty" rather than "has an authored emissive".
+///
+/// `color == [0,0,0]` alone zeroes the contribution regardless of
+/// `mult` (black times anything is still black); `mult == 0.0` alone
+/// zeroes it regardless of `color`. Either is sufficient for "not
+/// authored" — both must be non-zero for "authored".
+pub fn emissive_contribution_is_authored(color: [f32; 3], mult: f32) -> bool {
+    color != [0.0, 0.0, 0.0] && mult != 0.0
 }
 
 /// Free-form inputs to the keyword-based PBR classifier. Decoupled
@@ -1483,5 +1504,24 @@ mod tests {
         m.resolve_pbr();
         assert_eq!(m.metalness, 1.0);
         assert_eq!(m.roughness, 0.04);
+    }
+
+    /// #2591 (SKY-D7-03) — either a black color or a zero multiplier
+    /// alone is sufficient to mark a contribution unauthored; both must
+    /// be non-zero for "authored".
+    #[test]
+    fn emissive_contribution_is_authored_requires_both_nonzero_color_and_mult() {
+        assert!(emissive_contribution_is_authored([0.5, 0.5, 0.5], 1.25));
+        assert!(
+            !emissive_contribution_is_authored([0.0, 0.0, 0.0], 1.0),
+            "black color contributes nothing regardless of the multiplier"
+        );
+        assert!(
+            !emissive_contribution_is_authored([0.5, 0.5, 0.5], 0.0),
+            "a zero multiplier contributes nothing regardless of the color"
+        );
+        assert!(!emissive_contribution_is_authored([0.0, 0.0, 0.0], 0.0));
+        // Partial-channel authoring still counts.
+        assert!(emissive_contribution_is_authored([0.0, 0.2, 0.0], 1.0));
     }
 }

--- a/crates/nif/src/blocks/shader.rs
+++ b/crates/nif/src/blocks/shader.rs
@@ -880,6 +880,10 @@ impl BSLightingShaderProperty {
     /// - `lighting_effect_1/2` present (Skyrim-only fields).
     /// - No `root_material_path`, no wetness, no FO4 subsurface block,
     ///   no FO76 luminance/translucency/texture-arrays.
+    /// - No `grayscale_to_palette_scale` / `fresnel_power` (BSVER >= 130
+    ///   only) — constructed below at the neutral no-modulation defaults
+    ///   (`1.0` / `5.0`), matching `material_reference_stub` and
+    ///   `MaterialInfo::default()`. See #2589.
     /// - `glossiness` stays raw (0-100 scale authored).
     /// - Shader-type-data dispatches through the legacy `BSLightingShaderType` enum.
     fn parse_skyrim(stream: &mut NifStream, _bsver: u32) -> io::Result<Self> {
@@ -935,8 +939,21 @@ impl BSLightingShaderProperty {
             subsurface_rolloff: 0.0,
             rimlight_power: 0.0,
             backlight_power: 0.0,
-            grayscale_to_palette_scale: 0.0,
-            fresnel_power: 0.0,
+            // #2589 (SKY-D7-01) — `grayscale_to_palette_scale` /
+            // `fresnel_power` are FO4+ wire fields (BSVER >= 130) that
+            // Skyrim never serializes, so this arm has no authored value
+            // to read — same situation as every other unauthored field
+            // above. The neutral no-modulation defaults every OTHER
+            // no-value site in the pipeline agrees on are `1.0` / `5.0`
+            // (see `BSLightingShaderProperty::material_reference_stub`
+            // and `MaterialInfo::default()`), NOT `0.0`. `0.0` here
+            // silently survived `apply_bs_lighting_shader`'s unconditional
+            // copy into canonical `Material.fresnel_power`, producing a
+            // full-strength (`pow(1-cosθ,0)==1`) Fresnel term at every
+            // view angle the moment a shading consumer reads it — latent
+            // only because no consumer exists yet (#2284 follow-up).
+            grayscale_to_palette_scale: 1.0,
+            fresnel_power: 5.0,
             wetness: None,
             luminance: None,
             do_translucency: false,

--- a/crates/nif/src/blocks/shader_tests/skyrim.rs
+++ b/crates/nif/src/blocks/shader_tests/skyrim.rs
@@ -17,6 +17,32 @@ fn parse_bs_lighting_default_no_trailing() {
     assert_eq!(stream.position(), data.len() as u64);
 }
 
+/// Regression for #2589 (SKY-D7-01) — `grayscale_to_palette_scale` /
+/// `fresnel_power` are FO4+ wire fields Skyrim never serializes, so
+/// `parse_skyrim` has no authored value to construct them from. It must
+/// land on the same neutral no-modulation defaults every other no-value
+/// site in the pipeline agrees on (`1.0` / `5.0` —
+/// `BSLightingShaderProperty::material_reference_stub`,
+/// `MaterialInfo::default()`), not `0.0`/`0.0`. Pre-fix, the `0.0`
+/// literal survived `apply_bs_lighting_shader`'s unconditional copy all
+/// the way to canonical `Material.fresnel_power`.
+#[test]
+fn parse_bs_lighting_skyrim_arm_uses_neutral_fo4_field_defaults() {
+    let header = make_skyrim_header();
+    let data = build_bs_lighting_common(0); // shader_type=0 (Default)
+    let mut stream = NifStream::new(&data, &header);
+
+    let prop = BSLightingShaderProperty::parse(&mut stream).unwrap();
+    assert_eq!(
+        prop.grayscale_to_palette_scale, 1.0,
+        "grayscale_to_palette_scale must default to 1.0 (no modulation), not 0.0"
+    );
+    assert_eq!(
+        prop.fresnel_power, 5.0,
+        "fresnel_power must default to 5.0 (standard Schlick exponent), not 0.0"
+    );
+}
+
 #[test]
 fn parse_bs_lighting_env_map_trailing() {
     let header = make_skyrim_header();

--- a/crates/nif/src/import/material/dedicated_shader.rs
+++ b/crates/nif/src/import/material/dedicated_shader.rs
@@ -402,7 +402,20 @@ fn apply_bs_lighting_shader(
         // Capture rich material data.
         info.emissive_color = shader.emissive_color;
         info.emissive_mult = shader.emissive_multiple;
-        info.emissive_source = byroredux_core::ecs::components::material::EmissiveSource::Lighting;
+        // #2591 (SKY-D7-03) — only tag `Lighting` when this BSLSP actually
+        // authored a non-zero emissive. Vanilla Skyrim ships the vast
+        // majority of BSLightingShaderProperty blocks with the unauthored
+        // `[0,0,0]` / `1.0` default; tagging those `Lighting` anyway
+        // degenerated the discriminator to "has a BSLightingShaderProperty"
+        // rather than "has an authored emissive", contradicting
+        // `EmissiveSource::None`'s own doc.
+        if byroredux_core::ecs::components::material::emissive_contribution_is_authored(
+            shader.emissive_color,
+            shader.emissive_multiple,
+        ) {
+            info.emissive_source =
+                byroredux_core::ecs::components::material::EmissiveSource::Lighting;
+        }
         info.specular_color = shader.specular_color;
         info.specular_authored = true;
         info.specular_strength = shader.specular_strength;
@@ -525,8 +538,15 @@ fn apply_bs_effect_shader(
             // #1280 step 4 — tag the BSEffect source. Semantic is
             // diffuse-tint scale (per #166), not emissive; the
             // discriminator lets a future render path distinguish.
-            info.emissive_source =
-                byroredux_core::ecs::components::material::EmissiveSource::Effect;
+            // #2591 (SKY-D7-03) — gated on non-zero authoring, same as
+            // the BSLightingShaderProperty site above.
+            if byroredux_core::ecs::components::material::emissive_contribution_is_authored(
+                info.emissive_color,
+                info.emissive_mult,
+            ) {
+                info.emissive_source =
+                    byroredux_core::ecs::components::material::EmissiveSource::Effect;
+            }
             info.uv_offset = shader.uv_offset;
             info.uv_scale = shader.uv_scale;
             info.has_uv_transform = true;

--- a/crates/nif/src/import/material/emissive_source_tests.rs
+++ b/crates/nif/src/import/material/emissive_source_tests.rs
@@ -278,3 +278,83 @@ fn default_material_info_has_none_source() {
     let info = MaterialInfo::default();
     assert_eq!(info.emissive_source, EmissiveSource::None);
 }
+
+// #2591 (SKY-D7-03) — `EmissiveSource::None`'s own doc says materials
+// land there "without any of the three shader-property classes OR
+// where none of them authored a non-zero emissive". Pre-fix, all three
+// set-sites tagged their variant unconditionally, degenerating the
+// discriminator on Skyrim (where the overwhelming majority of
+// BSLightingShaderProperty blocks ship the unauthored `[0,0,0]`/`1.0`
+// default) to "has a BSLightingShaderProperty" rather than "has an
+// authored emissive". These three tests are the zero-authoring
+// counterpart of the three "must tag X" tests above — same fixtures,
+// with the emissive fields zeroed instead of the "distinctive
+// non-default" values those use.
+
+#[test]
+fn bslighting_unauthored_emissive_stays_none() {
+    let mut shader = minimal_bslighting();
+    shader.emissive_color = [0.0, 0.0, 0.0];
+    shader.emissive_multiple = 1.0; // BSLSP's own unauthored wire default
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(shader)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = tri_shape_with_shader_ref(0);
+    let mut pool = StringPool::new();
+    let info = extract_material_info(&scene, &shape, &[], &mut pool);
+    assert_eq!(
+        info.emissive_source,
+        EmissiveSource::None,
+        "an unauthored (black) BSLightingShaderProperty emissive must not \
+         be tagged Lighting — the color contributes nothing regardless of \
+         the multiplier"
+    );
+}
+
+#[test]
+fn bseffect_unauthored_emissive_stays_none() {
+    let mut shader = minimal_bseffect();
+    shader.base_color = [0.0, 0.0, 0.0, 1.0];
+    shader.base_color_scale = 0.0;
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(shader)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = tri_shape_with_shader_ref(0);
+    let mut pool = StringPool::new();
+    let info = extract_material_info(&scene, &shape, &[], &mut pool);
+    assert_eq!(
+        info.emissive_source,
+        EmissiveSource::None,
+        "an unauthored (zero-scale) BSEffectShaderProperty diffuse-tint \
+         must not be tagged Effect"
+    );
+}
+
+#[test]
+fn nimaterial_unauthored_emissive_stays_none() {
+    let mut mat = minimal_nimaterial();
+    mat.emissive = NiColor {
+        r: 0.0,
+        g: 0.0,
+        b: 0.0,
+    };
+    mat.emissive_mult = 1.0;
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(mat)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = tri_shape_with_property_list(&[0]);
+    let mut pool = StringPool::new();
+    let info = extract_material_info(&scene, &shape, &[], &mut pool);
+    assert_eq!(
+        info.emissive_source,
+        EmissiveSource::None,
+        "an unauthored (black) NiMaterialProperty emissive must not be \
+         tagged Material"
+    );
+}

--- a/crates/nif/src/import/material/legacy_properties.rs
+++ b/crates/nif/src/import/material/legacy_properties.rs
@@ -146,8 +146,15 @@ fn apply_material_property(scene: &NifScene, idx: usize, info: &mut MaterialInfo
             info.alpha = mat.alpha;
             info.emissive_mult = mat.emissive_mult;
             // #1280 step 4 — tag the legacy Oblivion/FO3/FNV source.
-            info.emissive_source =
-                byroredux_core::ecs::components::material::EmissiveSource::Material;
+            // #2591 (SKY-D7-03) — gated on non-zero authoring, same as
+            // the BSLightingShaderProperty / BSEffectShaderProperty sites.
+            if byroredux_core::ecs::components::material::emissive_contribution_is_authored(
+                info.emissive_color,
+                info.emissive_mult,
+            ) {
+                info.emissive_source =
+                    byroredux_core::ecs::components::material::EmissiveSource::Material;
+            }
             info.has_material_data = true;
         }
     }

--- a/crates/nif/src/import/material/lighting_shader_pbr_tests.rs
+++ b/crates/nif/src/import/material/lighting_shader_pbr_tests.rs
@@ -203,11 +203,28 @@ fn plain_refraction_keeps_authored_lighting_shader_type() {
     );
 }
 
-/// `MaterialInfo::default()` must mirror the BSLSP parser stub at
-/// `crates/nif/src/blocks/shader.rs:739-749` so the no-author fallback
-/// is the same as the FO76+ stopcond fallback. If either side drifts
-/// the renderer would see different rim/SSS/fresnel defaults depending
-/// on whether the BGSM stopcond fired or the block was parsed normally.
+/// `MaterialInfo::default()` must mirror
+/// `BSLightingShaderProperty::material_reference_stub` (function name,
+/// not a line number — #2590 / SKY-D7-02: the prior `shader.rs:739-749`
+/// citation had drifted onto unrelated struct-field docs since the
+/// #1279 three-arm parser split) so the no-author fallback is the same
+/// as the FO4/FO76+ stopcond fallback. If either side drifts the
+/// renderer would see different rim/SSS/fresnel defaults depending on
+/// whether the stopcond fired or the block was parsed normally.
+///
+/// This test only pins the `MaterialInfo::default()` ↔
+/// `material_reference_stub` half of the invariant. The `parse_skyrim`
+/// arm is a THIRD, independent site that must agree on
+/// `grayscale_to_palette_scale`/`fresnel_power` specifically (it never
+/// serializes those two FO4+-only fields, so it constructs literals
+/// rather than reading them — pre-#2589 / SKY-D7-01 those literals were
+/// `0.0`/`0.0` instead of the neutral `1.0`/`5.0` here, and this test
+/// could not have caught that drift since it never touches
+/// `parse_skyrim`). See
+/// `blocks::shader_tests::skyrim::parse_bs_lighting_skyrim_arm_uses_neutral_fo4_field_defaults`
+/// for that arm's direct pin. `parse_fo4` / `parse_fo76_plus` read real
+/// authored bytes for every field compared here, so neither has (or
+/// needs) a "stub default" to agree with.
 #[test]
 fn material_info_default_matches_bslsp_parser_stub_defaults() {
     let info = MaterialInfo::default();

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -592,13 +592,18 @@ pub(super) struct MaterialInfo {
     /// `BSLightingShaderProperty.grayscale_to_palette_scale` — FO4+
     /// BSVER >= 130. Modulator on the greyscale→palette LUT remap
     /// (NPC face tints, gradient-driven palette swaps). Default 1.0
-    /// = no scale (matches the BSLSP parser stub default at
-    /// `shader.rs:748`). See #1241.
+    /// = no scale — matches
+    /// `BSLightingShaderProperty::material_reference_stub` (the FO4/
+    /// FO76+ material-reference stopcond) and, since #2589, the
+    /// `parse_skyrim` arm too (it never serializes this FO4+-only
+    /// field, so it now constructs the same neutral literal instead of
+    /// the `0.0` it used pre-#2589). #1241 / #2589 (SKY-D7-01).
     pub grayscale_to_palette_scale: f32,
     /// `BSLightingShaderProperty.fresnel_power` — FO4+ BSVER >= 130.
     /// Per-material Schlick exponent for the Fresnel rim term.
-    /// Default 5.0 (standard Schlick exponent, matches the BSLSP
-    /// parser stub default at `shader.rs:749`). See #1241.
+    /// Default 5.0 (standard Schlick exponent) — same three-arm
+    /// agreement as [`Self::grayscale_to_palette_scale`] above.
+    /// #1241 / #2589 (SKY-D7-01).
     pub fresnel_power: f32,
     pub uv_offset: [f32; 2],
     pub uv_scale: [f32; 2],
@@ -1052,9 +1057,20 @@ impl Default for MaterialInfo {
             specular_enabled: true,
             glossiness: 80.0,
             // BSLightingShaderProperty PBR scalars — defaults mirror
-            // the parser stub at `crates/nif/src/blocks/shader.rs:739-749`
-            // so the no-author fallback is the same as the stopcond
-            // fallback. See #1241.
+            // `BSLightingShaderProperty::material_reference_stub`
+            // (function name, not a line number — #2590 / SKY-D7-02:
+            // the prior `shader.rs:739-749` citation had drifted onto
+            // unrelated struct-field docs since the #1279 three-arm
+            // parser split) so the no-author fallback is the same as
+            // the stopcond fallback. Since #2589 (SKY-D7-01), the
+            // `parse_skyrim` arm also agrees on `grayscale_to_
+            // palette_scale`/`fresnel_power` specifically — it used to
+            // construct those two FO4+-only fields as `0.0` instead of
+            // the neutral `1.0`/`5.0` every other arm/stub/default
+            // agrees on. `parse_fo4` / `parse_fo76_plus` read real
+            // authored bytes for every field here, so "the no-author
+            // fallback" only ever applies to `parse_skyrim` and the
+            // stopcond stub. See #1241.
             refraction_strength: 0.0,
             lighting_effect_1: 0.0,
             lighting_effect_2: 0.0,


### PR DESCRIPTION
…ser-stub doc anchors, unconditional EmissiveSource::Lighting tag

SKY-D7-01 (#2589): `parse_skyrim` (the Skyrim LE/SE BSLightingShaderProperty arm, BSVER 83-129) constructed `grayscale_to_palette_scale`/`fresnel_power` — both FO4+-only wire fields (BSVER >= 130) Skyrim never serializes — as literal `0.0`/`0.0`. Every other neutral-default site in the pipeline (`BSLightingShaderProperty::material_reference_stub`, `MaterialInfo::default()`) agrees on `1.0`/`5.0`. `apply_bs_lighting_shader` copies both fields unconditionally with no BSVER gate, so the wrong `0.0` survived into canonical `Material.fresnel_power` for essentially all lit Skyrim geometry. Latent today (no GPU consumer yet), but would produce full-strength Fresnel at every view angle — uniform edge-bright/washed shading — the moment a consumer lands. Fixed the two literals to match the neutral default every other site uses, and added a direct parser-level regression test (`parse_bs_lighting_skyrim_arm_uses_neutral_fo4_field_defaults`) since the existing guard test only ever compared `MaterialInfo::default()` against the stopcond stub, never against `parse_skyrim`.

SKY-D7-02 (#2590): three doc comments anchored the "mirrors the BSLSP parser stub" claim to `shader.rs:739-749`/`:748`/`:749` — since the #1279 three-arm parser split, those line numbers land on unrelated struct-field docs, not any stub. They also implied a single "parser stub default" exists when there were two disagreeing ones (`material_reference_stub` = `1.0/5.0`, `parse_skyrim` = `0.0/0.0` pre-#2589). Re-anchored all three to the function name (`BSLightingShaderProperty::material_reference_stub`) and stated plainly which of the three parser arms the neutral-default invariant actually applies to (`parse_skyrim` and the stopcond stub; `parse_fo4`/`parse_fo76_plus` always read authored bytes so have no "default" to agree on).

SKY-D7-03 (#2591): all three `EmissiveSource` set-sites (BSLightingShaderProperty -> Lighting, BSEffectShaderProperty -> Effect, NiMaterialProperty -> Material) tagged their variant unconditionally, regardless of whether the captured color/multiplier pair was actually non-zero. `EmissiveSource::None`'s own doc says materials land there "without any of the three shader-property classes OR where none of them authored a non-zero emissive" — but since vanilla Skyrim ships the overwhelming majority of BSLightingShaderProperty blocks with the unauthored `[0,0,0]`/`1.0` default, every one of them got tagged `Lighting` anyway, degenerating the discriminator to "has a BSLightingShaderProperty" rather than "has an authored emissive". Added a shared `emissive_contribution_is_authored(color, mult)` helper next to the enum and gated all three set-sites on it, plus fixed an adjacent stale `import/material/walker.rs` cross-reference in the `Effect` variant doc (the #166 rename note now lives in `dedicated_shader.rs`, same bug class as #2590). Added a zero-authoring regression test per set-site (mirroring each existing "must tag X" test's fixture with the emissive fields zeroed) plus a unit test for the helper itself.

SK-D6-03 (#2588): verified only — `BSTreeNode`'s wind-bone lists are correctly parsed and surfaced onto `ImportedNode.tree_bones`, and the field's own doc already documents that nothing outside crates/nif and crates/spt consumes it yet. No code or doc change needed; closed as confirmed-accurate forward-scope note per the issue's own suggested fix ("None required now").