### PR TITLE
Fix #2715 #2716 #2717: fence-gated bindless descriptor writes, correc…

### DIFF
--- a/.claude/issues/2715 2716 2717/INVESTIGATION.md
+++ b/.claude/issues/2715 2716 2717/INVESTIGATION.md
@@ -1,0 +1,46 @@
+# #2717 investigation notes
+
+Widening the corpus sweep test (per the issue's "failing that" fallback) surfaced a
+**real, separate, pre-existing bug**, unrelated to #2717's round-trip-serialization
+concern: 4 real Fallout 4 menus fail `inject_host_object_adapter` entirely today —
+
+- `interface\dialoguemenu.swf`
+- `interface\multiactivatemenu.swf`
+- `interface\specialmenu.swf`
+- `interface\terminalmenu.swf`
+
+`ScaleformHostCatalog::for_profile(Fallout4Avm2).host_object()` requires a lifecycle
+class whose **own** ABC traits include the host-object property (`BGSCodeObj`) AND
+**both** hooks (`onCodeObjCreate` AND `onCodeObjDestruction`). Diagnosed via a
+throwaway test dumping each menu's root class' own trait list against the real
+`Fallout4 - Interface.ba2` corpus (data present in this environment at
+`/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data`):
+
+- `DialogueMenu` traits: `[..., "BGSCodeObj", ..., "onCodeObjCreate", ...]` — **no**
+  `onCodeObjDestruction`.
+- `MultiActivateMenu`: same shape, also missing `onCodeObjDestruction`.
+- `SPECIALMenu`: same shape, also missing `onCodeObjDestruction`.
+- `TerminalMenu_fla.MainTimeline` / `Terminal`: same shape.
+
+This is legal, shipped ABC — these menus' native lifecycle apparently never needs an
+explicit destroy hook (or it's inherited/handled differently), but
+`inject_host_object_adapter`'s class search treats its absence as "this isn't the
+lifecycle class" and falls through to `Err("... lifecycle class was not found")`.
+Every caller (`SwfPlayer::new` / `new_with_profile` / `from_resource_provider` in
+`player.rs`) propagates that `Err` via `?` — so these 4 menus **fail to load
+entirely** in the current engine, not merely lose the host-object bridge.
+
+**Not fixed here** — out of scope for #2717 (which is specifically about
+`parse_swf`→`write_swf` losslessness for menus that DO get patched successfully).
+The new corpus-sweep test (`all_installed_fallout4_swfs_round_trip_through_injection`
+in `crates/ui/src/avm2_host.rs`) names these 4 paths explicitly via
+`KNOWN_MISSING_ON_DESTROY_TRAIT` and asserts the set doesn't silently grow or shrink,
+so a future fix (or regression) is caught rather than the test just quietly excluding
+them forever.
+
+**Recommended follow-up** (not filed as an issue by this pass — flagging for the
+user to decide): investigate whether `ScaleformHostCatalog`'s on-destroy requirement
+should be optional, or whether the class search should also check inherited traits
+(these classes' bases — `Shared.IMenu` — don't declare it either, per the same dump,
+so it's not a same-file-inheritance gap; it may be a native-code convention where
+destroy is genuinely optional for certain menu classes).

--- a/.claude/issues/2715 2716 2717/ISSUE.md
+++ b/.claude/issues/2715 2716 2717/ISSUE.md
@@ -1,0 +1,30 @@
+# #2715 — UI overlay rewrites a bindless descriptor on the previous, still-pending frame slot
+
+**Severity**: HIGH · **Domain**: renderer (byroredux-renderer) + binary (byroredux)
+**Location**: `byroredux/src/main.rs:662-695`, `crates/renderer/src/texture_registry.rs:1460-1488`, `crates/renderer/src/vulkan/context/draw.rs:1460`
+
+`TextureRegistry::apply_descriptor_write` writes the new descriptor immediately into `bindless_sets[self.current_slot]`, justified by "no submitted command buffer can be reading `bindless_sets[current_slot]` concurrently" — true only while inside `draw_frame` after `begin_frame` sets `current_slot`. But `main.rs`'s UI tick/render/upload block (`update_rgba`) runs *before* `ctx.draw_frame(...)` is called, while `current_slot` still names the *previous* iteration's frame, whose command buffer is in the pending state (`MAX_FRAMES_IN_FLIGHT == 2`). The bindless layout uses `PARTIALLY_BOUND | UPDATE_AFTER_BIND` (not `UPDATE_UNUSED_WHILE_PENDING`), and the UI texture index is dynamically used by that pending command buffer (`ui.frag` samples it every frame the overlay is up) — so this is a live descriptor-in-use write (`VUID-vkUpdateDescriptorSets-None-03047`), invisible without validation layers since the content is still correct by construction (the current frame's set gets the same payload through `pending_set_writes`).
+
+**Suggested fix**: either (a) make `apply_descriptor_write` queue for *all* slots (including `current_slot`) when a `recording: bool` latch (set by `begin_frame`, cleared at submit) is false, or (b) cheaper: move the UI tick/render/upload block from `main.rs` to inside `draw_frame` after `texture_registry.begin_frame`.
+
+---
+
+# #2716 — Injected AVM2 bootstrap reserves operand-stack headroom with `.max(2)`, a no-op on every real constructor
+
+**Severity**: MEDIUM · **Domain**: ui (byroredux-ui)
+**Location**: `crates/ui/src/avm2_host.rs:467-481` (`patch_root_constructor`)
+
+The injected 3-op bootstrap (`FindPropStrict` +1, `GetLocal` +1 → peak `D+2`, `CallPropVoid`) needs `max_stack >= D + 2` where `D` is the stack depth at the insertion point. The code does `body.max_stack = body.max_stack.max(2)`, which only guarantees `max_stack >= 2` — a no-op on every real constructor (which already declares ≥2). Correct today only because the compiler happens to emit the `BGSCodeObj` init at statement level (`D == 0`). Ruffle's AVM2 verifier does not reconcile declared `max_stack` against actual, so an overflow is a Rust index-out-of-bounds **panic** inside `player.tick()` (contained to the stack subslice, not a silent OOB write — hence MEDIUM not CRITICAL) for a lifecycle constructor that initializes `BGSCodeObj` inside an expression (`D > 0`) rather than a bare statement.
+
+**Suggested fix (one line)**: `body.max_stack = body.max_stack.saturating_add(2);` — unconditionally correct for any `D`.
+
+---
+
+# #2717 — Every FO4 AVM2 menu is round-tripped through a full parse_swf → write_swf re-serialization
+
+**Severity**: MEDIUM · **Domain**: ui (byroredux-ui)
+**Location**: `crates/ui/src/avm2_host.rs:54-137` (`inject_host_object_adapter`)
+
+`inject_host_object_adapter` fully parses every SWF tag into the typed `swf` crate representation, mutates two tags, and re-serializes the *entire* movie with `write_swf` — every font/bitmap/sprite/sound/shape tag is decoded and re-encoded, not copied. The sibling rewrite in `navigator.rs::prepare_import_asset_swf` deliberately avoids this by walking `raw_tag_records` and emitting through `write_swf_raw_tags` so untouched tags pass through byte-for-byte. Evidence base for "lossless" today is 2 of 311 FO4 menus, checked only by an `#[ignore]`d test gated behind an installed-corpus requirement that doesn't run in CI. Not a demonstrated failure (issue author ran the ignored corpus tests — all 3 pass on real data) — framed as an unverified-surface finding.
+
+**Suggested fix**: move the injection to the raw-tag-record strategy (splice `DoABC2` / patched root `DoABC` as opaque byte records), OR — failing that — widen the corpus test to sweep all 311 SWFs (parse→inject→parse) and gate on a data-present env var instead of `#[ignore]`.

--- a/crates/renderer/src/texture_registry.rs
+++ b/crates/renderer/src/texture_registry.rs
@@ -213,6 +213,26 @@ pub struct TextureRegistry {
     /// descriptor writes target `bindless_sets[current_slot]`; writes
     /// for every other slot go into `pending_set_writes[other]`.
     current_slot: usize,
+    /// #2715 (CONC-D7-UI-01) — `Some(slot)` exactly when `bindless_sets[slot]`
+    /// is *known*, via a completed fence wait, to be idle: no submitted
+    /// command buffer can be reading it. Set by `begin_frame` (which the
+    /// caller may only invoke after waiting on `slot`'s fence). Cleared by
+    /// `note_frame_submitted` once `draw_frame`'s `queue_submit` for that
+    /// slot succeeds, since that call creates a new pending submission
+    /// against it.
+    ///
+    /// `apply_descriptor_write`'s immediate-write fast path is safe ONLY
+    /// while this equals `Some(current_slot)`. A caller outside that
+    /// window — e.g. the UI overlay's `update_rgba`, called from the host
+    /// app's per-iteration update *before* that iteration's `draw_frame`
+    /// (and thus before its fence wait) — would otherwise write into a
+    /// slot whose command buffer from the *previous* iteration is still
+    /// in the pending state, racing a live shader read
+    /// (`VUID-vkUpdateDescriptorSets-None-03047`). Outside the window,
+    /// `apply_descriptor_write` queues the write for every slot instead,
+    /// including `current_slot` — the next `begin_frame` flush applies it
+    /// before that frame's command buffer is recorded.
+    fence_confirmed_idle_slot: Option<usize>,
     /// DDS uploads queued by `enqueue_dds_with_clamp` and drained by
     /// `flush_pending_uploads` (#881 / CELL-PERF-03). Each entry's
     /// bindless slot is already reserved (with the descriptor
@@ -390,6 +410,9 @@ impl TextureRegistry {
             staging_pool: None,
             pending_set_writes: vec![Vec::new(); MAX_FRAMES_IN_FLIGHT],
             current_slot: 0,
+            // No fence has been waited on yet — nothing is known-idle until
+            // the first `begin_frame` call.
+            fence_confirmed_idle_slot: None,
             pending_dds_uploads: Vec::new(),
             slot_capacity_warning_emitted: false,
         };
@@ -1412,6 +1435,22 @@ impl TextureRegistry {
         self.current_frame_id = self.current_frame_id.wrapping_add(1);
         self.current_slot = slot;
         self.flush_pending_set_writes(device, slot);
+        // #2715 — the caller's contract (see doc comment above) guarantees
+        // `slot`'s fence has already been waited on, so `bindless_sets[slot]`
+        // is now known-idle for `apply_descriptor_write`'s immediate-write
+        // fast path, until this frame's `queue_submit` (see
+        // `note_frame_submitted`).
+        self.fence_confirmed_idle_slot = Some(slot);
+    }
+
+    /// #2715 (CONC-D7-UI-01) — must be called once `draw_frame`'s
+    /// `queue_submit` for `slot` succeeds. From that point a new command
+    /// buffer is pending against `bindless_sets[slot]`, so
+    /// `apply_descriptor_write` may no longer write into it immediately.
+    pub fn note_frame_submitted(&mut self, slot: usize) {
+        if self.fence_confirmed_idle_slot == Some(slot) {
+            self.fence_confirmed_idle_slot = None;
+        }
     }
 
     /// Apply every queued descriptor write for `slot` via a single
@@ -1465,9 +1504,24 @@ impl TextureRegistry {
         image_view: vk::ImageView,
         sampler: vk::Sampler,
     ) {
-        // Immediate write on the current slot — safe: we're CPU-side
-        // recording its command buffer right now; no submission is
-        // pending against it.
+        // #2715 (CONC-D7-UI-01) — the immediate-write fast path is safe
+        // ONLY while a completed fence wait has proven `current_slot`
+        // idle (see `fence_confirmed_idle_slot`'s doc comment). A caller
+        // outside that window — e.g. the UI overlay's texture upload,
+        // which runs before its iteration's `draw_frame`/fence-wait —
+        // would otherwise write into a slot whose command buffer from the
+        // *previous* iteration is still pending, racing a live shader
+        // read (`VUID-vkUpdateDescriptorSets-None-03047`). Queue for
+        // every slot, `current_slot` included, in that case; the next
+        // `begin_frame` flush applies it before that frame records.
+        if self.fence_confirmed_idle_slot != Some(self.current_slot) {
+            self.record_pending_write_for_all_slots(handle, binding, image_view, sampler);
+            return;
+        }
+
+        // Immediate write on the current slot — safe: a completed fence
+        // wait has just proven no submitted command buffer can be reading
+        // `bindless_sets[self.current_slot]`.
         let image_info = vk::DescriptorImageInfo::default()
             .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
             .image_view(image_view)
@@ -1478,9 +1532,9 @@ impl TextureRegistry {
             handle,
             &image_info,
         );
-        // SAFETY: `self.current_slot` is being recorded by the CPU right
-        // now (see the comment above) — no submitted command buffer can be
-        // reading `bindless_sets[self.current_slot]` concurrently.
+        // SAFETY: `self.fence_confirmed_idle_slot == Some(self.current_slot)`
+        // (checked above) — a completed fence wait has proven no submitted
+        // command buffer can be reading `bindless_sets[self.current_slot]`.
         unsafe {
             device.update_descriptor_sets(&[write], &[]);
         }
@@ -1502,6 +1556,30 @@ impl TextureRegistry {
             if slot == self.current_slot {
                 continue;
             }
+            queue.push(PendingSetWrite {
+                handle,
+                binding,
+                image_view,
+                sampler,
+            });
+        }
+    }
+
+    /// #2715 (CONC-D7-UI-01) — pure queue bookkeeping: push a pending
+    /// write onto EVERY slot, `current_slot` included. Used by
+    /// `apply_descriptor_write` when `fence_confirmed_idle_slot` doesn't
+    /// prove `current_slot` idle, so the immediate-write fast path isn't
+    /// safe for it either this call. Split out (mirroring
+    /// `record_pending_writes_for_other_slots`) so unit tests can
+    /// exercise the queue mechanics without a real Vulkan device.
+    fn record_pending_write_for_all_slots(
+        &mut self,
+        handle: TextureHandle,
+        binding: u32,
+        image_view: vk::ImageView,
+        sampler: vk::Sampler,
+    ) {
+        for queue in &mut self.pending_set_writes {
             queue.push(PendingSetWrite {
                 handle,
                 binding,

--- a/crates/renderer/src/texture_registry_tests.rs
+++ b/crates/renderer/src/texture_registry_tests.rs
@@ -114,6 +114,7 @@ fn make_registry_for_overflow_test(max_textures: u32, occupied: usize) -> Textur
         staging_pool: None,
         pending_set_writes: vec![Vec::new(); MAX_FRAMES_IN_FLIGHT],
         current_slot: 0,
+        fence_confirmed_idle_slot: None,
         pending_dds_uploads: Vec::new(),
         slot_capacity_warning_emitted: false,
     }
@@ -550,6 +551,102 @@ fn pending_writes_cleared_by_recreate_semantics() {
         queue.clear();
     }
     assert!(reg.pending_set_writes.iter().all(|q| q.is_empty()));
+}
+
+// ── #2715 (CONC-D7-UI-01) fence-confirmed-idle write gating ─────
+
+/// Regression for #2715: `begin_frame`'s contract is that the caller
+/// already waited on `slot`'s fence — that's what `fence_confirmed_idle_slot`
+/// is meant to record. `note_frame_submitted` must clear it again once a
+/// new command buffer is pending against that slot, so a later write
+/// outside the fence-confirmed window (e.g. the UI overlay's texture
+/// upload, which runs before its iteration's `draw_frame`) can't take the
+/// immediate-write fast path against a slot that's actually still pending.
+#[test]
+fn fence_confirmed_idle_slot_tracks_wait_and_submit() {
+    let mut reg = make_registry_for_overflow_test(16, 0);
+    assert_eq!(
+        reg.fence_confirmed_idle_slot, None,
+        "nothing is known-idle before the first fence wait"
+    );
+
+    // `begin_frame`'s device-touching half (flush_pending_set_writes) is
+    // a no-op when the slot's queue is empty, so the idle-tracking half
+    // is exercised directly here rather than through begin_frame (which
+    // needs a real ash::Device).
+    reg.current_slot = 0;
+    reg.fence_confirmed_idle_slot = Some(0);
+    assert_eq!(reg.fence_confirmed_idle_slot, Some(0));
+
+    // `queue_submit` for slot 0 succeeded — slot 0 now has a pending
+    // command buffer again, so it must no longer read as confirmed-idle.
+    reg.note_frame_submitted(0);
+    assert_eq!(
+        reg.fence_confirmed_idle_slot, None,
+        "note_frame_submitted must clear the idle mark for the slot that \
+         was just submitted (#2715)"
+    );
+
+    // Submitting a DIFFERENT slot than the one currently marked idle must
+    // not clear the mark — only the fence wait for THAT slot invalidates
+    // it, and this scenario shouldn't arise in practice (begin_frame
+    // always re-marks before submit), but the method must stay precise.
+    reg.fence_confirmed_idle_slot = Some(1);
+    reg.note_frame_submitted(0);
+    assert_eq!(
+        reg.fence_confirmed_idle_slot,
+        Some(1),
+        "note_frame_submitted(0) must not clear a mark held by a \
+         different slot"
+    );
+}
+
+/// Regression for #2715: when `current_slot` is NOT fence-confirmed idle
+/// (the state `apply_descriptor_write` is in when called before that
+/// iteration's `draw_frame`/fence-wait — e.g. the UI overlay's texture
+/// upload), the write must queue for EVERY slot, `current_slot` included
+/// — not just the "other" slots `record_pending_writes_for_other_slots`
+/// targets. Otherwise the payload never reaches `current_slot`'s
+/// descriptor set at all once it's later confirmed idle by a future
+/// `begin_frame`, since only `flush_pending_set_writes` — driven by the
+/// pending queue — applies it then.
+#[test]
+fn write_queues_for_current_slot_too_when_not_fence_confirmed_idle() {
+    let mut reg = make_registry_for_overflow_test(16, 0);
+    reg.current_slot = 0;
+    reg.fence_confirmed_idle_slot = None; // not yet confirmed for ANY slot
+
+    reg.record_pending_write_for_all_slots(9, 0, vk::ImageView::null(), vk::Sampler::null());
+
+    assert_eq!(
+        reg.pending_set_writes[0].len(),
+        1,
+        "current_slot (0) must ALSO receive the queued write when it \
+         isn't fence-confirmed idle (#2715) — unlike \
+         record_pending_writes_for_other_slots, which deliberately skips it"
+    );
+    assert_eq!(reg.pending_set_writes[0][0].handle, 9);
+    assert_eq!(reg.pending_set_writes[1].len(), 1);
+    assert_eq!(reg.pending_set_writes[1][0].handle, 9);
+}
+
+/// Sibling case: `current_slot` fence-confirmed idle for a DIFFERENT slot
+/// than the one currently recording still must not take the
+/// immediate-write fast path — `apply_descriptor_write`'s guard compares
+/// against `current_slot` specifically, not "any slot is idle".
+#[test]
+fn stale_idle_mark_for_a_different_slot_does_not_authorize_immediate_write() {
+    let mut reg = make_registry_for_overflow_test(16, 0);
+    reg.current_slot = 0;
+    reg.fence_confirmed_idle_slot = Some(1); // slot 1 was confirmed, not 0
+
+    assert_ne!(
+        reg.fence_confirmed_idle_slot,
+        Some(reg.current_slot),
+        "the guard `apply_descriptor_write` checks (fence_confirmed_idle_slot \
+         == Some(current_slot)) must be false here, or the fix's central \
+         invariant is broken"
+    );
 }
 
 // ── #881 pending DDS upload queue mechanics ────────────────────

--- a/crates/renderer/src/vulkan/context/draw.rs
+++ b/crates/renderer/src/vulkan/context/draw.rs
@@ -3300,6 +3300,13 @@ impl VulkanContext {
             drop(queue);
         }
 
+        // #2715 (CONC-D7-UI-01) — `queue_submit` above just created a new
+        // pending submission against `bindless_sets[frame]`, so
+        // `TextureRegistry::apply_descriptor_write`'s immediate-write fast
+        // path may no longer target this slot until the next `begin_frame`
+        // (post fence-wait) call re-confirms it idle.
+        self.texture_registry.note_frame_submitted(frame);
+
         // #917 / REN-D10-NEW-03 — advance SVGF + TAA `frames_since_
         // creation` counters now that `queue_submit` returned success.
         // Each pipeline self-gates on its `dispatched_this_frame` flag

--- a/crates/ui/src/avm2_host.rs
+++ b/crates/ui/src/avm2_host.rs
@@ -354,6 +354,30 @@ fn method_called_with_bgs_receiver(abc: &AbcFile, ops: &[Op]) -> Option<Vec<u8>>
     None
 }
 
+/// #2716 (SAFEUI-02) — the injected 3-op bootstrap (`FindPropStrict` +1,
+/// `GetLocal` +1 -> peak +2, `CallPropVoid`) needs two slots ABOVE
+/// whatever depth `D` the operand stack is already at when it splices in,
+/// i.e. `max_stack` must become at least `D + 2`. The pre-fix
+/// `existing_max_stack.max(2)` only guarantees `max_stack >= 2`, which
+/// every real constructor already satisfies on its own (an `InitProperty`
+/// alone consumes three operands) — a no-op that happened to be correct
+/// only because BGSCodeObj's init is emitted at statement level (`D == 0`)
+/// by the compiler in every corpus example seen so far. A constructor
+/// that initializes BGSCodeObj inside an expression (legal ABC, `D > 0`)
+/// would overflow the AVM2 operand stack — a Rust index-out-of-bounds
+/// panic in Ruffle's interpreter, since Ruffle's verifier does not
+/// reconcile declared `max_stack` against actual (`core/src/avm2/verify.rs`
+/// has no reference to `max_stack`; the frame is sized once from it in
+/// `Stack::get_stack_frame`). `saturating_add` is correct for any `D`:
+/// `existing_max_stack` already reflects the deepest point BEFORE the
+/// splice, so adding the injection's own peak growth on top bounds the
+/// deepest point AFTER it, regardless of where in the body that peak was.
+/// Split out (pure, no `MethodBody`) so unit tests can pin the arithmetic
+/// without reconstructing a full ABC.
+fn max_stack_with_injected_bootstrap_headroom(existing_max_stack: u32) -> u32 {
+    existing_max_stack.saturating_add(2)
+}
+
 fn patch_root_constructor(abc_data: &[u8], root_class: &[u8]) -> Result<Vec<u8>, String> {
     let mut abc = Reader::new(abc_data)
         .read()
@@ -477,7 +501,7 @@ fn patch_root_constructor(abc_data: &[u8], root_class: &[u8]) -> Result<Vec<u8>,
         insertion_offset..insertion_offset,
         injection.iter().copied(),
     );
-    body.max_stack = body.max_stack.max(2);
+    body.max_stack = max_stack_with_injected_bootstrap_headroom(body.max_stack);
     let inserted = injection.len() as u32;
     let insertion_offset = insertion_offset as u32;
     for exception in &mut body.exceptions {
@@ -925,8 +949,8 @@ mod tests {
     use swf::{DoAbc2, DoAbc2Flag, FileAttributes, SwfStr, Tag};
 
     use super::{
-        build_adapter_abc, inject_host_object_adapter, referenced_host_methods, write_ops,
-        DESTROYED_EVENT,
+        build_adapter_abc, inject_host_object_adapter, max_stack_with_injected_bootstrap_headroom,
+        referenced_host_methods, write_ops, DESTROYED_EVENT,
     };
     use crate::{ScaleformHostCatalog, ScaleformProfile};
 
@@ -1013,6 +1037,146 @@ mod tests {
         }
     }
 
+    /// Regression for #2717 / SAFEUI-03: `inject_host_object_adapter`
+    /// fully parses and re-serializes the ENTIRE movie (every font,
+    /// bitmap, sprite, sound, shape tag decoded and re-encoded, not
+    /// copied) rather than the raw-tag-splice strategy its sibling
+    /// `navigator.rs::prepare_import_asset_swf` uses. Before this test the
+    /// only real-data evidence for "lossless on FO4 content" was 2 of 311
+    /// menus, checked by an `#[ignore]`d test that never runs in CI. This
+    /// sweeps every `.swf` in the FO4 interface archive through
+    /// injection and asserts the output re-parses — NOT gated behind
+    /// `#[ignore]` (so the corpus is actually swept whenever it's
+    /// present), but self-skips (rather than failing) when the archive
+    /// isn't available, since the corpus is multi-gigabyte game data that
+    /// can't ship with the repo.
+    ///
+    /// Four menus (`KNOWN_MISSING_ON_DESTROY_TRAIT` below) are excluded
+    /// from the "must succeed" assertion: they were discovered by an
+    /// earlier run of *this* test to fail the *unrelated*, pre-existing
+    /// lifecycle-class search — a separate bug from what #2717 is about.
+    /// `Shared.ScaleformHostCatalog`'s Fallout 4 profile requires a class
+    /// whose OWN traits include the host-object property AND both the
+    /// on-create AND on-destroy hooks; these four menus' lifecycle class
+    /// (`DialogueMenu`, `MultiActivateMenu`, `SPECIALMenu`, `Terminal`)
+    /// declares the property and on-create hook but never an
+    /// `onCodeObjDestruction` trait of its own — legal, real, shipped ABC.
+    /// The lookup falls through to "lifecycle class not found",
+    /// `inject_host_object_adapter` returns `Err`, and every caller
+    /// propagates that `Err` (`SwfPlayer::new` / `new_with_profile` /
+    /// `from_resource_provider`, `player.rs`) — so today these 4 real
+    /// Fallout 4 menus fail to load entirely. That is a real, separate
+    /// defect worth its own issue (loosen the on-destroy requirement, or
+    /// search inherited traits) — NOT something #2717's round-trip
+    /// serialization safety fix should touch, and not something this test
+    /// should silently paper over either, hence naming it explicitly
+    /// instead of a bare allow-list.
+    #[test]
+    fn all_installed_fallout4_swfs_round_trip_through_injection() {
+        const KNOWN_MISSING_ON_DESTROY_TRAIT: &[&str] = &[
+            "interface\\dialoguemenu.swf",
+            "interface\\multiactivatemenu.swf",
+            "interface\\specialmenu.swf",
+            "interface\\terminalmenu.swf",
+        ];
+
+        let path = std::env::var("BYROREDUX_FO4_DATA").unwrap_or_else(|_| {
+            "/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data".to_string()
+        });
+        let archive_path = std::path::Path::new(&path).join("Fallout4 - Interface.ba2");
+        let Ok(archive) = Ba2Archive::open(&archive_path) else {
+            eprintln!(
+                "skipping all_installed_fallout4_swfs_round_trip_through_injection: \
+                 {archive_path:?} not available (set BYROREDUX_FO4_DATA to override)"
+            );
+            return;
+        };
+        let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
+
+        let mut swf_paths: Vec<String> = archive
+            .list_files()
+            .into_iter()
+            .filter(|path| path.ends_with(".swf"))
+            .map(str::to_string)
+            .collect();
+        swf_paths.sort();
+        assert!(
+            !swf_paths.is_empty(),
+            "expected .swf files in the FO4 interface archive at {archive_path:?}"
+        );
+
+        let mut injected_count = 0usize;
+        let mut failures = Vec::new();
+        let mut still_missing_on_destroy = Vec::new();
+        for movie_path in &swf_paths {
+            let swf = match archive.extract(movie_path) {
+                Ok(data) => data,
+                Err(error) => {
+                    failures.push(format!("{movie_path}: extract failed: {error}"));
+                    continue;
+                }
+            };
+            match inject_host_object_adapter(&swf, catalog) {
+                Ok((patched, state)) => {
+                    if state == super::ScaleformHostObjectState::AdapterInjected {
+                        injected_count += 1;
+                        // The structural sanity check #2717 asks for: the
+                        // fully re-serialized movie must still be a valid
+                        // SWF. This does NOT prove byte-for-byte losslessness
+                        // (that needs the raw-tag-splice rewrite the issue's
+                        // primary suggested fix describes) — it proves the
+                        // `swf` crate's write path didn't produce a movie
+                        // that can no longer be parsed at all, which is the
+                        // failure mode a corrupted re-encode would produce.
+                        let reparsed = swf::decompress_swf(patched.as_slice())
+                            .map_err(|error| error.to_string())
+                            .and_then(|decompressed| {
+                                swf::parse_swf(&decompressed)
+                                    .map_err(|error| error.to_string())
+                                    .map(|_movie| ())
+                            });
+                        if let Err(error) = reparsed {
+                            failures.push(format!(
+                                "{movie_path}: patched output failed to re-parse: {error}"
+                            ));
+                        }
+                    }
+                }
+                Err(error) => {
+                    if KNOWN_MISSING_ON_DESTROY_TRAIT.contains(&movie_path.as_str())
+                        && error.contains("lifecycle class was not found")
+                    {
+                        still_missing_on_destroy.push(movie_path.clone());
+                    } else {
+                        failures.push(format!("{movie_path}: injection failed: {error}"));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "{} of {} FO4 SWFs failed the injection round-trip ({injected_count} actually \
+             went through AVM2 adapter injection; {} excluded as the known, unrelated \
+             on-destroy-trait gap):\n{}",
+            failures.len(),
+            swf_paths.len(),
+            still_missing_on_destroy.len(),
+            failures.join("\n"),
+        );
+        // If this list has shrunk, the on-destroy gap got fixed (or the
+        // menu changed) — update KNOWN_MISSING_ON_DESTROY_TRAIT and the
+        // doc comment above rather than leaving a stale exclusion. If it
+        // has GROWN, a new menu just started hitting the same gap.
+        assert_eq!(
+            still_missing_on_destroy,
+            KNOWN_MISSING_ON_DESTROY_TRAIT,
+            "the set of menus hitting the known on-destroy-trait gap changed — \
+             update KNOWN_MISSING_ON_DESTROY_TRAIT (and file/link the follow-up \
+             issue this comment references) rather than leaving this stale"
+        );
+    }
+
     #[test]
     fn marker_without_a_lifecycle_class_is_rejected() {
         let marker_abc = marker_abc();
@@ -1086,5 +1250,59 @@ mod tests {
         let mut bytes = Vec::new();
         Writer::new(&mut bytes).write(abc).unwrap();
         bytes
+    }
+
+    /// Regression for #2716 / SAFEUI-02: the injected bootstrap needs
+    /// `existing_max_stack + 2` headroom for ANY existing depth, not just
+    /// `max(existing_max_stack, 2)`. The pre-fix formula was a no-op for
+    /// every constructor that already declares `max_stack >= 2` — which is
+    /// every real one (an `InitProperty` alone needs three operands) — so
+    /// pin the case that formula silently got wrong: a constructor whose
+    /// declared depth already exceeds 2 must still grow by exactly 2, not
+    /// stay unchanged.
+    #[test]
+    fn injected_bootstrap_headroom_adds_two_regardless_of_existing_depth() {
+        for existing in [0u32, 1, 2, 3, 5, 10] {
+            let fixed = max_stack_with_injected_bootstrap_headroom(existing);
+            assert_eq!(
+                fixed,
+                existing + 2,
+                "existing_max_stack={existing}: bootstrap needs exactly 2 \
+                 slots of headroom above whatever depth the constructor \
+                 already reaches"
+            );
+
+            // The retired `.max(2)` formula this replaces: correct only by
+            // coincidence at existing <= 2, and silently wrong (stays flat
+            // instead of growing) for every existing depth above that —
+            // exactly the BGSCodeObj-inside-an-expression (D > 0) shape
+            // #2716 describes.
+            let retired_formula = existing.max(2);
+            if existing > 2 {
+                assert_ne!(
+                    fixed, retired_formula,
+                    "existing_max_stack={existing}: the fixed formula must \
+                     diverge from the retired one here, or this test isn't \
+                     actually exercising the bug #2716 fixes"
+                );
+            }
+        }
+    }
+
+    /// `saturating_add` must not wrap even at the type's ceiling — ABC
+    /// `max_stack` is a `u30` in the format (so real inputs never
+    /// approach `u32::MAX`), but the Rust field is a plain `u32` and the
+    /// arithmetic operator must stay a deliberate, safe choice rather
+    /// than an overflow-panicking `+`.
+    #[test]
+    fn injected_bootstrap_headroom_saturates_instead_of_wrapping() {
+        assert_eq!(
+            max_stack_with_injected_bootstrap_headroom(u32::MAX),
+            u32::MAX
+        );
+        assert_eq!(
+            max_stack_with_injected_bootstrap_headroom(u32::MAX - 1),
+            u32::MAX
+        );
     }
 }


### PR DESCRIPTION
…t AVM2 bootstrap stack headroom, sweep FO4 SWF corpus for injection round-trip

#2715 — TextureRegistry::apply_descriptor_write wrote immediately into bindless_sets[current_slot], justified by "the CPU is recording this slot right now, no submission is pending against it". That's only true from begin_frame's post-fence-wait point through this frame's queue_submit. The UI overlay's texture upload runs in main.rs before that iteration's draw_frame call, while current_slot still names the previous iteration's slot, whose command buffer is in the pending state (VUID-vkUpdateDescriptorSets-None-03047). Added fence_confirmed_idle_slot, set by begin_frame (whose contract already requires the caller to have waited on the slot's fence) and cleared by a new note_frame_submitted hook called right after queue_submit succeeds. apply_descriptor_write now queues the write for every slot, current_slot included, whenever that mark doesn't match — the next begin_frame's flush applies it before that frame records. Fixes the race for every caller of the bindless registry, not just the UI path.

#2716 — patch_root_constructor's injected 3-op AVM2 bootstrap (FindPropStrict +1, GetLocal +1 -> peak D+2, CallPropVoid) needs max_stack >= D + 2 where D is the operand-stack depth at the splice point. body.max_stack.max(2) only guarantees max_stack >= 2, a no-op on every real constructor (which already declares >= 2 on its own) — correct today only because BGSCodeObj's init happens to be emitted at statement level (D == 0) in every corpus example. A constructor that initializes BGSCodeObj inside an expression (legal ABC, D > 0) would overflow the AVM2 operand stack, panicking Ruffle's interpreter (its verifier doesn't reconcile declared max_stack against actual). saturating_add(2) is correct for any D.

#2717 — inject_host_object_adapter fully parses and re-serializes every tag in an FO4 menu's SWF, not just the two it mutates, unlike the raw-tag-splice strategy its sibling navigator.rs:: prepare_import_asset_swf already uses. The full raw-tag-record rewrite this implies (splicing DoABC2/patched-root-DoABC as opaque byte records) is a larger, higher-risk change for a finding the issue itself frames as unverified-surface rather than a demonstrated bug. Took the issue's explicit fallback instead: widened the single 3-menu #[ignore]d corpus test (never runs in CI) into a full 311-SWF sweep that isn't gated behind #[ignore] — it self-skips when the corpus isn't present and asserts a successful parse->inject->reparse for every menu that goes through injection otherwise.

Running that sweep against the real Fallout 4 corpus surfaced a separate, real, pre-existing bug: 4 menus (dialoguemenu, multiactivatemenu, specialmenu, terminalmenu) fail inject_host_object_adapter entirely today, because their lifecycle class declares BGSCodeObj + onCodeObjCreate but never its own onCodeObjDestruction trait — legal, shipped ABC that ScaleformHostCatalog's all-three-traits requirement rejects, so every SwfPlayer constructor propagates the Err and these menus fail to load. Out of scope for #2717 (a round-trip-serialization concern, not a class-detection one) — named explicitly in the new test via KNOWN_MISSING_ON_DESTROY_TRAIT with an assertion that the set can't silently grow or shrink, and written up in INVESTIGATION.md as a recommended follow-up issue rather than fixed here.