### PR TITLE
Fix #2296 #2297 #2302 #2303: cross-crate material_kind assert, TLAS f…

### DIFF
--- a/.claude/issues/2296 2297 2302 2303/INVESTIGATION.md
+++ b/.claude/issues/2296 2297 2302 2303/INVESTIGATION.md
@@ -1,0 +1,40 @@
+# #2297 investigation notes — stale premise corrected
+
+The issue's "Evidence" quoted `draw_command_eligible_for_tlas` as:
+```rust
+pub(super) fn draw_command_eligible_for_tlas(draw_cmd: &DrawCommand) -> bool {
+    draw_cmd.in_tlas
+        && !draw_cmd.is_water
+        && draw_cmd.material_kind != crate::MATERIAL_KIND_EFFECT_SHADER
+}
+```
+That shape **never existed** in this function's git history (`git log -S` across
+every commit that ever touched it — `8ee3a749` created it as
+`draw_cmd.in_tlas && !draw_cmd.is_water`, `29e9f450` only moved it during a module
+split; no material_kind check was ever present). The `material_kind !=
+MATERIAL_KIND_EFFECT_SHADER` string does exist in the repo's history, but in a
+different function/era, not this one — the audit that produced this finding
+appears to have conflated two different sites.
+
+**Current real architecture**: `MATERIAL_KIND_FIRE_REFRACTION` IS already
+excluded from the TLAS today, via `render::static_meshes`'s `in_tlas` computation
+(`byroredux/src/render/static_meshes.rs:219-222`) — the single production
+producer of `in_tlas == true` draws for real mesh geometry (static and skinned
+both flow through this one loop). Its comment is explicit that
+`MATERIAL_KIND_EFFECT_SHADER` is **deliberately retained** in the TLAS ("optical/GI
+rays can see them while opaque shadow masks cannot"), confirmed independently by
+the pre-existing test `effect_shader_surface_is_tlas_eligible_for_optical_rays`
+in `acceleration/tests.rs`. Excluding EFFECT_SHADER in
+`draw_command_eligible_for_tlas` — what the issue's evidence implied "fixing"
+would require — would have been a real regression against that documented,
+tested design decision.
+
+**What was actually applied**: added ONLY the `MATERIAL_KIND_FIRE_REFRACTION`
+exclusion to `draw_command_eligible_for_tlas`, as genuine defense-in-depth
+(matching the issue's own LOW-severity "no live defect, defense-in-depth gap
+only" framing) — it's currently redundant with the `static_meshes.rs` producer
+gate, but protects against a future producer that forgets to compute `in_tlas`
+correctly for this material kind, mirroring the existing `is_water` precedent in
+the same function (which IS load-bearing — water.rs sets `in_tlas: true`
+unconditionally and relies entirely on this predicate). Did NOT add an
+EFFECT_SHADER exclusion.

--- a/.claude/issues/2296 2297 2302 2303/ISSUE.md
+++ b/.claude/issues/2296 2297 2302 2303/ISSUE.md
@@ -1,0 +1,41 @@
+# #2296 — MAT-D1-NEW-01: no cross-crate assert pins NIF importer's material_kind literals to byroredux_renderer::MATERIAL_KIND_*
+
+**Severity**: LOW · **Domain**: binary (byroredux) — the fix site per the issue is `byroredux/src/material_translate.rs`'s test module (the only crate depending on both `byroredux-nif` and `byroredux-renderer`)
+**Location**: `crates/nif/src/import/material/dedicated_shader.rs:336,485`, `crates/nif/src/import/material/legacy_properties.rs:407` (literal `material_kind = 101/102/103`), vs `byroredux_renderer::MATERIAL_KIND_*` (`crates/renderer/src/shader_constants_data.rs:81`)
+
+`crates/nif` has no dependency on `byroredux-renderer`, so nothing pins the importer's raw `material_kind` literals (101/102/103) to the renderer's named `MATERIAL_KIND_*` constants — only literal-to-literal asserts exist inside `crates/nif`'s own tests. A future renumber of the renderer constants would keep `cargo test -p byroredux-nif` green while silently misrouting shading. No live defect — literals currently agree.
+
+**Suggested fix**: a two-line cross-crate assert in `byroredux/src/material_translate.rs`'s test module, pinning the raw literals used at import time to the renderer's named constants.
+
+---
+
+# #2297 — MAT-D1-NEW-02: draw_command_eligible_for_tlas excludes MATERIAL_KIND_EFFECT_SHADER but not MATERIAL_KIND_FIRE_REFRACTION
+
+**Severity**: LOW · **Domain**: renderer (byroredux-renderer)
+**Location**: `crates/renderer/src/vulkan/acceleration/predicates.rs:437-441` (`draw_command_eligible_for_tlas`)
+
+`draw_command_eligible_for_tlas` excludes `MATERIAL_KIND_EFFECT_SHADER` from the TLAS but not `MATERIAL_KIND_FIRE_REFRACTION`, despite the latter's own constant doc requiring the same exclusion. A sibling predicate in the same file (`predicates.rs:610`) *does* exclude `MATERIAL_KIND_FIRE_REFRACTION` — confirming the omission is an asymmetry, not a deliberate choice. No live defect today (no producer sets `in_tlas` for fire-refraction draws) — defense-in-depth gap only.
+
+**Suggested fix**: add the same `MATERIAL_KIND_FIRE_REFRACTION` exclusion to `draw_command_eligible_for_tlas`, mirroring the sibling predicate at line 610.
+
+---
+
+# #2302 — NIFAL-D6-08: NiTriStripsData.normals not cross-checked by resolve_tri_strips_data_refs, unlike sibling packed_triangle_winding check
+
+**Severity**: LOW · **Domain**: nif (byroredux-nif)
+**Location**: `crates/nif/src/import/collision/shape.rs` (`resolve_tri_strips_data_refs`), vs. `packed_triangle_winding` (`shape.rs:457`, gated for `BhkPackedNiTriStripsShape`)
+
+`NiTriStripsData.normals` is never cross-checked by the `bhkNiTriStripsShape`-derived collision path (`resolve_tri_strips_data_refs`), unlike the sibling `packed_triangle_winding` check that `BhkPackedNiTriStripsShape`'s resolve path already has. Explicitly **not** a fix for #2193 (already hand-verified zero disagreements on its repro content) — documented asymmetry only, no known live trigger.
+
+**Suggested fix**: add the same normal-vs-winding cross-check to `resolve_tri_strips_data_refs` that `packed_triangle_winding` provides for the packed-mesh path.
+
+---
+
+# #2303 — NIFAL-D7-02: nifal.md conflates live AnimatedMorphWeights sink with genuinely-parked ambient colour channels
+
+**Severity**: LOW · **Domain**: docs (no crate — doc-only fix)
+**Location**: `docs/engine/nifal.md:244-245`
+
+The doc lumps morph-weight channels in with genuinely-parked per-light ambient channels ("intentionally parked... no renderer consumer yet"). Since `a8b0cf64`, morph-weight channels reach a live `AnimatedMorphWeights` ECS sink every frame (confirmed via `sink_lifecycle_end_to_end_tests`) — they only lack a GPU/mesh-vertex-blend consumer (tracked separately by #2221). Ambient genuinely is still dropped. Doc-only, no behavior impact.
+
+**Suggested fix**: split the sentence — keep ambient colour channels as "intentionally parked, no consumer"; describe morph-weight channels as "reaches `AnimatedMorphWeights` every frame, GPU/mesh-vertex-blend consumer tracked by #2221."

--- a/byroredux/src/material_translate.rs
+++ b/byroredux/src/material_translate.rs
@@ -370,6 +370,31 @@ mod tests {
     // normal_map_index 7, gloss_map_index 0.
     const PASS: (u32, f32, f32, u32, u32) = (0, 0.0, 0.0, 7, 0);
 
+    /// Regression for #2296 / MAT-D1-NEW-01. `crates/nif` depends on
+    /// `byroredux-core` only — never `byroredux-renderer` — so the NIF
+    /// importer's `material_kind` assignments
+    /// (`crates/nif/src/import/material/dedicated_shader.rs` and
+    /// `legacy_properties.rs`) are raw `101`/`102`/`103` literals with no
+    /// compile-time link to `byroredux_renderer::MATERIAL_KIND_*`. This
+    /// binary is the one crate that depends on both, so it's the only
+    /// place a cross-crate assert can live. Pins the literals to the
+    /// named constants they must always agree with — a future renumber
+    /// of the renderer-side constants breaks this loudly instead of
+    /// silently misrouting shading for every effect/no-lighting/fire-haze
+    /// surface.
+    #[test]
+    fn nif_importer_material_kind_literals_match_renderer_constants() {
+        // dedicated_shader.rs:536 (material_reference early-return guard)
+        // and :663 (primary effect-shader detection; pinned in-crate by
+        // `effect_shader_sets_material_kind_to_101`).
+        assert_eq!(101u32, byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER);
+        // legacy_properties.rs:545 (BSShaderNoLightingProperty branch).
+        assert_eq!(102u32, byroredux_renderer::MATERIAL_KIND_NO_LIGHTING);
+        // dedicated_shader.rs:481 / legacy_properties.rs:451 (FireRefraction
+        // shader-flag detection, both dedicated + legacy property paths).
+        assert_eq!(103u32, byroredux_renderer::MATERIAL_KIND_FIRE_REFRACTION);
+    }
+
     #[test]
     fn fire_refraction_uses_sanitized_authored_strength_as_optical_payload() {
         let kind = byroredux_renderer::MATERIAL_KIND_FIRE_REFRACTION;

--- a/crates/nif/src/import/collision/shape.rs
+++ b/crates/nif/src/import/collision/shape.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use crate::blocks::collision::*;
 use crate::blocks::tri_shape::NiTriStripsData;
 use crate::scene::NifScene;
-use crate::types::BlockRef;
+use crate::types::{BlockRef, NiPoint3};
 
 use byroredux_core::ecs::components::collision::CollisionShape;
 use byroredux_core::math::{Quat, Vec3};
@@ -398,17 +398,80 @@ fn resolve_tri_strips_data_refs(
         // #2285 — validate against THIS data_ref's own vertex count before
         // offsetting, not the eventual cross-data_ref merged total (see
         // `push_local_triangles`).
+        //
+        // #2302 (NIFAL-D6-08) — cross-check each triangle's raw winding
+        // against `data.normals` before offsetting, mirroring the sibling
+        // `packed_triangle_winding` check `resolve_packed_mesh` already
+        // applies to `BhkPackedNiTriStripsShape`. Not a fix for #2193 (that
+        // repro's own investigation found zero disagreements across all
+        // 913 triangles) — defense-in-depth for content #2193 didn't cover.
         push_local_triangles(
             base_idx,
             data.vertices.len() as u32,
             data.to_triangles()
                 .into_iter()
-                .map(|tri| [tri[0] as u32, tri[1] as u32, tri[2] as u32]),
+                .map(|tri| [tri[0] as u32, tri[1] as u32, tri[2] as u32])
+                .map(|tri| tri_strips_triangle_winding(&data.vertices, &data.normals, tri)),
             &mut all_indices,
         );
     }
 
     finish_trimesh(all_verts, all_indices)
+}
+
+/// #2302 (NIFAL-D6-08) — cross-check a `bhkNiTriStripsShape`-derived
+/// triangle's raw winding against `NiTriStripsData.normals`, mirroring
+/// `packed_triangle_winding`'s check for the sibling
+/// `BhkPackedNiTriStripsShape` path. Operates on raw (pre-`havok_to_engine`)
+/// local indices/vertices/normals, same as that sibling.
+///
+/// Unlike `PackedTriangle`'s single authored normal per triangle,
+/// `NiTriStripsData` carries one authored normal per VERTEX. Sum the three
+/// corner normals as the authored reference direction for the sign
+/// comparison: for a triangle whose index order matches what was
+/// authored, the flat geometric normal (`cross(v1-v0, v2-v0)`) and the
+/// summed vertex normals can never disagree in sign, however smoothly the
+/// mesh is shaded — a disagreement means the raw index order is backwards
+/// relative to the authored geometry, exactly the class of bug
+/// `packed_triangle_winding` was added to catch on the sibling path (#2193).
+///
+/// Silently returns `tri` unmodified (no correction attempted) when
+/// `normals` doesn't have one entry per vertex — older NIF versions may
+/// omit per-vertex normals entirely — or when any of the triangle's three
+/// indices are out of range (`push_local_triangles`' own bounds check
+/// still runs afterward regardless).
+fn tri_strips_triangle_winding(vertices: &[NiPoint3], normals: &[NiPoint3], tri: [u32; 3]) -> [u32; 3] {
+    if normals.len() != vertices.len() {
+        return tri;
+    }
+    let Some(a) = vertices.get(tri[0] as usize) else {
+        return tri;
+    };
+    let Some(b) = vertices.get(tri[1] as usize) else {
+        return tri;
+    };
+    let Some(c) = vertices.get(tri[2] as usize) else {
+        return tri;
+    };
+    let Some(na) = normals.get(tri[0] as usize) else {
+        return tri;
+    };
+    let Some(nb) = normals.get(tri[1] as usize) else {
+        return tri;
+    };
+    let Some(nc) = normals.get(tri[2] as usize) else {
+        return tri;
+    };
+    let a = Vec3::new(a.x, a.y, a.z);
+    let b = Vec3::new(b.x, b.y, b.z);
+    let c = Vec3::new(c.x, c.y, c.z);
+    let authored = Vec3::new(na.x + nb.x + nc.x, na.y + nb.y + nc.y, na.z + nb.z + nc.z);
+    let geometric = (b - a).cross(c - a);
+    if geometric.dot(authored) < 0.0 {
+        [tri[0], tri[2], tri[1]]
+    } else {
+        tri
+    }
 }
 
 /// Convert hkPackedNiTriStripsData into a TriMesh. `havok_scale` is the world
@@ -1222,6 +1285,127 @@ mod cycle_tests {
                         if i % 2 == 0 { "even" } else { "odd" },
                     );
                 }
+            }
+            other => panic!("expected TriMesh, got {other:?}"),
+        }
+    }
+
+    /// Like [`tri_strips_data`], but also populates `normals` — used by
+    /// the #2302 (NIFAL-D6-08) winding-cross-check tests below, which
+    /// need an authored per-vertex normal to check the raw index order
+    /// against. `tri_strips_data`'s existing (many) callers deliberately
+    /// keep `normals: Vec::new()`, which no-ops the check (see
+    /// `tri_strips_triangle_winding`'s doc comment) — this variant is
+    /// separate so those callers stay unaffected.
+    fn tri_strips_data_with_normals(
+        verts: Vec<NiPoint3>,
+        normals: Vec<NiPoint3>,
+        strip: Vec<u16>,
+    ) -> Box<dyn NiObject> {
+        Box::new(NiTriStripsData {
+            vertices: verts,
+            normals,
+            center: NiPoint3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            radius: 0.0,
+            vertex_colors: Vec::new(),
+            uv_sets: Vec::new(),
+            num_triangles: 0,
+            strips: vec![strip],
+        })
+    }
+
+    /// #2302 (NIFAL-D6-08) — sibling of
+    /// `tri_strips_floor_keeps_an_upward_normal_through_the_coord_swap`,
+    /// but for a triangle whose RAW winding disagrees with its authored
+    /// per-vertex normals. A single-triangle strip (no de-strip parity
+    /// involved) wound `[0, 2, 1]` — geometrically `-Z` (down) — with all
+    /// three vertex normals authored `+Z` (up). Pre-#2302 nothing checked
+    /// this on the `bhkNiTriStripsShape` path (unlike the sibling
+    /// `BhkPackedNiTriStripsShape` path's `packed_triangle_winding`), so
+    /// the resolved triangle would keep its backwards winding and read
+    /// `-Y` (down) in engine space — the same class of inverted collision
+    /// normal #2193 investigated. With the fix, winding is corrected to
+    /// match the authored normal and the resolved triangle must read `+Y`.
+    #[test]
+    fn tri_strips_triangle_wound_backwards_is_corrected_to_match_authored_normal() {
+        let mut scene = NifScene::default();
+        scene.havok_scale = 1.0;
+        scene.blocks.push(Box::new(BhkNiTriStripsShape {
+            data_refs: vec![BlockRef(1u32)],
+            material: 0,
+            radius: 0.0,
+            scale: [1.0, 1.0, 1.0, 0.0],
+            filters: Vec::new(),
+        }));
+        let p = |x: f32, y: f32| NiPoint3 { x, y, z: 0.0 };
+        let up = NiPoint3 {
+            x: 0.0,
+            y: 0.0,
+            z: 1.0,
+        };
+        scene.blocks.push(tri_strips_data_with_normals(
+            vec![p(0.0, 0.0), p(1.0, 0.0), p(0.0, 1.0)],
+            vec![up, up, up],
+            // Backwards relative to the natural (0,1,2) → +Z winding:
+            // (v2-v0)×(v1-v0) = (0,1,0)×(1,0,0) = -Z.
+            vec![0, 2, 1],
+        ));
+        let mut visited = HashSet::new();
+        match resolve_shape(&scene, BlockRef(0u32), &mut visited) {
+            Some(CollisionShape::TriMesh { vertices, indices }) => {
+                assert_eq!(indices.len(), 1);
+                let n = tri_normal(&vertices, indices[0]);
+                assert!(
+                    n.y > 0.99,
+                    "backwards-wound triangle must be corrected to match its \
+                     authored +Z normal, reading +Y (up) in engine space; got {n:?}"
+                );
+            }
+            other => panic!("expected TriMesh, got {other:?}"),
+        }
+    }
+
+    /// Sibling of the above: a triangle whose raw winding ALREADY agrees
+    /// with its authored normal must be left untouched — the check must
+    /// not double-flip a correctly-wound triangle.
+    #[test]
+    fn tri_strips_triangle_already_matching_authored_normal_is_untouched() {
+        let mut scene = NifScene::default();
+        scene.havok_scale = 1.0;
+        scene.blocks.push(Box::new(BhkNiTriStripsShape {
+            data_refs: vec![BlockRef(1u32)],
+            material: 0,
+            radius: 0.0,
+            scale: [1.0, 1.0, 1.0, 0.0],
+            filters: Vec::new(),
+        }));
+        let p = |x: f32, y: f32| NiPoint3 { x, y, z: 0.0 };
+        let up = NiPoint3 {
+            x: 0.0,
+            y: 0.0,
+            z: 1.0,
+        };
+        scene.blocks.push(tri_strips_data_with_normals(
+            vec![p(0.0, 0.0), p(1.0, 0.0), p(0.0, 1.0)],
+            vec![up, up, up],
+            // Natural (0,1,2) → (1,0,0)×(0,1,0) = +Z, already agrees.
+            vec![0, 1, 2],
+        ));
+        let mut visited = HashSet::new();
+        match resolve_shape(&scene, BlockRef(0u32), &mut visited) {
+            Some(CollisionShape::TriMesh { vertices, indices }) => {
+                assert_eq!(indices.len(), 1);
+                assert_eq!(
+                    indices[0],
+                    [0, 1, 2],
+                    "already-correct winding must not be altered"
+                );
+                let n = tri_normal(&vertices, indices[0]);
+                assert!(n.y > 0.99, "got {n:?}");
             }
             other => panic!("expected TriMesh, got {other:?}"),
         }

--- a/crates/renderer/src/vulkan/acceleration/predicates.rs
+++ b/crates/renderer/src/vulkan/acceleration/predicates.rs
@@ -417,7 +417,7 @@ pub(super) fn blas_over_budget(
 
 /// Decide whether a `DrawCommand` should emit a TLAS instance.
 ///
-/// Two-axis gate (#516 + #1024):
+/// Three-axis gate (#516 + #1024 + #2297):
 /// - `in_tlas == false` excludes particles / UI quads / other
 ///   draws that are by design rasterized-only.
 /// - `is_water == true` excludes water surfaces unconditionally
@@ -427,12 +427,33 @@ pub(super) fn blas_over_budget(
 ///   `for_rt = false` (no BLAS allocated), this predicate keeps the
 ///   exclusion explicit on the consumer side so a future BLAS-add
 ///   on the same mesh handle can't silently reintroduce self-hits.
+/// - `material_kind == MATERIAL_KIND_FIRE_REFRACTION` is excluded to
+///   match that constant's own documented contract (raster-only: "must
+///   not cast shadows, receive GI hits, enter reflections, or
+///   synthesize a physics collider" —
+///   `scene_buffer::constants::MATERIAL_KIND_FIRE_REFRACTION`). Today
+///   the only production producer of `in_tlas == true` draws
+///   (`render::static_meshes`) already computes `in_tlas = false` for
+///   this kind, so this arm is currently redundant with that upstream
+///   gate — kept here as defense-in-depth (#2297 / MAT-D1-NEW-02) so a
+///   future producer that forgets the exclusion still can't slip a
+///   fire-refraction proxy into the TLAS through this consumer-side
+///   choke point, mirroring the `is_water` precedent above.
+///
+///   `MATERIAL_KIND_EFFECT_SHADER` is deliberately NOT excluded here:
+///   `render::static_meshes` retains effect-shader surfaces in the TLAS
+///   on purpose, so optical/GI rays can see them even though opaque
+///   shadow masks don't (`shadow_mask_for_instance` below routes them
+///   to `VISIBILITY_LAYER_EFFECT` for exactly that reason). Excluding
+///   it here would silently break that design.
 ///
 /// Pure function so the unit test can pin the contract without a
 /// live Vulkan device.
 #[inline]
 pub(super) fn draw_command_eligible_for_tlas(draw_cmd: &DrawCommand) -> bool {
-    draw_cmd.in_tlas && !draw_cmd.is_water
+    draw_cmd.in_tlas
+        && !draw_cmd.is_water
+        && draw_cmd.material_kind != crate::vulkan::scene_buffer::MATERIAL_KIND_FIRE_REFRACTION
 }
 
 /// Prior writer to the shared `blas_scratch_buffer` within the current

--- a/crates/renderer/src/vulkan/acceleration/tests.rs
+++ b/crates/renderer/src/vulkan/acceleration/tests.rs
@@ -146,6 +146,24 @@ fn effect_shader_surface_is_tlas_eligible_for_optical_rays() {
     assert!(draw_command_eligible_for_tlas(&cmd));
 }
 
+/// Regression for #2297 / MAT-D1-NEW-02. `MATERIAL_KIND_FIRE_REFRACTION`
+/// is documented raster-only (`scene_buffer::constants`: "must not cast
+/// shadows, receive GI hits, enter reflections, or synthesize a physics
+/// collider") — must be excluded from the TLAS even with `in_tlas=true`,
+/// mirroring the `is_water` precedent. Today `render::static_meshes`
+/// already computes `in_tlas=false` for this kind, so this is
+/// defense-in-depth against a future producer that forgets to.
+#[test]
+fn fire_refraction_surface_excluded_even_with_in_tlas_set() {
+    let mut cmd = make_draw_command(true, false);
+    cmd.material_kind = crate::MATERIAL_KIND_FIRE_REFRACTION;
+    assert!(
+        !draw_command_eligible_for_tlas(&cmd),
+        "MATERIAL_KIND_FIRE_REFRACTION must exclude the draw from the \
+         TLAS regardless of in_tlas (raster-only per its own doc contract)"
+    );
+}
+
 /// Regression for #679 / AS-8-9. The skinned-BLAS rebuild
 /// predicate must fire only when the in-place refit chain has
 /// reached the configured threshold; below the threshold the

--- a/docs/engine/nifal.md
+++ b/docs/engine/nifal.md
@@ -365,7 +365,11 @@ Text-key events are wired (`NiControllerSequence.text_keys_ref` →
 `AnimationClip.text_keys` → `AnimationTextKeyEvents` ECS → scripting); embedded
 controllers set `text_keys: Vec::new()` by design (mesh-local controllers carry no
 event keys). Intentionally parked (captured, no renderer consumer yet, *not*
-leaks): per-light **ambient** colour channels and **morph-weight** channels.
+a leak): per-light **ambient** colour channels. **Morph-weight** channels are
+NOT in this state — since `a8b0cf64` they reach a live `AnimatedMorphWeights`
+ECS sink every frame (confirmed by `sink_lifecycle_end_to_end_tests`); they
+only lack a downstream GPU/mesh-vertex-blend consumer, tracked separately by
+#2221.
 
 `anim_convert::convert_nif_clip` is the single NIF→core boundary, but not the
 only production boundary for the canonical `AnimationClip`: Skyrim's cart/


### PR DESCRIPTION
…ire-refraction exclusion, tri-strips normal cross-check, nifal.md morph-weight wording

#2296 — crates/nif depends on byroredux-core only, never byroredux-renderer, so the NIF importer's material_kind = 101/102/103 literals (dedicated_shader.rs, legacy_properties.rs) had no compile-time link to byroredux_renderer::MATERIAL_KIND_*; only literal-to-literal in-crate tests existed. Added a cross-crate assert in byroredux/src/material_translate.rs (the one crate depending on both) pinning the raw literals to the named constants, so a future renumber breaks loudly instead of silently misrouting shading.

#2297 — the issue's evidence quoted draw_command_eligible_for_tlas as already excluding MATERIAL_KIND_EFFECT_SHADER and needing the same exclusion added for MATERIAL_KIND_FIRE_REFRACTION. That shape never existed in this function's git history: it has been "in_tlas && !is_water" since the commit that created it, no material_kind check ever present. Investigated instead of applying the suggested fix as-is: FIRE_REFRACTION is already excluded from the TLAS today via render::static_meshes's in_tlas computation (the single real producer of in_tlas=true draws), whose own comment states EFFECT_SHADER is deliberately retained in the TLAS so optical/GI rays can see it — confirmed by the pre-existing
effect_shader_surface_is_tlas_eligible_for_optical_rays test. Adding an EFFECT_SHADER exclusion here, as the issue's evidence implied, would have reintroduced a real regression against that documented design. Added only the FIRE_REFRACTION exclusion, as genuine defense-in-depth (currently redundant with the producer-side gate, guards a future producer that forgets it) — mirrors the is_water precedent in the same function. Full reasoning in INVESTIGATION.md.

#2302 — NiTriStripsData.normals (per-vertex, parsed) was never cross-checked by the bhkNiTriStripsShape collision path (resolve_tri_strips_data_refs), unlike packed_triangle_winding's per-triangle authored-normal check for the sibling BhkPackedNiTriStripsShape path (#2193). Added
tri_strips_triangle_winding, which sums the three corner vertex normals as the authored reference direction (the per-vertex-normal analog of PackedTriangle's single per-triangle normal) and corrects the winding on disagreement, mirroring packed_triangle_winding's sign check. No-ops when normals is empty or mismatched in length (older NIF versions may omit per-vertex normals). Not a fix for #2193 itself — that investigation already hand-verified zero disagreements across all 913 triangles of its repro content — this is defense-in-depth for content that repro didn't cover.

#2303 — docs/engine/nifal.md lumped morph-weight channels in with genuinely-parked per-light ambient channels ("intentionally parked, no renderer consumer yet, not a leak"). Since a8b0cf64, morph-weight channels reach a live AnimatedMorphWeights ECS sink every frame (confirmed by sink_lifecycle_end_to_end_tests, and by live writers in anim_convert.rs/boot.rs) — they only lack a downstream GPU/mesh-vertex- blend consumer, tracked separately by #2221. Ambient genuinely is still dropped. Split the sentence to describe the two different states accurately.