### PR TITLE
Fix #2656 #2657 #2658 #2659: papyrus flag-loop newline crossing, ques…

### DIFF
--- a/.claude/issues/2656 2657 2658 2659/INVESTIGATION.md
+++ b/.claude/issues/2656 2657 2658 2659/INVESTIGATION.md
@@ -1,0 +1,72 @@
+# Investigation notes
+
+## #2657 — mostly already fixed by an unrelated intervening commit
+
+Before touching anything, reading `crates/scripting/src/translate/effects.rs` showed
+`receiver_object` and `explicit_quest_receiver` ALREADY normalizing the lookup key
+through `quest_property_key` (strip `::` prefix / `_var` suffix, lowercase) — the
+exact fix #2657's mismatch #1 asked for, including a doc comment explicitly citing
+"(#2657)". `git log -S "fn quest_property_key"` traced it to `53f7de9d` ("Fix #2653:
+require an unambiguous quest receiver for Reset() and SetActive()"), landed the same
+day as #2657 was filed, which incidentally normalized the same key space while fixing
+a different, adjacent ambiguity. A hand-built `::MQ101_var` AST test already existed
+too (`effects.rs` test `quest_start_on_a_direct_property_declines_rather_than_mislowering_to_scene`).
+
+What genuinely remained open: mismatch #2 (the type test is exact `Type::Object("quest")`,
+missing Quest-*derived* script types like `mq206script`). Investigated whether this is
+fixable without new infrastructure — it isn't: `quest_property_names` only has the one
+`Script` AST in scope, with no script-class-hierarchy resolver anywhere in the codebase
+to answer "does `mq206script` transitively extend `Quest`?". Building one is out of
+scope for this pass (would need either loading + extends-chain-resolving every script
+in a load order, or a `.pex`-side type table with the same missing hierarchy info).
+Not attempted — documented in-code (`quest_property_names`'s doc comment) and flagged
+here as a candidate follow-up issue rather than guessed at with a naming heuristic
+(e.g. "ends in *quest*" would violate the project's no-guessing policy and misclassify
+real non-quest scripts).
+
+Added one regression test exercising the FULL production pipeline
+(`populate_quest_fragments_from_script`, not just the lower-level `classify_effect`
+primitive) with a hand-built `::MQ101_var.Start()` AST, confirming mismatch #1's fix
+holds end-to-end through the real call path.
+
+## #2658 — real corpus measurement after the fix
+
+Ran `fragment_coverage` (release) against `Skyrim - Misc.bsa` (14026 .pex) +
+`Fallout4 - Misc.ba2` (7875 .pex) after switching it to
+`lower_fragment_with_quest_properties`:
+
+```
+fully lowered (claimed): 9361 (32.6% of behavioral)
+StartQuest   44   (was ~0 in the issue's pre-fix "context-free" measurement)
+StopQuest   747   (was ~728)
+StartScene  810
+StopScene   249
+```
+
+Non-zero `StartQuest`/`StopQuest` on real content, where the issue's evidence showed
+near-zero pre-fix, is the direct empirical confirmation that #2657's key-normalization
+fix is now actually exercised by a harness that matches production. Total "claimed"
+count is unchanged (9361) — expected, since this fix reclassifies WITHIN the claimed
+set (StartScene → StartQuest), it doesn't change whether a fragment claims at all.
+
+## #2659 — Arc snapshot chosen over "move the bail"
+
+The issue offered two alternatives. Investigated "move the bail ahead of the clone"
+first and found it's not a simple reorder: `DeferredFragmentEffects::new` (which does
+the `QuestDefinitionRegistry` clone) must run OUTSIDE the `QuestStageState`/
+`QuestObjectiveState` mutable-guard scope — that's the specific lock-ordering
+constraint `#2539` (`6ad64ef6`) fixed, confirmed by reading that commit directly. Since
+whether there's "work to do" (`queue.is_empty()`) can only be known AFTER draining the
+journal, which needs those same guards, the only way to bail-before-clone is to
+acquire the guards twice (build+check the queue, drop, clone the registry, re-acquire
+for dispatch) — and this codebase's scheduler is genuinely parallel (rayon-backed,
+`crates/core/src/ecs/scheduler.rs`), so a dropped-then-reacquired guard window is a
+real (if narrow) behavioral change, not just a lock-ordering non-issue.
+
+Took the lower-risk second option instead: made `QuestDefinitionRegistry`'s clone
+O(1) by `Arc`-wrapping its internal map, so the existing unconditional clone stops
+being expensive rather than trying to avoid calling it. Zero control-flow changes in
+`fragment.rs`'s dispatch system. Verified soundness (both writers take `&mut World`,
+so no reader can hold a stale `Arc` clone while a write via `Arc::make_mut` happens)
+and correctness (a write after a snapshot is taken must clone-on-write, not mutate the
+snapshot) with dedicated tests in `quest_stages.rs`.

--- a/.claude/issues/2656 2657 2658 2659/ISSUE.md
+++ b/.claude/issues/2656 2657 2658 2659/ISSUE.md
@@ -1,0 +1,41 @@
+# #2656 — SCR-D4-NEW11-01: parse_property_flags reaches across the newline and swallows the Auto of a following Auto State
+
+**Severity**: MEDIUM · **Domain**: papyrus (byroredux-papyrus)
+**Location**: `crates/papyrus/src/parser/script.rs:421-453` (`parse_property_flags`), interacting with `mod.rs:77-87` (`peek_with_span`) and `script.rs:551-557` (`parse_state`)
+
+`parse_property_flags` is a `loop { match self.peek() { ... } }`, and `Parser::peek` skips `Token::Newline`. So the flag loop doesn't stop at the end of the property declaration line — it scans into subsequent lines. `Auto` is both a property flag AND the leading token of a top-level `Auto State` item, so a short-form property declaration immediately followed by `Auto State` has its `Auto` consumed by the property's flag loop, and `parse_state` builds the state with `is_auto: false`, silently, no diagnostic. Only vulnerable flag loop (checked all six) — `Auto` is the only flag that's also a legal item-starter. Bounded today: `is_auto` has no runtime consumer, `.pex` path hardcodes it false, `parse_script` has no production caller.
+
+**Suggested fix**: have `parse_property_flags` stop at a `Newline` (peek raw inside the loop, or track the property declaration's line and break on crossing it). Add regression tests (cases A-E from the issue). Make the `r5_round_trip` fixture assertion independent of the trailing doc comment (currently passes only by accident).
+
+---
+
+# #2657 — SCR-D5-NEW11-01: Regression of #2538: known_quest_properties guard never fires on decompiled .pex — the fix is inert on real input
+
+**Severity**: MEDIUM · **Domain**: scripting (byroredux-scripting)
+**Location**: `crates/scripting/src/translate/effects.rs:1044-1071` (`receiver_object`), `crates/scripting/src/fragment.rs:1170-1184` (`quest_property_names`), regression test at `effects.rs:1425-1492`
+
+Two independent key-space mismatches make #2538's guard unreachable on the only input the production path ever sees: (1) `quest_property_names` stores the lowercased authored property name (`mq101`), but `receiver_object` looks up the identifier straight off `Expr::Ident` — a decompiled `.pex` auto-property read is the backing variable `::MQ101_var`, not `MQ101`; `ObjectRef::property_name()` strips that decoration but is only applied downstream at dispatch, never before this lookup. (2) the type test is an exact `Type::Object("quest")` match, missing Quest-*derived* script types (`mq206script` etc). Real-corpus evidence: 63 Start/StopScene effects whose receiver is literally a Quest-typed property of the same script, surviving the #2538 fix unchanged. Low *runtime* impact (a dispatch-time fallback already resolves most of these correctly) but the fix itself is inert, and where the guard would fire it declines the *whole fragment* (worse than the fallback).
+
+**Suggested fix**: normalize the lookup key through `ObjectRef::property_name()` semantics before consulting `known_quest_properties`; widen `quest_property_names` to accept Quest-derived script types (or key off the `.pex` property type table). Then use the set *positively*: `explicit_quest_receiver` should accept `QuestRef::Property(name)` when known-Quest, lowering to `Effect::StartQuest` instead of declining. Add a regression test built from a hand-constructed `::X_var` AST (the `.psc` parser can't express this shape).
+
+---
+
+# #2658 — SCR-D5-NEW11-03: fragment_coverage and mq101_conformance measure the context-free lowering path, not the production one
+
+**Severity**: MEDIUM · **Domain**: scripting (byroredux-scripting)
+**Location**: `crates/scripting/examples/fragment_coverage.rs:147`, `crates/scripting/examples/mq101_conformance.rs:1407,1450`
+
+Both harnesses call `lower_fragment` (empty quest-property set) while the single production caller (`fragment.rs::populate_quest_fragments_from_script`) calls `lower_fragment_with_quest_properties` with a real set. Today the two paths happen to agree exactly (9361/9361, 11284/11284) *only because of* #2657's bug — once that's fixed, the harnesses will silently diverge from production, and the M47.3 Phase-2 coverage checkbox can't be honestly ticked from the harness as written.
+
+**Suggested fix**: lift `quest_property_names` out of `fragment.rs` into `translate::effects` (or `pub(crate)` + re-export), have both examples call `lower_fragment_with_quest_properties` with the per-script set. Consider marking `lower_fragment` `#[doc(hidden)]`/test-only so future call sites can't accidentally pick the context-free path.
+
+---
+
+# #2659 — SCR-D6-NEW11-02: DeferredFragmentEffects::new deep-clones the whole QuestDefinitionRegistry every frame, before the early-bail
+
+**Severity**: MEDIUM · **Domain**: scripting (byroredux-scripting)
+**Location**: `crates/scripting/src/fragment.rs:335-341` (`DeferredFragmentEffects::new`), consumed by `quest_fragment_dispatch_system`; early-bail at `:1372-1374`
+
+The #2539 fix correctly snapshot-clones `QuestDefinitionRegistry` before taking the `(QuestStageState, QuestObjectiveState)` write guards (eliminating a nested-lock issue), but the clone happens unconditionally in `new()`, *before* the `queue.is_empty() || frags.is_empty()` bail. A frame with no quest activity still deep-copies the entire registry. Measured: 0.651 ms/frame on real Skyrim.esm (1811 QUST records); 15.6 ms/frame (entire frame budget) on a synthetic 5,000-quest load order. The registry's only writers run at load time (`&mut World`), so it's immutable for the whole frame being copied.
+
+**Suggested fix**: move the bail ahead of the clone (construct `DeferredFragmentEffects` lazily, only once there's work to do) — or replace the deep clone with an `Arc` snapshot swapped on mutation (sound and free since writers are load-time-only).

--- a/crates/papyrus/src/parser/script.rs
+++ b/crates/papyrus/src/parser/script.rs
@@ -418,32 +418,44 @@ impl Parser {
         })
     }
 
+    /// #2656 (SCR-D4-NEW11-01) — matches on [`Self::peek_raw`], NOT
+    /// [`Self::peek`]. `peek` skips `Token::Newline`, so a loop driven by
+    /// it doesn't stop at the end of the property declaration line — it
+    /// scans into subsequent lines looking for more flags. `Auto` is both
+    /// a property flag AND the leading token of a top-level `Auto State`
+    /// item, so a short-form property declaration immediately followed by
+    /// `Auto State` had its `Auto` swallowed here, and `parse_state` built
+    /// the state with `is_auto: false` — silently, no diagnostic. Per the
+    /// grammar (`type Property IDENT (= expr)? property_flag* NEWLINE`),
+    /// every flag is on the property's own line, so stopping at the raw
+    /// next token being a `Newline` (rather than skipping past it) is
+    /// exactly the intended boundary.
     fn parse_property_flags(&mut self) -> PropertyFlags {
         let mut flags = PropertyFlags::empty();
         loop {
-            match self.peek() {
+            match self.peek_raw() {
                 Some(Token::KwAuto) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::AUTO;
                 }
                 Some(Token::KwAutoReadOnly) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::AUTO_READ_ONLY;
                 }
                 Some(Token::KwConst) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::CONST;
                 }
                 Some(Token::KwMandatory) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::MANDATORY;
                 }
                 Some(Token::KwHidden) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::HIDDEN;
                 }
                 Some(Token::KwConditional) => {
-                    self.advance().unwrap();
+                    self.advance_raw().unwrap();
                     flags |= PropertyFlags::CONDITIONAL;
                 }
                 _ => break,
@@ -972,6 +984,122 @@ EndState
             }
             other => panic!("expected State, got {other:?}"),
         }
+    }
+
+    // ── #2656 (SCR-D4-NEW11-01) — short-form property flags must not
+    // reach across the newline into a following `Auto State` ──────
+
+    fn find_state<'a>(s: &'a Script, name: &str) -> &'a State {
+        s.body
+            .iter()
+            .find_map(|item| match &item.node {
+                ScriptItem::State(state) if state.name.node.0 == name => Some(state),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no state named {name:?} in parsed script"))
+    }
+
+    /// Case A (the bug). A short-form `Auto` property immediately
+    /// followed by `Auto State` — pre-fix, `parse_property_flags`
+    /// scanned past the property's own newline and consumed the
+    /// state's `Auto`, so `Waiting.is_auto` came out `false` with zero
+    /// reported errors.
+    #[test]
+    fn property_immediately_before_auto_state_does_not_swallow_its_auto() {
+        let src = "\
+ScriptName Foo
+
+Int Property Bar = 5 Auto
+
+Auto State Waiting
+EndState
+";
+        let s = parse(src);
+        assert!(
+            find_state(&s, "Waiting").is_auto,
+            "the state's own Auto must not be consumed by the preceding \
+             property's flag loop (#2656)"
+        );
+    }
+
+    /// Case B (control). The same adjacency, but a plain (non-Auto)
+    /// `State` — must read `is_auto == false`, so this and case A are
+    /// verified to produce genuinely DIFFERENT ASTs. Pre-fix, A and B
+    /// produced byte-identical ASTs (both `false`) because the bug
+    /// swallowed A's `Auto` regardless of what state followed.
+    #[test]
+    fn property_immediately_before_plain_state_reports_not_auto() {
+        let src = "\
+ScriptName Foo
+
+Int Property Bar = 5 Auto
+
+State Waiting
+EndState
+";
+        let s = parse(src);
+        assert!(!find_state(&s, "Waiting").is_auto);
+    }
+
+    /// Case C. A `Function` item between the property and the `Auto
+    /// State` already broke the buggy loop pre-fix (`Function` isn't a
+    /// flag token) — pinned so a future refactor can't silently
+    /// reintroduce a wider reach that this case would have caught.
+    #[test]
+    fn property_before_auto_state_separated_by_function_stays_auto() {
+        let src = "\
+ScriptName Foo
+
+Int Property Bar = 5 Auto
+
+Function DoNothing()
+EndFunction
+
+Auto State Waiting
+EndState
+";
+        let s = parse(src);
+        assert!(find_state(&s, "Waiting").is_auto);
+    }
+
+    /// Case D. A full-form property (its own `EndProperty` terminates
+    /// `parse_property_accessors` before `parse_state` ever runs) — was
+    /// already safe pre-fix, pinned as a control.
+    #[test]
+    fn full_form_property_before_auto_state_stays_auto() {
+        let src = "\
+ScriptName Foo
+
+Int Property Bar
+  Int Function GetBar()
+    Return 5
+  EndFunction
+EndProperty
+
+Auto State Waiting
+EndState
+";
+        let s = parse(src);
+        assert!(find_state(&s, "Waiting").is_auto);
+    }
+
+    /// Case E. A top-level variable declaration between the property
+    /// and the `Auto State` — also already safe pre-fix (`Ident` isn't
+    /// a flag token either), pinned as a control.
+    #[test]
+    fn property_before_auto_state_separated_by_variable_stays_auto() {
+        let src = "\
+ScriptName Foo
+
+Int Property Bar = 5 Auto
+
+Int SomeVar = 0
+
+Auto State Waiting
+EndState
+";
+        let s = parse(src);
+        assert!(find_state(&s, "Waiting").is_auto);
     }
 
     /// #2125 — a parser-level error in ONE function inside a `State` must

--- a/crates/papyrus/tests/r5_round_trip.rs
+++ b/crates/papyrus/tests/r5_round_trip.rs
@@ -92,6 +92,19 @@ fn parse_default_rumble_on_activate() {
     assert!(state_names.contains(&"inactive"));
 
     // `active` is the Auto state.
+    //
+    // #2656 (SCR-D4-NEW11-01) — this assertion alone does NOT prove
+    // `parse_property_flags` stops at the property's own line: the
+    // `shakeRight` property immediately preceding `Auto State active`
+    // in this fixture has a trailing `{ doc comment }` on the next
+    // line, which happens to break the (pre-fix) buggy flag loop before
+    // it could reach the state's `Auto` — an accident of this
+    // fixture's formatting, not a property of the parser. The real,
+    // fixture-independent regression coverage (a short-form property
+    // with NO trailing doc comment immediately before `Auto State`) is
+    // `parser::script::tests::property_immediately_before_auto_state_
+    // does_not_swallow_its_auto` and its siblings in
+    // `crates/papyrus/src/parser/script.rs`.
     let active = states.iter().find(|s| s.name.node.0 == "active").unwrap();
     assert!(active.is_auto, "'active' must be the Auto state");
 }

--- a/crates/scripting/examples/fragment_coverage.rs
+++ b/crates/scripting/examples/fragment_coverage.rs
@@ -25,7 +25,8 @@ use std::collections::BTreeMap;
 use byroredux_bsa::{Ba2Archive, BsaArchive};
 use byroredux_papyrus::ast::ScriptItem;
 use byroredux_pex::{decompile::decompile_script, parse};
-use byroredux_scripting::translate::effects::{lower_fragment, Effect};
+use byroredux_scripting::fragment::quest_property_names;
+use byroredux_scripting::translate::effects::{lower_fragment_with_quest_properties, Effect};
 
 enum Archive {
     Bsa(BsaArchive),
@@ -126,6 +127,11 @@ fn main() {
             else {
                 continue;
             };
+            // #2658 (SCR-D5-NEW11-03) — computed once per script, matching
+            // the production caller (`populate_quest_fragments_from_script`),
+            // and fed to `lower_fragment_with_quest_properties` below so
+            // this measures the SAME lowering path production runs.
+            let quest_properties = quest_property_names(&script);
             for item in &script.body {
                 let ScriptItem::Function(func) = &item.node else {
                     continue;
@@ -144,7 +150,9 @@ fn main() {
                     continue;
                 }
                 behavioral += 1;
-                if let Some(effects) = lower_fragment(&func.body) {
+                if let Some(effects) =
+                    lower_fragment_with_quest_properties(&func.body, &quest_properties)
+                {
                     claimed += 1;
                     claimed_effects += effects.len();
                     for e in &effects {

--- a/crates/scripting/examples/mq101_conformance.rs
+++ b/crates/scripting/examples/mq101_conformance.rs
@@ -29,9 +29,10 @@ use byroredux_plugin::esm::records::script_instance::SceneFragmentEvent;
 use byroredux_plugin::esm::records::{
     SceneActionType, QUEST_FLAG_START_GAME_ENABLED, SCENE_BEGIN_ON_QUEST_START,
 };
+use byroredux_scripting::fragment::quest_property_names;
 use byroredux_scripting::papyrus_demo::PlayerEntity;
 use byroredux_scripting::quest_stages::QuestStageState;
-use byroredux_scripting::translate::effects::{lower_fragment, Effect};
+use byroredux_scripting::translate::effects::{lower_fragment_with_quest_properties, Effect};
 use byroredux_scripting::{
     dispatch_player_cinematic_animation_event, image_space_modifier_system,
     install_engine_start_quest, install_image_space_modifiers, install_scene_quest_aliases,
@@ -1384,6 +1385,13 @@ fn run() -> Result<Checks, Box<dyn Error>> {
                                 _ => None,
                             })
                             .collect();
+                        // #2658 (SCR-D5-NEW11-03) — computed once per script,
+                        // matching the production caller
+                        // (`populate_quest_fragments_from_script`), and fed to
+                        // `lower_fragment_with_quest_properties` at both call
+                        // sites below so this conformance gate measures the
+                        // SAME lowering path production runs.
+                        let quest_properties = quest_property_names(&script);
 
                         let mut missing_bindings = Vec::new();
                         let mut no_op = 0usize;
@@ -1404,7 +1412,10 @@ fn run() -> Result<Checks, Box<dyn Error>> {
                                 continue;
                             }
                             behavioral += 1;
-                            if let Some(fragment_effects) = lower_fragment(&function.body) {
+                            if let Some(fragment_effects) = lower_fragment_with_quest_properties(
+                                &function.body,
+                                &quest_properties,
+                            ) {
                                 lowered += 1;
                                 for effect in &fragment_effects {
                                     *effects.entry(effect_kind(effect)).or_default() += 1;
@@ -1445,9 +1456,9 @@ fn run() -> Result<Checks, Box<dyn Error>> {
                                 )
                             },
                         );
-                        let cart_init_effects = functions
-                            .get("fragment_175")
-                            .and_then(|function| lower_fragment(&function.body));
+                        let cart_init_effects = functions.get("fragment_175").and_then(|function| {
+                            lower_fragment_with_quest_properties(&function.body, &quest_properties)
+                        });
                         let cart_init_kinds = cart_init_effects.as_ref().map(|effects| {
                             let mut kinds = BTreeMap::<&'static str, usize>::new();
                             for effect in effects {

--- a/crates/scripting/src/fragment.rs
+++ b/crates/scripting/src/fragment.rs
@@ -390,6 +390,14 @@ pub struct DeferredFragmentEffects {
 
 impl DeferredFragmentEffects {
     /// Snapshot fragment resources before acquiring the quest-state guards.
+    ///
+    /// Called unconditionally by every production caller of this batch,
+    /// including on frames with no quest-stage activity at all — see
+    /// [`quest_fragment_dispatch_system`]'s early-bail, which runs AFTER
+    /// this snapshot for the #2539 lock-ordering reason documented on the
+    /// struct above. `QuestDefinitionRegistry::clone()` is an O(1) `Arc`
+    /// refcount bump (#2659 / SCR-D6-NEW11-02), not a deep copy — that's
+    /// what keeps this unconditional call cheap on every load-order size.
     pub fn new(world: &World) -> Self {
         Self {
             quest_definitions: world
@@ -1238,7 +1246,31 @@ pub fn register(world: &mut World) {
 /// one, which the AST alone cannot. Properties are always top-level
 /// (never nested in a `State` block, unlike functions/events), so no
 /// `StateItem` walk is needed here.
-fn quest_property_names(script: &Script) -> std::collections::HashSet<String> {
+///
+/// #2657 (SCR-D5-NEW11-01) — the receiver-side key-space mismatch (a
+/// decompiled `.pex` reads a property through its `::X_var` backing
+/// variable, not the authored name this set is keyed by) is fixed;
+/// `receiver_object`/`explicit_quest_receiver` normalize through
+/// `quest_property_key` before consulting this set (#2653, `53f7de9d`).
+///
+/// A SEPARATE, still-open gap from the same issue: the type test below
+/// is an exact `Type::Object("quest")` match, so a property typed with a
+/// Quest-*derived* script (`mq206script`, `dn019script`, `min03script`,
+/// …) is never collected — real corpus content does this. Closing it
+/// needs a script-class-hierarchy resolver (something that can answer
+/// "does `mq206script` transitively extend `Quest`?"); nothing in this
+/// crate builds one today, and this single-`Script` function has no
+/// access to any other script's `extends` declaration to improvise one.
+/// Not attempted here — flagged as a candidate follow-up issue rather
+/// than guessed at with a naming-convention heuristic.
+///
+/// `pub` (#2658 / SCR-D5-NEW11-03) — so `examples/fragment_coverage.rs`
+/// and `examples/mq101_conformance.rs` can build the same per-script set
+/// this function's one production caller
+/// ([`populate_quest_fragments_from_script`]) does, and measure
+/// `lower_fragment_with_quest_properties` (what production actually
+/// runs) instead of context-free `lower_fragment`.
+pub fn quest_property_names(script: &Script) -> std::collections::HashSet<String> {
     script
         .body
         .iter()

--- a/crates/scripting/src/fragment/tests.rs
+++ b/crates/scripting/src/fragment/tests.rs
@@ -598,6 +598,87 @@ fn populate_from_script_skips_absent_and_declined_fragments() {
     assert!(frags.get(Q, 7).is_none(), "absent fragment not registered");
 }
 
+/// Regression for #2657 (SCR-D5-NEW11-01), pinned end-to-end through the
+/// REAL production entry point (`populate_quest_fragments_from_script`),
+/// not just the lower-level `classify_effect`/`lower_fragment_with_
+/// quest_properties` primitives `translate::effects`'s own test already
+/// covers. A decompiled `.pex` auto-property read arrives as its backing
+/// variable (`::MQ101_var`), a shape the `.psc` `Ident` regex can never
+/// produce — `first_fn_body`-style `parse_script` fixtures elsewhere in
+/// this file cannot express this AST, so it's hand-built here, mirroring
+/// `translate::effects::tests::sp`.
+///
+/// Confirmed by direct code inspection that `quest_property_key`'s
+/// `::`/`_var`-stripping normalization (added under #2653, `53f7de9d`)
+/// already fixes the key-space mismatch #2657 reported — this test locks
+/// that fix in against the exact real-input shape, through the exact
+/// call path production uses, so a future refactor of either
+/// `quest_property_names` or `receiver_object`/`explicit_quest_receiver`
+/// can't silently reopen it.
+#[test]
+fn populate_from_script_resolves_decompiled_backing_variable_quest_property() {
+    use byroredux_papyrus::ast::{Function, Identifier, Property};
+
+    fn sp<T>(node: T) -> Spanned<T> {
+        Spanned::new(node, byroredux_papyrus::span::Span::new(0, 0))
+    }
+
+    let script = Script {
+        name: sp(Identifier("QF_TestQuest".into())),
+        parent: Some(sp(Identifier("Quest".into()))),
+        flags: byroredux_papyrus::ast::ScriptFlags::empty(),
+        body: vec![
+            sp(ScriptItem::Property(Box::new(Property {
+                ty: sp(Type::Object(Identifier("Quest".into()))),
+                name: sp(Identifier("MQ101".into())),
+                flags: byroredux_papyrus::ast::PropertyFlags::AUTO,
+                initial_value: None,
+                getter: None,
+                setter: None,
+                doc_comment: None,
+            }))),
+            sp(ScriptItem::Function(Function {
+                return_type: None,
+                name: sp(Identifier("Fragment_99".into())),
+                params: Vec::new(),
+                flags: byroredux_papyrus::ast::FunctionFlags::empty(),
+                // The decompiler's actual shape for `MQ101.Start()`:
+                // `::MQ101_var.Start()`, not the `.psc`-expressible
+                // `MQ101.Start()`.
+                body: vec![sp(Stmt::ExprStmt(sp(
+                    byroredux_papyrus::ast::Expr::Call {
+                        callee: Box::new(sp(byroredux_papyrus::ast::Expr::MemberAccess {
+                            object: Box::new(sp(byroredux_papyrus::ast::Expr::Ident(
+                                Identifier("::MQ101_var".into()),
+                            ))),
+                            member: sp(Identifier("Start".into())),
+                        })),
+                        args: Vec::new(),
+                    },
+                )))],
+                doc_comment: None,
+            })),
+        ],
+    };
+
+    let bindings = [(1u16, "Fragment_99")];
+    let world = fixture();
+    let inserted = {
+        let mut frags = world.resource_mut::<QuestStageFragments>();
+        populate_quest_fragments_from_script(&mut frags, Q, &script, &bindings)
+    };
+    assert_eq!(
+        inserted, 1,
+        "MQ101.Start() (decompiled shape) must lower to StartQuest and \
+         register, not decline the fragment (#2657)"
+    );
+    let frags = world.resource::<QuestStageFragments>();
+    assert!(
+        frags.get(Q, 1).is_some(),
+        "the fragment must be registered for stage 1"
+    );
+}
+
 #[test]
 fn dispatch_resolves_property_targeted_effect_via_registered_vmad() {
     // The counterpart to `property_targeted_effect_skipped_without_vmad`:

--- a/crates/scripting/src/quest_stages.rs
+++ b/crates/scripting/src/quest_stages.rs
@@ -44,6 +44,7 @@ use byroredux_plugin::esm::records::{
     QUEST_FLAG_START_GAME_ENABLED, QUEST_LOG_FLAG_COMPLETE_QUEST, QUEST_LOG_FLAG_FAIL_QUEST,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
 use crate::papyrus_demo::PlayerEntity;
 
@@ -675,9 +676,21 @@ impl StartGameQuestRegistry {
     }
 }
 
+/// #2659 (SCR-D6-NEW11-02) — `definitions` is `Arc`-wrapped so
+/// `#[derive(Clone)]` is an O(1) refcount bump, not an O(quest count) deep
+/// copy. `DeferredFragmentEffects::new` (`fragment.rs`) clones this
+/// registry unconditionally, once per `quest_fragment_dispatch_system`
+/// call — measured up to the entire frame budget on a heavily-modded
+/// (5,000-quest) load order when it was a deep clone. Sound because the
+/// registry's only writers ([`install_start_game_quests`],
+/// [`install_engine_start_quest`]) take `world: &mut World` — an
+/// exclusive borrow that can't coexist with any system's outstanding
+/// `Arc` clone from a prior read — so every write either uniquely owns
+/// the `Arc` (in-place mutation via `Arc::make_mut`, no copy) or is the
+/// registry's very first population.
 #[derive(Debug, Clone, Default)]
 pub struct QuestDefinitionRegistry {
-    definitions: HashMap<QuestFormId, QuestDefinition>,
+    definitions: Arc<HashMap<QuestFormId, QuestDefinition>>,
 }
 
 impl Resource for QuestDefinitionRegistry {}
@@ -903,7 +916,7 @@ pub fn install_start_game_quests(
     let count = quests.len();
     world.resource_mut::<StartGameQuestRegistry>().quests = quests;
     world.resource_mut::<StartGameQuestRegistry>().initial_flags = initial_flags;
-    world.resource_mut::<QuestDefinitionRegistry>().definitions = definitions;
+    world.resource_mut::<QuestDefinitionRegistry>().definitions = Arc::new(definitions);
     count
 }
 
@@ -924,9 +937,7 @@ pub fn install_engine_start_quest(
         .quests
         .insert(quest, start_up_stage)
         != Some(start_up_stage);
-    world
-        .resource_mut::<QuestDefinitionRegistry>()
-        .definitions
+    Arc::make_mut(&mut world.resource_mut::<QuestDefinitionRegistry>().definitions)
         .entry(quest)
         .or_insert_with(|| QuestDefinition {
             editor_id: String::new(),
@@ -1600,5 +1611,71 @@ mod tests {
         assert_eq!(s.get_stage(q1), 0);
         assert_eq!(s.get_stage(q2), 30, "reset must be quest-scoped");
         assert!(s.get_stage_done(q2, 30));
+    }
+
+    // ── #2659 (SCR-D6-NEW11-02) — Arc-shared QuestDefinitionRegistry ──
+
+    /// Regression pinning the actual perf fix: `QuestDefinitionRegistry::
+    /// clone()` must share the underlying allocation (an `Arc` refcount
+    /// bump), not deep-copy it. `DeferredFragmentEffects::new`
+    /// (`fragment.rs`) calls this unconditionally on every
+    /// `quest_fragment_dispatch_system` invocation — a deep clone there
+    /// was measured at up to the entire frame budget on a heavily-modded
+    /// (5,000-quest) load order.
+    #[test]
+    fn registry_clone_shares_the_same_allocation() {
+        let mut world = World::new();
+        world.insert_resource(QuestDefinitionRegistry::default());
+        world.insert_resource(StartGameQuestRegistry::default());
+        install_engine_start_quest(&mut world, QuestFormId(0x1000), Some(10));
+
+        let original = world.resource::<QuestDefinitionRegistry>().clone();
+        let snapshot = original.clone();
+        assert!(
+            Arc::ptr_eq(&original.definitions, &snapshot.definitions),
+            "clone() must share the same Arc allocation, not deep-copy \
+             the definitions map (#2659)"
+        );
+    }
+
+    /// Correctness counterpart: once a snapshot clone is taken (as
+    /// `DeferredFragmentEffects::new` does before the quest-state guards
+    /// are acquired), a LATER write to the live registry (via
+    /// `Arc::make_mut`, which clones-on-write when the Arc is shared)
+    /// must NOT retroactively mutate that snapshot. If `Arc::make_mut`'s
+    /// clone-on-write ever failed to trigger here, a prior frame's
+    /// still-alive snapshot would silently observe a later frame's
+    /// writes — exactly the class of bug sharing the allocation could
+    /// introduce if done carelessly.
+    #[test]
+    fn write_after_snapshot_does_not_mutate_the_snapshot() {
+        let mut world = World::new();
+        world.insert_resource(QuestDefinitionRegistry::default());
+        world.insert_resource(StartGameQuestRegistry::default());
+        let quest_a = QuestFormId(0x1000);
+        install_engine_start_quest(&mut world, quest_a, Some(10));
+
+        // Snapshot BEFORE the second write, exactly like
+        // `DeferredFragmentEffects::new` does before taking the
+        // quest-state guards.
+        let snapshot = world.resource::<QuestDefinitionRegistry>().clone();
+        assert!(snapshot.contains(quest_a));
+        assert!(!snapshot.contains(QuestFormId(0x2000)));
+
+        let quest_b = QuestFormId(0x2000);
+        install_engine_start_quest(&mut world, quest_b, Some(20));
+
+        // The live registry sees both quests now...
+        assert!(world.resource::<QuestDefinitionRegistry>().contains(quest_a));
+        assert!(world.resource::<QuestDefinitionRegistry>().contains(quest_b));
+        // ...but the earlier snapshot must still see only the first —
+        // proving the shared allocation was cloned-on-write, not mutated
+        // through the snapshot's own (still-live) Arc handle.
+        assert!(snapshot.contains(quest_a));
+        assert!(
+            !snapshot.contains(quest_b),
+            "a write after the snapshot was taken must not retroactively \
+             appear in it (#2659 Arc clone-on-write correctness)"
+        );
     }
 }

--- a/crates/scripting/src/translate/effects.rs
+++ b/crates/scripting/src/translate/effects.rs
@@ -243,6 +243,17 @@ struct Scope {
 /// empty quest-property set, for the many call sites (mostly tests) with
 /// no script-level property metadata available — preserves this
 /// function's pre-#2538 behavior exactly for those.
+///
+/// #2658 (SCR-D5-NEW11-03) — `#[doc(hidden)]` because the context-free
+/// path is test-only by design: the single production caller
+/// (`fragment::populate_quest_fragments_from_script`) always calls
+/// [`lower_fragment_with_quest_properties`] with a real set instead. Two
+/// coverage/conformance measurement harnesses called this one anyway,
+/// which for a time made them measure a lowering path production never
+/// runs — hiding it from docs is a nudge against a future call site
+/// picking it by mistake, not an access restriction (both examples and
+/// every test in this crate can still see and call it fine).
+#[doc(hidden)]
 pub fn lower_fragment(body: &[Spanned<Stmt>]) -> Option<Vec<Effect>> {
     lower_fragment_with_quest_properties(body, &HashSet::new())
 }


### PR DESCRIPTION
…t-property guard verification, harness lowering-path parity, Arc-shared quest registry

#2656 — parse_property_flags's loop matched on peek() (skips Token::Newline), so it scanned past the end of the property's own declaration line into subsequent lines looking for more flags. Auto is both a property flag AND the leading token of a top-level Auto State item, so a short-form property declaration immediately followed by Auto State had its Auto silently swallowed, and parse_state built the state with is_auto: false — no diagnostic. Switched the loop to peek_raw()/advance_raw() so it stops at the property's own newline, matching the grammar (property_flag* NEWLINE). Verified all five other flag loops in the file are not vulnerable (none of their flags are also legal item-starters). Added cases A-E from the issue as dedicated regression tests, and annotated the r5_round_trip fixture assertion that used to pass only by accident (a trailing doc comment happened to break the buggy loop before it reached the state).

#2657 — investigated before applying the suggested fix: the key-space mismatch the issue reported (receiver_object looking up a decompiled ::X_var backing variable against a set keyed by the authored property name) was already fixed by 53f7de9d (Fix #2653), an unrelated same-day commit that happened to touch the same normalization helper (quest_property_key) and already carries a test citing "(#2657)". Added one more regression test exercising the actual production entry point (populate_quest_fragments_from_script) with a hand-built ::MQ101_var AST to confirm the fix holds end-to-end, not just at the primitive level. The second mismatch the issue reported (Quest-derived script types like mq206script not recognized by quest_property_names's exact Type::Object("quest") match) remains open — fixing it needs a script-class-hierarchy resolver this codebase doesn't have; documented in quest_property_names's doc comment and in INVESTIGATION.md as a follow-up rather than guessed at with a naming heuristic.

#2658 — fragment_coverage and mq101_conformance both called lower_fragment (empty quest-property context) while the only production caller uses lower_fragment_with_quest_properties with a real per-script set, so neither measured what the engine actually does. Made quest_property_names pub so both examples can build the same set the production caller does, switched both to the context-aware lowering call, and marked lower_fragment #[doc(hidden)] as a nudge against a future call site picking the context-free path by mistake (still fully callable — every test in the crate still uses it deliberately). Re-ran fragment_coverage against the real Skyrim SE
+ FO4 Misc archives: StartQuest/StopQuest counts are now non-zero on real content where the issue's pre-fix measurement showed near-zero, directly confirming #2657's fix is exercised by production-equivalent lowering.

#2659 — DeferredFragmentEffects::new deep-clones QuestDefinitionRegistry unconditionally, before quest_fragment_dispatch_system's queue.is_empty() || frags.is_empty() early-bail, on every call. Investigated "move the bail ahead of the clone" first: the clone must happen outside the QuestStageState/QuestObjectiveState mutable-guard scope (the #2539 lock-ordering fix), and knowing whether the queue is empty needs those same guards to drain the journal, so bailing first would require acquiring the guards twice — a real behavioral change given this scheduler is genuinely parallel (rayon-backed), not just a lock-ordering nuance. Took the lower-risk alternative instead: Arc-wrapped QuestDefinitionRegistry's internal map so its Clone impl is an O(1) refcount bump instead of a deep copy, leaving fragment.rs's control flow untouched. Sound because both writers (install_start_game_quests, install_engine_start_quest) take world: &mut World, so a write via Arc::make_mut never races a reader's outstanding Arc clone. Added tests pinning both the sharing (clone doesn't allocate) and the correctness (a write after a snapshot clones on write rather than mutating the snapshot).