### PR TITLE
Fix #2681 #2682 #2683 #2684: measure-then-disprove draw-sort key hoisting, self-swap fix, GpuBuffer flush SAFETY corrections, 6 unsafe fn docs

### DIFF
--- a/.claude/issues/2681 2682 2683 2684/ISSUE.md
+++ b/.claude/issues/2681 2682 2683 2684/ISSUE.md
@@ -1,0 +1,37 @@
+# Issues 2681, 2682, 2683, 2684
+
+All four filed from perf/safety audits (`docs/audits/AUDIT_PERFORMANCE_2026-08-12.md` and
+`docs/audits/AUDIT_SAFETY_2026-08-12.md`). Domain: **renderer** (`byroredux-renderer` /
+`byroredux` binary).
+
+## #2681 — PERF-D2-04: sort_draw_commands re-extracts the 11-tuple key from a ~480-byte DrawCommand on every comparison
+- **Severity**: LOW
+- **Location**: `byroredux/src/render/mod.rs` — `sort_draw_commands` / `draw_sort_key`
+- **Bug**: `sort_unstable_by_key`/`par_sort_unstable_by_key` re-evaluate `draw_sort_key` on each comparison (~2·N·log₂N extractions), each touching a ~480-byte `DrawCommand`. Sibling `collect_lights` was already converted to decorate-sort-undecorate for the same reason (#2034).
+- **Caveat (explicit in issue)**: "No quantitative guard exists for this site; do not land it on reasoning alone." Suggested fix: prototype decorate-sort-undecorate behind the existing `manual_bench_draw_sort_serial_vs_parallel` bench harness (sweeps N=400…10K), extend with a third arm, ship ONLY if the win survives at N=1800–3400 (actual runtime baseline range), and re-derive `DRAW_SORT_PARALLEL_THRESHOLD` together.
+- **Scope decision needed**: this requires a bench harness run + measurement, not a blind land — check what's actually feasible in this environment.
+
+## #2682 — PERF-D2-05: sort_draw_commands' in-place partition self-swaps ~480-byte DrawCommands
+- **Severity**: LOW (downgraded from MEDIUM by the auditor's own disproof)
+- **Location**: `byroredux/src/render/mod.rs` — `sort_draw_commands` (raster/RT-only partition loop)
+- **Bug**: `draw_commands.swap(raster_len, index)` called unconditionally; `<[T]>::swap` does a full 3-way copy even when `raster_len == index` (self-swap). Worst case O(N) wasted ~480B copies when nothing is culled (e.g. `BYRO_NO_CULL=1`).
+- **Fix** (one-liner, given in the issue): `if raster_len != index { draw_commands.swap(raster_len, index); }`.
+
+## #2683 — SAFE-D4-01: GpuBuffer flush SAFETY comments assert false facts
+- **Severity**: MEDIUM
+- **Location**: `crates/renderer/src/vulkan/buffer.rs` — `GpuBuffer::flush_if_needed` (SAFETY ~768-771, block ~772), `GpuBuffer::write_mapped`'s flush (SAFETY ~826-832, block ~833), `GpuBuffer::flush_range` (SAFETY ~870-872, block ~873); helper `aligned_flush_range` (~506-516)
+- **Bug**: Three `vkFlushMappedMemoryRanges` call sites' SAFETY comments claim the flushed range is "contained within this allocation's slice" and that "gpu-allocator already pads sub-allocations to nonCoherentAtomSize" — both false. `aligned_flush_range` rounds the offset DOWN and size UP, producing a strict superset of the allocation (widens outward), not a subset. gpu-allocator 0.28 has zero `nonCoherentAtomSize`/`non_coherent` awareness (verified in vendored source) — it only aligns to `VkMemoryRequirements.alignment`. `write_mapped`'s comment additionally claims a cap that `aligned_flush_range` never applies.
+- **Impact**: Not unsound today (every call site uses `AllocationScheme::GpuAllocatorManaged`, so widened range stays inside the parent multi-MB block) — but the comment is actively misleading for a future refactor (e.g. switching to `DedicatedBuffer` or exceeding gpu-allocator's 64MB host-visible block) that could put `offset+size` past the parent allocation with no guard.
+- **Suggested Fix**: Rewrite the three SAFETY comments to state the true invariant ("range is widened outward past the sub-allocation, bounded only by the parent gpu-allocator block, which is a multiple of NON_COHERENT_ATOM_SIZE"); add a `debug_assert!` that `aligned_offset + aligned_size <= <parent block size>` (or clamp) so a future dedicated-allocation regression fails loudly.
+
+## #2684 — SAFE-D4-03: six unsafe fn carry no # Safety doc section
+- **Severity**: MEDIUM
+- **Location**:
+  - `crates/renderer/src/vulkan/frame_upscaler.rs` — `record_native_blit` (~592), `record_fsr_barriers_before` (~705), `record_fsr_depth_restore` (~764), `record_fsr_barriers_after` (~822)
+  - `crates/renderer/src/vulkan/gbuffer.rs` — `GBufferAttachment::destroy` (~180)
+  - `crates/renderer/src/vulkan/context/screenshot.rs` — `screenshot_record_copy` (~101)
+- **Bug**: These 6 of 77 workspace `unsafe fn` lack a `# Safety` doc section stating the caller contract, unlike the other 71. All private/`pub(super)` (crate-internal blast radius), but the 4 `frame_upscaler` ones are the FSR3 boundary barriers whose contract (cmd in recording state, images in specific layout) is discussed at length in prose but never written as a caller obligation. `GBufferAttachment::destroy`'s inner blocks reference "caller of `destroy` (an `unsafe fn`) guarantees…" forwarding to a contract that doesn't exist at the signature.
+- **Fix**: Add `# Safety` section to each of the six stating the caller obligation. Consider `#![warn(clippy::missing_safety_doc)]` on `crates/renderer` (private fns aren't caught by clippy's default lint) — evaluate feasibility/noise before adding.
+
+## Domain
+renderer → `byroredux-renderer` (#2683, #2684) / `byroredux` binary (#2681, #2682)

--- a/byroredux/src/render/draw_sort_key_tests.rs
+++ b/byroredux/src/render/draw_sort_key_tests.rs
@@ -539,6 +539,130 @@ fn manual_bench_draw_sort_serial_vs_parallel() {
     }
 }
 
+/// #2681 (PERF-D2-04) — third arm: decorate-sort-undecorate. Extracts the
+/// 11-tuple key once per element into a `Vec<(Key, usize)>` (a fraction of
+/// `DrawCommand`'s ~480 bytes), sorts THAT by key (O(N) key extractions
+/// instead of `sort_unstable_by_key`'s ~2·N·log₂N re-extractions from the
+/// full struct on every comparison — the same transform #2034 already
+/// applied to `collect_lights`), then applies the resulting permutation via
+/// a `Vec<Option<DrawCommand>>` scratch buffer (`DrawCommand` isn't `Clone`,
+/// so `.take()` is the obviously-correct way to move each element into its
+/// sorted slot without an in-place cycle-walk).
+///
+/// Per the issue: **do not land the production change on this reasoning
+/// alone** — only if this arm measurably wins over `manual_bench_draw_sort_
+/// serial_vs_parallel`'s serial/parallel arms at the N=1800–3400 range the
+/// runtime baselines actually occupy (see PERF-D2-03).
+///
+/// **Measured outcome (2026-08-13, this repo's dev hardware, two
+/// independent runs): the hypothesis does NOT hold.** Decorate-sort-
+/// undecorate is 2–3× SLOWER than the current `sort_unstable_by_key`
+/// baseline across nearly the entire swept range (N=400..2750, and again at
+/// N=5000/10000), reproducibly. It only "wins" at N=3000 and N=3400
+/// specifically, and that pair doesn't fit a real algorithmic crossover —
+/// both neighboring points (N=2750 below, N=5000 above) favor the baseline
+/// heavily, and `decorate_serial` itself drops implausibly between N=2750
+/// and N=3400 with no corresponding rise afterward, consistent with a
+/// measurement artifact (scheduler/thermal/cache noise) rather than a
+/// signal. **Conclusion: the production sort is NOT changed.** The
+/// mechanism reasoning in the issue (per-comparison key extraction
+/// dominates) doesn't predict what's actually measured here, most likely
+/// because `draw_sort_key`'s ~10 touched fields sit within the first couple
+/// of `DrawCommand` cache lines rather than scattered across all ~8, and/or
+/// the optimizer inlines the extraction into the comparator well enough
+/// that the un-decorated approach's per-swap cost (large-struct `ptr::swap`
+/// during the sort itself, same either way at this element count) dominates
+/// over decorate's saved extractions. This bench is kept as the permanent,
+/// re-runnable falsification — re-run it (not the reasoning) before ever
+/// revisiting this optimization.
+///
+/// `cargo test -p byroredux --release manual_bench_draw_sort_decorate_sort_undecorate -- --ignored --nocapture`.
+#[test]
+#[ignore]
+fn manual_bench_draw_sort_decorate_sort_undecorate() {
+    use rayon::prelude::*;
+    use std::time::Instant;
+    fn make_inputs(n: usize) -> Vec<DrawCommand> {
+        let mut v = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut c = cmd((i % 7) == 0, (i % 13) == 0, (i % 5) == 0);
+            c.mesh_handle = (i as u32 * 2654435761) & 0xFFFF;
+            c.entity_id = i as u32;
+            c.sort_depth = (i as u32 * 1664525).wrapping_add(1013904223);
+            c.src_blend = ((i % 4) as u8) + 5;
+            c.dst_blend = ((i % 3) as u8) + 6;
+            c.z_test = (i % 2) == 0;
+            c.z_write = (i % 3) == 0;
+            c.z_function = ((i % 8) as u8) + 1;
+            v.push(c);
+        }
+        v
+    }
+    fn decorate_sort_undecorate(v: Vec<DrawCommand>, parallel: bool) -> Vec<DrawCommand> {
+        let mut keyed: Vec<_> = v
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (draw_sort_key(c), i))
+            .collect();
+        if parallel {
+            keyed.par_sort_unstable_by_key(|&(k, _)| k);
+        } else {
+            keyed.sort_unstable_by_key(|&(k, _)| k);
+        }
+        let mut slots: Vec<Option<DrawCommand>> = v.into_iter().map(Some).collect();
+        keyed
+            .iter()
+            .map(|&(_, idx)| slots[idx].take().expect("each index visited exactly once"))
+            .collect()
+    }
+    const ITERS: u32 = 50;
+    for &n in &[
+        400usize, 800, 1500, 1800, 2000, 2250, 2500, 2750, 3000, 3400, 5000, 10_000,
+    ] {
+        let mut baseline_ns = 0u128;
+        for _ in 0..ITERS {
+            let mut v = make_inputs(n);
+            let t0 = Instant::now();
+            v.sort_unstable_by_key(draw_sort_key);
+            baseline_ns += t0.elapsed().as_nanos();
+            std::hint::black_box(&v);
+        }
+        let mut decorate_serial_ns = 0u128;
+        for _ in 0..ITERS {
+            let v = make_inputs(n);
+            let t0 = Instant::now();
+            let sorted = decorate_sort_undecorate(v, false);
+            decorate_serial_ns += t0.elapsed().as_nanos();
+            std::hint::black_box(&sorted);
+        }
+        let mut decorate_par_ns = 0u128;
+        for _ in 0..ITERS {
+            let v = make_inputs(n);
+            let t0 = Instant::now();
+            let sorted = decorate_sort_undecorate(v, true);
+            decorate_par_ns += t0.elapsed().as_nanos();
+            std::hint::black_box(&sorted);
+        }
+        let baseline = baseline_ns / ITERS as u128;
+        let dec_serial = decorate_serial_ns / ITERS as u128;
+        let dec_par = decorate_par_ns / ITERS as u128;
+        let best_decorate = dec_serial.min(dec_par);
+        let ratio = baseline as f64 / best_decorate as f64;
+        let winner = if baseline <= best_decorate {
+            "baseline"
+        } else if dec_serial <= dec_par {
+            "decorate-serial"
+        } else {
+            "decorate-parallel"
+        };
+        eprintln!(
+            "N={:>6}  baseline={:>8} ns  decorate_serial={:>8} ns  decorate_par={:>8} ns  \
+             ratio(baseline/best_decorate)={:>5.2}  winner={}",
+            n, baseline, dec_serial, dec_par, ratio, winner
+        );
+    }
+}
+
 // ── Option B: !in_raster prefix sorts RT-only draws to the end ────
 //
 // When `MAX_INSTANCES` cap fires, the SSBO upload silently drops the

--- a/byroredux/src/render/mod.rs
+++ b/byroredux/src/render/mod.rs
@@ -467,7 +467,16 @@ pub(crate) fn sort_draw_commands(draw_commands: &mut [DrawCommand]) -> usize {
     let mut raster_len = 0;
     for index in 0..draw_commands.len() {
         if draw_commands[index].in_raster {
-            draw_commands.swap(raster_len, index);
+            // #2682 (PERF-D2-05) — `<[T]>::swap` lowers to `ptr::swap`, which
+            // performs the full three-way ~480-byte copy regardless of index
+            // equality. `raster_len == index` for the whole initial run of
+            // consecutive `in_raster` commands (i.e. every frame where
+            // nothing gets culled, or any run under `BYRO_NO_CULL=1`), so an
+            // unconditional swap wastes up to `N × 2 × sizeof(DrawCommand)`
+            // of self-copy traffic in the fully-visible case.
+            if raster_len != index {
+                draw_commands.swap(raster_len, index);
+            }
             raster_len += 1;
         }
     }

--- a/crates/renderer/src/vulkan/buffer.rs
+++ b/crates/renderer/src/vulkan/buffer.rs
@@ -515,6 +515,65 @@ fn aligned_flush_range(
     (aligned_offset, aligned_size)
 }
 
+/// #2683 (SAFE-D4-01) — best-effort guard against `aligned_flush_range`'s
+/// outward rounding pushing a flush past the end of the memory object it's
+/// flushing into. `Allocation` doesn't expose the parent gpu-allocator
+/// block's size through any public API (verified against the vendored
+/// `gpu-allocator 0.28.0` source — `memory_block_index` is private and
+/// there is no accessor), so this can only check the one case gpu-allocator
+/// DOES make checkable: `Allocation::is_dedicated()` — an allocation made
+/// with an explicit `AllocationScheme::Dedicated{Buffer,Image}` gets its
+/// OWN `VkDeviceMemory` object sized to exactly `alloc.size()`, so for that
+/// case `alloc.offset() + alloc.size()` IS the true end of the memory
+/// object and a widened flush past it is a real
+/// VUID-VkMappedMemoryRange-size-01389 violation, not just an
+/// over-generous flush into a sibling sub-allocation. This is exactly the
+/// escalation path the SAFETY comments at the three call sites warn about:
+/// a future refactor switching a host-visible buffer to a dedicated
+/// allocation scheme.
+///
+/// Does NOT catch the OTHER escalation those comments warn about — a
+/// `GpuAllocatorManaged` allocation whose requested size exceeds
+/// gpu-allocator's shared-block threshold also gets a personal block sized
+/// to fit exactly it, with the identical VUID exposure, but
+/// `is_dedicated()` reports `false` for that case too (it reflects the
+/// requested `AllocationScheme`, not whether gpu-allocator's internal
+/// bin-packing happened to hand this allocation its own block) — nothing
+/// in the public API distinguishes it from an ordinary shared-block
+/// sub-allocation. That gap needs either an upstream gpu-allocator API
+/// addition or validation-layer verification per the issue; not fixable
+/// from this side of the crate boundary.
+fn debug_assert_flush_range_bounded(
+    alloc: &vulkan::Allocation,
+    aligned_offset: vk::DeviceSize,
+    aligned_size: vk::DeviceSize,
+) {
+    if alloc.is_dedicated() {
+        debug_assert!(
+            flush_range_within(aligned_offset, aligned_size, alloc.offset(), alloc.size()),
+            "flush range [{aligned_offset}, {}) escapes the dedicated allocation's \
+             [{}, {}) — VUID-VkMappedMemoryRange-size-01389 (#2683)",
+            aligned_offset + aligned_size,
+            alloc.offset(),
+            alloc.offset() + alloc.size(),
+        );
+    }
+}
+
+/// Pure bound check `debug_assert_flush_range_bounded` relies on, split out
+/// so the arithmetic is unit-testable without a live `Allocation` —
+/// `gpu_allocator::vulkan::Allocation`'s fields are all private with no
+/// public setters, only `Default` (all-zero), so a meaningful populated
+/// instance can't be constructed outside the crate that owns it.
+fn flush_range_within(
+    aligned_offset: vk::DeviceSize,
+    aligned_size: vk::DeviceSize,
+    alloc_offset: vk::DeviceSize,
+    alloc_size: vk::DeviceSize,
+) -> bool {
+    aligned_offset >= alloc_offset && aligned_offset + aligned_size <= alloc_offset + alloc_size
+}
+
 pub struct GpuBuffer {
     pub buffer: vk::Buffer,
     pub size: vk::DeviceSize,
@@ -778,10 +837,22 @@ impl GpuBuffer {
 
         if !self.is_coherent {
             let (aligned_offset, aligned_size) = aligned_flush_range(alloc.offset(), alloc.size());
-            // SAFETY: alloc.memory() is valid and mapped. The range is contained
-            // within this allocation's slice of the parent VkDeviceMemory: offset
-            // is rounded down and size rounded up to nonCoherentAtomSize, which
-            // gpu-allocator already pads sub-allocations to.
+            debug_assert_flush_range_bounded(alloc, aligned_offset, aligned_size);
+            // SAFETY: alloc.memory() is valid and mapped. `aligned_flush_range`
+            // rounds the offset DOWN and the size UP to `NON_COHERENT_ATOM_SIZE`,
+            // so the flushed range is a strict SUPERSET of this allocation, not a
+            // subset — it is bounded only by the parent gpu-allocator memory
+            // block, not by `alloc`'s own `[offset, offset+size)` slice.
+            // gpu-allocator 0.28 has no `nonCoherentAtomSize` awareness at all
+            // (verified against the vendored source — zero occurrences of
+            // `non_coherent`/`atom_size`); it sub-allocates purely on
+            // `VkMemoryRequirements.alignment`, so nothing pads sub-allocations
+            // to this boundary on its behalf. What actually keeps this sound
+            // today: every call site here uses `AllocationScheme::
+            // GpuAllocatorManaged`, so `alloc.memory()` backs a multi-MB shared
+            // block and the widened range still lands inside it — see #2683 /
+            // SAFE-D4-01 and `debug_assert_flush_range_bounded`'s doc for the
+            // one case (a dedicated allocation) that's actually checkable.
             unsafe {
                 let range = vk::MappedMemoryRange::default()
                     .memory(alloc.memory())
@@ -835,14 +906,18 @@ impl GpuBuffer {
             // rounds outward to satisfy that.
             let (aligned_offset, aligned_size) =
                 aligned_flush_range(alloc.offset(), len as vk::DeviceSize);
+            debug_assert_flush_range_bounded(alloc, aligned_offset, aligned_size);
 
             // SAFETY: alloc.memory() returns the VkDeviceMemory backing this
-            // allocation, which is valid and mapped (verified above). The
-            // range is contained within this allocation's region of the parent
-            // memory object — aligned_size is rounded up to atom size but
-            // capped at the written length, and gpu-allocator pads
-            // sub-allocations to atom size so the rounded-up tail stays
-            // within the allocation.
+            // allocation, which is valid and mapped (verified above).
+            // `aligned_size` is rounded UP from `len` (the written length) to
+            // `NON_COHERENT_ATOM_SIZE` with no cap — `aligned_flush_range`
+            // never clamps to `alloc.size()` — so the flushed range can extend
+            // past this allocation's own end, bounded only by the parent
+            // gpu-allocator memory block (see #2683 / SAFE-D4-01 and
+            // `debug_assert_flush_range_bounded`'s doc). Sound today because
+            // every call site uses `AllocationScheme::GpuAllocatorManaged`,
+            // whose shared multi-MB block absorbs the overshoot.
             unsafe {
                 let range = vk::MappedMemoryRange::default()
                     .memory(alloc.memory())
@@ -879,10 +954,17 @@ impl GpuBuffer {
         }
 
         let (aligned_offset, aligned_size) = aligned_flush_range(alloc.offset() + offset, size);
+        debug_assert_flush_range_bounded(alloc, aligned_offset, aligned_size);
 
-        // SAFETY: alloc.memory() is valid and mapped. The range is contained
-        // within this allocation — caller is responsible for ensuring
-        // `offset + size <= alloc.size()`.
+        // SAFETY: alloc.memory() is valid and mapped. Caller is responsible
+        // for `offset + size <= alloc.size()`, but the ACTUALLY flushed range
+        // is `aligned_flush_range`'s outward-rounded superset of
+        // `[offset, offset+size)`, not that range itself — it can extend past
+        // this allocation's own end, bounded only by the parent gpu-allocator
+        // memory block (see #2683 / SAFE-D4-01 and
+        // `debug_assert_flush_range_bounded`'s doc). Sound today because
+        // every call site uses `AllocationScheme::GpuAllocatorManaged`, whose
+        // shared multi-MB block absorbs the overshoot.
         unsafe {
             let range = vk::MappedMemoryRange::default()
                 .memory(alloc.memory())
@@ -1272,6 +1354,49 @@ mod tests {
         assert_ne!(sz, vk::WHOLE_SIZE);
         let (_, sz) = aligned_flush_range(1024 * 1024, 4096);
         assert_ne!(sz, vk::WHOLE_SIZE);
+    }
+
+    /// Regression for #2683 (SAFE-D4-01) — `aligned_flush_range`'s outward
+    /// rounding produces a range that is a strict SUPERSET of the input
+    /// `[offset, offset+size)`, never a subset. The pre-fix SAFETY comments
+    /// claimed the opposite ("contained within this allocation's slice").
+    /// Pin the actual relationship directly against the function under
+    /// test, independent of any `Allocation` fixture.
+    #[test]
+    fn aligned_flush_range_widens_outward_never_inward() {
+        for (offset, size) in [(100u64, 200u64), (50, 50), (0, 48), (37, 999)] {
+            let (aligned_offset, aligned_size) = aligned_flush_range(offset, size);
+            assert!(
+                aligned_offset <= offset,
+                "aligned_offset must round DOWN, never up past the real start"
+            );
+            assert!(
+                aligned_offset + aligned_size >= offset + size,
+                "aligned end must round UP, never down past the real end"
+            );
+        }
+    }
+
+    /// Regression for #2683 (SAFE-D4-01) — `flush_range_within` (the pure
+    /// arithmetic `debug_assert_flush_range_bounded` gates its assert on)
+    /// must accept a range that stays inside `[alloc_offset,
+    /// alloc_offset+alloc_size)` and reject one that overshoots either end.
+    #[test]
+    fn flush_range_within_accepts_contained_and_rejects_overshoot() {
+        // Exact match — the tightest possible "contained" case.
+        assert!(flush_range_within(0, 256, 0, 256));
+        // Strictly inside.
+        assert!(flush_range_within(64, 128, 0, 256));
+        // Overshoots the end — exactly the bug `aligned_flush_range`'s
+        // outward-rounding size can produce against a dedicated allocation.
+        assert!(!flush_range_within(0, 512, 0, 256));
+        // Undershoots the start — defensive; not reachable via
+        // `aligned_flush_range` today (offset is unsigned and
+        // `alloc_offset` is always 0 for a dedicated allocation, per the
+        // block-sizing argument in `debug_assert_flush_range_bounded`'s
+        // doc), but the helper must still catch it if that invariant ever
+        // changes upstream.
+        assert!(!flush_range_within(0, 128, 64, 256));
     }
 
     /// #1759 / TD7-002 — `aligned_flush_range` rounds with the bitmask trick

--- a/crates/renderer/src/vulkan/context/screenshot.rs
+++ b/crates/renderer/src/vulkan/context/screenshot.rs
@@ -98,6 +98,14 @@ impl VulkanContext {
     ///
     /// Called in `draw_frame()` after composite dispatch, before `end_command_buffer`.
     /// The swapchain image is in `PRESENT_SRC_KHR` layout after the composite pass.
+    ///
+    /// # Safety
+    ///
+    /// `cmd` must be recording outside a render pass. `swapchain_image` must
+    /// currently be in `PRESENT_SRC_KHR` layout (this frame's composite pass
+    /// output) and must remain live through submission — this function
+    /// leaves it back in `PRESENT_SRC_KHR` before returning, so the caller's
+    /// subsequent present call sees the layout it expects either way.
     pub(super) unsafe fn screenshot_record_copy(
         &mut self,
         cmd: vk::CommandBuffer,

--- a/crates/renderer/src/vulkan/frame_upscaler.rs
+++ b/crates/renderer/src/vulkan/frame_upscaler.rs
@@ -589,6 +589,17 @@ impl FrameUpscaler {
     /// barrier that is already being recorded — and the cost of getting the
     /// narrowing wrong is a same-command-buffer WAW that no test can see.
     /// If it is ever narrowed, split the barrier per call site first.
+    ///
+    /// # Safety
+    ///
+    /// `cmd` must be recording outside a render pass. `scene_color` must be
+    /// in `SHADER_READ_ONLY_OPTIMAL` (composition's output layout) and
+    /// `self.output_images[frame]` must currently be in `output_layout`
+    /// (the caller-declared parameter — `SHADER_READ_ONLY_OPTIMAL` on the
+    /// steady-state bridge path, `GENERAL` on the dispatch-failure recovery
+    /// path). Both images must remain live through submission. This is the
+    /// same contract as `record`'s own `# Safety` doc; every call site
+    /// shares it (see the `// SAFETY:` comment at each).
     unsafe fn record_native_blit(
         &self,
         device: &ash::Device,
@@ -702,6 +713,17 @@ impl FrameUpscaler {
         }
     }
 
+    /// # Safety
+    ///
+    /// `cmd` must be recording outside a render pass. `inputs.scene_color`,
+    /// `inputs.motion_vectors`, `inputs.reactive`, and `inputs.transparency`
+    /// must each be in `SHADER_READ_ONLY_OPTIMAL` (their producing render
+    /// pass's output layout — this barrier is execution-only for the four,
+    /// no layout change). `inputs.depth` must be in
+    /// `DEPTH_STENCIL_READ_ONLY_OPTIMAL`. `self.output_images[frame]` must
+    /// be in `SHADER_READ_ONLY_OPTIMAL` (this frame slot's steady-state
+    /// layout from the prior blit/dispatch). All named images must remain
+    /// live through submission.
     unsafe fn record_fsr_barriers_before(
         &self,
         device: &ash::Device,
@@ -761,6 +783,14 @@ impl FrameUpscaler {
 
     /// Put depth back into the layout every other pass expects after the FSR
     /// boundary barriers ran but the dispatch itself was rejected.
+    ///
+    /// # Safety
+    ///
+    /// `cmd` must be recording outside a render pass. `depth_image` must be
+    /// in `SHADER_READ_ONLY_OPTIMAL` — the layout `record_fsr_barriers_before`
+    /// left it in earlier in this same `cmd`; this fn is only ever called on
+    /// that recovery path, undoing just the depth half of that transition.
+    /// The image must remain live through submission.
     unsafe fn record_fsr_depth_restore(
         &self,
         device: &ash::Device,
@@ -819,6 +849,16 @@ impl FrameUpscaler {
     /// code paths those presets exercise on this driver. **Re-run that
     /// check when the SDK is upgraded** — a backend change to resource-state
     /// tracking would break these barriers silently on the happy path.
+    ///
+    /// # Safety
+    ///
+    /// `cmd` must be recording outside a render pass. `depth_image` must be
+    /// in `SHADER_READ_ONLY_OPTIMAL` and `self.output_images[frame]` must be
+    /// in `GENERAL` — the layouts the validated SDK contract above claims
+    /// the FFX Vulkan backend leaves them in. The SDK dispatch's compute
+    /// accesses must already be recorded into this same `cmd` before this
+    /// call, ahead of this barrier's `COMPUTE_SHADER` source stage. Both
+    /// images must remain live through submission.
     unsafe fn record_fsr_barriers_after(
         &self,
         device: &ash::Device,
@@ -1125,6 +1165,97 @@ mod tests {
             blit_output_src_access(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL),
             vk::AccessFlags::SHADER_READ
         );
+    }
+
+    /// Regression for #2684 (SAFE-D4-03) — six `unsafe fn` (four here, one
+    /// each in `gbuffer.rs` / `context/screenshot.rs`) carried no `# Safety`
+    /// doc section stating the caller contract, unlike the other 71 of 77
+    /// workspace `unsafe fn`. All are private/`pub(super)`, so
+    /// `clippy::missing_safety_doc` doesn't catch them — verified
+    /// empirically (stripping the doc from `Attachment::destroy` and
+    /// running `cargo clippy -- -W clippy::missing_safety_doc` produces
+    /// zero diagnostics), which is also why enabling that lint crate-wide
+    /// per the issue's "consider" suggestion was skipped: it wouldn't have
+    /// covered the actual gap. Source-scan pin instead: each `unsafe fn`
+    /// signature must be immediately preceded by a `# Safety` heading in
+    /// its doc comment (allowing intervening doc lines, since some of
+    /// these also carry unrelated prose sections above the contract).
+    #[test]
+    fn frame_upscaler_and_sibling_unsafe_fns_carry_safety_doc_sections() {
+        const GBUFFER_RS: &str = include_str!("gbuffer.rs");
+        const SCREENSHOT_RS: &str = include_str!("context/screenshot.rs");
+        const FRAME_UPSCALER_RS: &str = include_str!("frame_upscaler.rs");
+
+        // (source, needle identifying the fn, human label)
+        let sites: &[(&str, &str, &str)] = &[
+            (FRAME_UPSCALER_RS, "unsafe fn record_native_blit(", "record_native_blit"),
+            (
+                FRAME_UPSCALER_RS,
+                "unsafe fn record_fsr_barriers_before(",
+                "record_fsr_barriers_before",
+            ),
+            (
+                FRAME_UPSCALER_RS,
+                "unsafe fn record_fsr_depth_restore(",
+                "record_fsr_depth_restore",
+            ),
+            (
+                FRAME_UPSCALER_RS,
+                "unsafe fn record_fsr_barriers_after(",
+                "record_fsr_barriers_after",
+            ),
+            (
+                GBUFFER_RS,
+                "unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {",
+                "Attachment::destroy",
+            ),
+            (
+                SCREENSHOT_RS,
+                "unsafe fn screenshot_record_copy(",
+                "screenshot_record_copy",
+            ),
+        ];
+
+        for (src, needle, label) in sites {
+            let before_fn = src
+                .split_once(needle)
+                .unwrap_or_else(|| panic!("{label} disappeared or its signature changed (#2684)"))
+                .0;
+            // Drop the trailing PARTIAL line (e.g. "    pub(super) " —
+            // everything on the signature's own line up to where `needle`
+            // starts matching). Left in, that fragment is neither blank nor
+            // `///`-prefixed, so it would poison the reverse walk below
+            // before it ever reaches the real doc comment lines above it.
+            let before_fn = before_fn.rsplit_once('\n').map_or("", |(rest, _)| rest);
+            // The doc comment block immediately preceding the signature —
+            // everything back to the last non-doc-comment, non-blank line.
+            let doc_block: Vec<&str> = before_fn
+                .lines()
+                .rev()
+                .take_while(|line| {
+                    let trimmed = line.trim();
+                    trimmed.is_empty() || trimmed.starts_with("///")
+                })
+                .collect::<Vec<_>>();
+            // A genuine `# Safety` HEADING line — not just prose elsewhere
+            // in the block that happens to mention the phrase (e.g. "same
+            // contract as `record`'s own `# Safety` doc"). Strip the `///`
+            // prefix and surrounding whitespace and require an exact match,
+            // the same way a Markdown renderer identifies a heading line.
+            let has_safety_heading = doc_block.iter().any(|line| {
+                line.trim()
+                    .strip_prefix("///")
+                    .map(str::trim)
+                    .is_some_and(|rest| rest == "# Safety")
+            });
+            assert!(
+                has_safety_heading,
+                "{label} is `unsafe fn` but its doc comment has no `# Safety` \
+                 HEADING line stating the caller contract (#2684 / SAFE-D4-03) \
+                 — a mention of the phrase elsewhere in its doc prose does \
+                 not count",
+            );
+        }
     }
 }
 

--- a/crates/renderer/src/vulkan/gbuffer.rs
+++ b/crates/renderer/src/vulkan/gbuffer.rs
@@ -177,6 +177,14 @@ impl Attachment {
         Ok(())
     }
 
+    /// # Safety
+    ///
+    /// No in-flight command buffer or descriptor set may still reference
+    /// any image, image view, or allocation owned by this `Attachment` —
+    /// i.e. the caller must have fenced/idled the device (or otherwise
+    /// proven no outstanding GPU work touches them) before calling this.
+    /// `device` must be the same logical device the images/views/
+    /// allocations were created against.
     unsafe fn destroy(&mut self, device: &ash::Device, allocator: &SharedAllocator) {
         for &view in &self.views {
             // SAFETY: caller of `destroy` (an `unsafe fn`) guarantees no


### PR DESCRIPTION
Fixes #2681, #2682, #2683, #2684 (#2681/#2682 from `AUDIT_PERFORMANCE_2026-08-12.md`, #2683/#2684 from `AUDIT_SAFETY_2026-08-12.md`).

- **#2681**: prototyped the suggested decorate-sort-undecorate transform for `sort_draw_commands` as a third bench arm and measured it. Result: 2–3x **slower** than the current approach across nearly the whole swept range — the hypothesis doesn't hold. No production change; the bench + measured outcome are kept in tree as a permanent falsification record.
- **#2682**: one-line fix — guard `sort_draw_commands`'s partition swap with `if raster_len != index` to avoid a pointless self-swap of ~480-byte `DrawCommand`s.
- **#2683**: `GpuBuffer`'s three flush call sites had SAFETY comments asserting facts about `aligned_flush_range`'s output that are provably false (claims a subset when the function produces a superset; claims gpu-allocator padding that doesn't exist in 0.28). Rewrote all three to state the true invariant, and added `debug_assert_flush_range_bounded` covering the one case gpu-allocator's public API makes checkable (`is_dedicated()`).
- **#2684**: added `# Safety` sections to the 6 of 77 workspace `unsafe fn` that lacked one (4 FSR3 barrier fns in `frame_upscaler.rs`, `Attachment::destroy` in `gbuffer.rs`, `screenshot_record_copy`). Verified empirically that `clippy::missing_safety_doc` doesn't fire on private fns (so enabling it wouldn't have covered this gap) — skipped rather than added for false coverage. Workspace-wide sweep confirms all 78 unsafe fns now state a safety contract.

`cargo test -p byroredux-renderer`: 601 passed. `cargo test -p byroredux`: 1102 passed. Full workspace suite: one pre-existing unrelated failure in `fire_lights.rs` (confirmed present on `main` before this change).