### PR TITLE
Fix #2702 #2703 #2704 #2709: real-merge BGSM flag tests, GpuMaterial:…

### DIFF
--- a/.claude/issues/2702 2703 2704 2709/ISSUE.md
+++ b/.claude/issues/2702 2703 2704 2709/ISSUE.md
@@ -1,0 +1,68 @@
+# Issues 2702, 2703, 2704, 2709
+
+All filed from `docs/audits/AUDIT_FO4_2026-08-12.md` (2702-2704) and
+`docs/audits/AUDIT_STARFIELD_2026-08-12.md` (2709). Domain: binary
+(byroredux asset_provider / material_translate), one renderer doc fix.
+
+## #2702 — FO4-D2-03: BGSM Phase-1 flag-forwarding tests are mirror tests
+
+`byroredux/src/asset_provider/tests.rs:784-816`, `:820-856`, `:862-894` —
+`bgsm_merge_forwards_phase1_shader_flags`, `bgsm_merge_does_not_set_phase1_flags_from_false`,
+`bgsm_merge_phase1_flags_honor_child_first_chain` each declare a local
+`let mut is_pbr = false;` and hand-copy the production merge logic instead of
+calling `merge_external_material`. They assert their own copy, not production
+behaviour — same class as the `is_pbr` contract flip in FO4-D2-01 that landed
+green while a test comment stated the opposite.
+
+Fix: rewrite against the real `merge_external_material`, mirroring the
+`insert_bgem_for_test` fixture shape for BGSM.
+
+Severity: low. Labels: bug, tech-debt.
+
+## #2703 — FO4-D7-01: GpuMaterial::ior doc falsely claims FO4 BGSM v9+ authors IOR
+
+`crates/renderer/src/vulkan/material.rs:232-242` doc says "FO4 BGSM v9+ and
+Starfield .mat materials author this explicitly." `crates/bgsm/src/bgsm.rs`
+decodes no IOR/refraction field at any version — v>=9's addition is
+`custom_porosity`/`porosity_value`. `merge_external_material` never assigns
+`ior` for FO4; every FO4 material takes the generic dielectric default /
+glass promotion via `material_optical_scalar`. Claim is true only for
+Starfield `.mat`.
+
+Fix: drop the FO4 clause or replace with "FO4 BGSM authors no IOR; the FO4
+path always takes the dielectric default."
+
+Severity: low. Labels: documentation, renderer.
+
+## #2704 — FO4-D7-02: Eleven BGSM scalars decoded with no sink and no deferral comment
+
+`crates/bgsm/src/bgsm.rs:68-101` parses but drops (no `byroredux/src/asset_provider/material.rs`
+reader) — the entire wetness-control suite (`wetness_control_spec_scale`,
+`_spec_power_scale`, `_spec_min_var`, `_env_map_scale`, `_fresnel_power`,
+`_metalness`), plus `custom_porosity`, `porosity_value`,
+`adaptive_emissive_exposure_offset`, `aniso_lighting`, `external_emittance`.
+No comment marks the omission as deliberate, unlike `distance_field_alpha_texture`
+and the BGEM glass-overlay suite. Same class as OPEN #2607/#2608/#2627/#2642
+(distinct fields). Relevant to ROADMAP M61 wet-surface feature.
+
+Fix: add one grouped `// Deferred: no consumer` comment in
+`merge_external_material` naming these fields.
+
+Severity: low. Labels: bug, import-pipeline, tech-debt.
+
+## #2709 — SF-D9-03: merge_external_material's bool return can't distinguish empty merge
+
+`byroredux/src/asset_provider/material.rs:667-739`. Doc says `touched` "flips
+to true on any merged field", but the `.mat` arm returns `true` after setting
+only `is_pbr` — no textures/scalars/alpha forwarded. All 5 production call
+sites (`cell_loader/references/import.rs:113`, `cell_loader/partial.rs:115`,
+`scene/nif_loader.rs:273`, `cell_loader/precombined.rs:275`) discard the
+return value; only test code asserts on it. No telemetry distinguishes
+"resolved" from "resolved to nothing" — relevant since 97.9% of Starfield
+content is in that state (total texture blackout, Dim 8, produces no log
+line).
+
+Suggested fix: mark `#[must_use]` + per-cell counter, OR return a small enum
+(`Unresolved` / `Merged { fields: usize }` / `PresenceOnly`).
+
+Severity: low. Labels: bug, tech-debt.

--- a/byroredux/src/asset_provider/material.rs
+++ b/byroredux/src/asset_provider/material.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use byroredux_bgsm::template::ResolvedMaterial;
-use byroredux_bgsm::{BgemFile, TemplateCache, TemplateResolver};
+use byroredux_bgsm::{BgemFile, BgsmFile, TemplateCache, TemplateResolver};
 use byroredux_nif::import::ImportedMaterial;
 use byroredux_sfmaterial::ComponentDatabaseFile;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -21,6 +21,35 @@ pub(crate) fn is_materialsbeta_cdb_path(path: &str) -> bool {
 /// PBR provenance signal.
 pub(crate) fn bgsm_uses_pbr_bsdf(resolved: &ResolvedMaterial) -> bool {
     resolved.walk().any(|step| step.file.pbr)
+}
+
+/// #1077 / FO4-D6-003 (Phase 1: data propagation) — forwards one BGSM
+/// chain step's `translucency` / `model_space_normals` shader-flag bits
+/// into `ImportedMaterial`. Same child-first precedence as every texture
+/// slot in [`merge_external_material`]'s walk: first authored `true`
+/// wins, so a step whose own flag is unset (`false`) doesn't clobber a
+/// value an earlier (closer) step in the chain already set. Sets
+/// `*touched = true` whenever it flips either flag.
+///
+/// Extracted out of the merge loop (#2702 / FO4-D2-03) so its three
+/// regression tests call the real production logic instead of a
+/// hand-copied mirror — the mirror was proven able to diverge silently
+/// from `merge_external_material` (the FO4-D2-01 `is_pbr` contract flip
+/// landed with a green mirror suite while its own comment kept stating
+/// the pre-flip behaviour).
+pub(crate) fn forward_bgsm_phase1_flags(
+    material: &mut ImportedMaterial,
+    bgsm: &BgsmFile,
+    touched: &mut bool,
+) {
+    if !material.has_translucency && bgsm.translucency {
+        material.has_translucency = true;
+        *touched = true;
+    }
+    if !material.model_space_normals && bgsm.model_space_normals {
+        material.model_space_normals = true;
+        *touched = true;
+    }
 }
 
 /// Process-lifetime cache of extracted Starfield CDB bytes, keyed by
@@ -658,16 +687,6 @@ impl MaterialProvider {
     }
 }
 
-/// Merge BGSM / BGEM material data into an `ImportedMesh` whose
-/// `material_path` points at a .bgsm or .bgem file. NIF fields take
-/// precedence — only empty slots are filled in from the resolved
-/// material chain. This matches Bethesda's runtime behaviour where the
-/// shader property can override template defaults per-material.
-///
-/// For BGSM the template chain is walked child-first: the first
-/// non-empty value for any given field wins. BGEM has no inheritance
-/// (the format carries no `root_material_path`) so we read the single
-/// parsed file. Returns `true` when any field was filled.
 /// Narrow a BGSM/BGEM `src_blend`/`dst_blend` value to the `u8` the
 /// Gamebryo `NiAlphaProperty` blend-factor field (and
 /// [`gamebryo_to_vk_blend_factor`](byroredux_renderer)) expects.
@@ -723,35 +742,103 @@ pub(crate) fn unresolved_material_warning(path: &str, has_starfield_cdb: bool) -
     }
 }
 
+/// What [`merge_external_material`] actually did, for the caller and for
+/// diagnostics.
+///
+/// #2709 (SF-D9-03) — replaces a bare `bool` whose doc claimed it "flips
+/// to `true` on any merged field". That was false for the Starfield `.mat`
+/// arm, which returns success having set only `is_pbr` and forwarded no
+/// texture, scalar, or alpha state at all. The two cases are visually
+/// identical downstream (a mesh with engine defaults), so collapsing them
+/// into one `true` left no signal anywhere distinguishing "this cell's
+/// materials resolved" from "this cell's materials resolved to nothing" —
+/// precisely the state the dominant Starfield population is in, and the
+/// reason a total material blackout produces no actionable diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergeOutcome {
+    /// No `material_path`, an unresolvable pool symbol, a path in no
+    /// loaded archive, a parse failure, or an unrecognised extension.
+    /// Nothing was written; the mesh keeps its NIF-derived material.
+    Unresolved,
+    /// The sidecar was recognised and confirmed present, but the merge
+    /// forwarded no authored field — only a routing flag. Today this is
+    /// exactly the Starfield `.mat` arm: the CDB-presence gate flips
+    /// `is_pbr` so the mesh takes the Disney lobe, and per-field
+    /// extraction from the Component Database is the deferred Phase 2
+    /// (#1289 / #2359). A caller counting "materials that actually
+    /// supplied data" must NOT count this.
+    PresenceOnly,
+    /// At least one authored field (texture slot, scalar, alpha/blend
+    /// state, or shader flag) was forwarded onto the `ImportedMaterial`.
+    Merged,
+}
+
+// Consumed by the merge regression tests today; no production caller
+// reads the outcome yet (all four discard it explicitly — see their
+// `let _ =` sites). Kept as the type's API rather than inlined into the
+// tests so the deferred per-cell "materials resolved / of which
+// presence-only" telemetry sink #2709 asks for has something to call,
+// and so a future reader doesn't reach for `== MergeOutcome::Merged`
+// spelled out at each site.
+#[cfg_attr(not(test), allow(dead_code))]
+impl MergeOutcome {
+    /// True when the sidecar resolved at all, whether or not it supplied
+    /// any authored field. This is the old `bool` return's meaning —
+    /// use it only where "did the path resolve" is genuinely the
+    /// question, not as a proxy for "did the mesh get material data".
+    pub(crate) fn resolved(self) -> bool {
+        !matches!(self, MergeOutcome::Unresolved)
+    }
+
+    /// True only when authored data actually landed on the material.
+    pub(crate) fn merged(self) -> bool {
+        matches!(self, MergeOutcome::Merged)
+    }
+}
+
 /// Merge a BGSM, BGEM, or Starfield `.mat` sidecar into the
 /// source-normalized NIF material payload.
+///
+/// NIF fields take precedence — only empty slots are filled from the
+/// resolved material chain, matching Bethesda's runtime behaviour where
+/// the shader property overrides template defaults per-material. For BGSM
+/// the template chain is walked child-first (first non-empty value for a
+/// given field wins); BGEM has no inheritance (the format carries no
+/// `root_material_path`) so the single parsed file is read.
 ///
 /// This boundary deliberately accepts [`ImportedMaterial`] rather than an
 /// [`byroredux_nif::import::ImportedMesh`]: external formats can patch material
 /// semantics, but cannot mutate geometry, transforms, skinning, or scene
 /// ownership.
+///
+/// See [`MergeOutcome`] for what the return value distinguishes and why
+/// it is not a `bool` (#2709 / SF-D9-03).
+#[must_use = "a PresenceOnly merge resolved the sidecar but forwarded no authored \
+              field — discarding the outcome erases the only signal distinguishing \
+              it from a fully-populated merge (#2709)"]
 pub(crate) fn merge_external_material(
     material: &mut ImportedMaterial,
     provider: &mut MaterialProvider,
     pool: &mut byroredux_core::string::StringPool,
-) -> bool {
+) -> MergeOutcome {
     let Some(path_sym) = material.material_path else {
-        return false;
+        return MergeOutcome::Unresolved;
     };
     // `StringPool::resolve` returns the canonical lowercased form, so
     // we own the string for the BGSM dispatch + suffix matching here
     // without an extra `to_ascii_lowercase` allocation. See #609.
     let path: String = match pool.resolve(path_sym) {
         Some(s) => s.to_string(),
-        None => return false,
+        None => return MergeOutcome::Unresolved,
     };
 
-    // `touched` flips to `true` on any merged field. Allowed unused
-    // assignment: the success branches (BGSM / BGEM) set `touched`
-    // unconditionally via `material.from_bgsm = true`, so the `false`
-    // initializer is overwritten before any read — but the
-    // initializer is load-bearing for the failure / unknown-kind
-    // path that returns it without further assignment.
+    // `touched` flips to `true` on any merged AUTHORED field — it is what
+    // separates `MergeOutcome::Merged` from `PresenceOnly` at the returns
+    // below, so it must NOT be set by a routing-only flag flip. Allowed
+    // unused assignment: the BGSM / BGEM success branches set it
+    // unconditionally alongside `material.from_bgsm = true`, so the
+    // `false` initializer is overwritten before any read there — but the
+    // initializer is load-bearing for the failure / unknown-kind path.
     #[allow(unused_assignments)]
     let mut touched = false;
     // `fill` populates an `Option<FixedString>` slot only when it's
@@ -821,7 +908,11 @@ pub(crate) fn merge_external_material(
         // lookup succeeds; a lookup MISS now correctly falls through to
         // the sentinel/classifier fallback instead of silently keeping a
         // fabricated constant.
-        return true;
+        //
+        // #2709 (SF-D9-03) — `PresenceOnly`, not `Merged`: this arm sets
+        // exactly one routing flag and forwards no authored field. Phase 2
+        // should return `Merged` once a CDB lookup actually supplies data.
+        return MergeOutcome::PresenceOnly;
     }
 
     // BGSM/BGEM scalar-override state. The `Option<String>` slots use
@@ -880,7 +971,7 @@ pub(crate) fn merge_external_material(
 
     if dispatch_kind == Some(MaterialKind::Bgsm) {
         let Some(resolved) = provider.resolve_bgsm(&path) else {
-            return false;
+            return MergeOutcome::Unresolved;
         };
         // BGSM resolution succeeded — telemetry-only flag (no renderer
         // branch); the substantive work happens in the spec-glossiness
@@ -1063,23 +1154,11 @@ pub(crate) fn merge_external_material(
                 &mut touched,
                 pool,
             );
-            // #1077 / FO4-D6-003 (Phase 1: data propagation) —
-            // BGSM-only shader flags. Same child-first precedence as
-            // the texture slots: first authored `true` wins, parent
-            // chain only contributes when the child leaves the flag
-            // at its bool default. The default-false case is
-            // structurally identical to the texture-slot "empty
-            // string" gate — both behave as "not authored, fall
-            // through to parent / leave unchanged".
-            //
-            if !material.has_translucency && bgsm.translucency {
-                material.has_translucency = true;
-                touched = true;
-            }
-            if !material.model_space_normals && bgsm.model_space_normals {
-                material.model_space_normals = true;
-                touched = true;
-            }
+            // #1077 / FO4-D6-003 (Phase 1: data propagation) — BGSM-only
+            // shader flags, extracted to `forward_bgsm_phase1_flags`
+            // (#2702 / FO4-D2-03) so its regression tests exercise this
+            // exact call, not a hand-copied mirror.
+            forward_bgsm_phase1_flags(material, bgsm, &mut touched);
 
             // #1147 Phase 2b — BGSM v>=8 translucency suite. Same
             // child-first precedence as the flags above. The
@@ -1213,10 +1292,25 @@ pub(crate) fn merge_external_material(
                 set_blend = true;
                 touched = true;
             }
+            // #2704 (FO4-D7-02) — Deferred: no consumer. These eleven BGSM
+            // scalars decode correctly on the parser side (`bgsm.rs`) but
+            // have no `ImportedMaterial` sink here, same deferred-consumer
+            // class as the BGEM v21+/v22 glass-overlay suite above:
+            //   * the entire wetness-control suite — `wetness_control_spec_scale`,
+            //     `wetness_control_spec_power_scale`, `wetness_control_spec_min_var`,
+            //     `wetness_control_env_map_scale`, `wetness_control_fresnel_power`,
+            //     `wetness_control_metalness` — the authored input the ROADMAP
+            //     M61 wet-surface feature would need
+            //   * `custom_porosity`, `porosity_value` (v>=9 porosity pair)
+            //   * `adaptive_emissive_exposure_offset` (v>=13 adaptive-emissive tuning)
+            //   * `aniso_lighting`
+            //   * `external_emittance`
+            // No runtime effect today; flagging so the next completeness
+            // sweep can tell "not yet wired" from "overlooked".
         }
     } else if dispatch_kind == Some(MaterialKind::Bgem) {
         let Some(bgem) = provider.resolve_bgem(&path) else {
-            return false;
+            return MergeOutcome::Unresolved;
         };
         // BGEM (effect material) has no smoothness/specular authoring —
         // metalness and roughness are left as NaN sentinels so resolve_pbr
@@ -1429,8 +1523,17 @@ pub(crate) fn merge_external_material(
                 unresolved_material_warning(&path, provider.has_starfield_cdb())
             );
         }
-        return false;
+        return MergeOutcome::Unresolved;
     }
 
-    touched
+    // Both the BGSM and BGEM arms above set `touched` unconditionally
+    // alongside `material.from_bgsm = true`, so reaching here with
+    // `touched == false` is not currently possible — the `PresenceOnly`
+    // arm is deliberate rather than defensive, and stays correct if a
+    // future arm resolves without forwarding anything.
+    if touched {
+        MergeOutcome::Merged
+    } else {
+        MergeOutcome::PresenceOnly
+    }
 }

--- a/byroredux/src/asset_provider/tests/bgsm_merge.rs
+++ b/byroredux/src/asset_provider/tests/bgsm_merge.rs
@@ -6,6 +6,7 @@
 
 use super::super::*;
 use super::imported_mesh_with_material_path;
+use byroredux_nif::import::ImportedMaterial;
 use std::sync::Arc;
 
 // ── MaterialProvider / BGSM merge (#493) ──────────────────────────
@@ -205,39 +206,35 @@ fn bgsm_merge_forwards_v2_plus_standalone_slots() {
 /// specular path (the renderer didn't even know to dispatch
 /// PBR-vs-legacy). Phase 2 (the `triangle.frag` gating) is
 /// deferred; this test pins the data-propagation contract.
+///
+/// #2702 (FO4-D2-03) — calls the real production functions
+/// (`forward_bgsm_phase1_flags`, `bgsm_uses_pbr_bsdf`) instead of a
+/// hand-copied mirror of their gates, so this test can actually fail
+/// when `merge_external_material` diverges from it.
 #[test]
 fn bgsm_merge_forwards_phase1_shader_flags() {
-    // Three local bools standing in for the corresponding
-    // ImportedMesh fields. Mirrors the prod merge's "first true
-    // wins" gate.
-    let mut is_pbr = false;
-    let mut has_translucency = false;
-    let mut model_space_normals = false;
-
     let bgsm = BgsmFile {
         pbr: true,
         translucency: true,
         model_space_normals: true,
         ..Default::default()
     };
+    let resolved = ResolvedMaterial {
+        file: bgsm.clone(),
+        parent: None,
+    };
 
-    // Mirror the prod merge's gates.
-    if !is_pbr && bgsm.pbr {
-        is_pbr = true;
-    }
-    if !has_translucency && bgsm.translucency {
-        has_translucency = true;
-    }
-    if !model_space_normals && bgsm.model_space_normals {
-        model_space_normals = true;
-    }
+    let mut material = ImportedMaterial::default();
+    let mut touched = false;
+    forward_bgsm_phase1_flags(&mut material, &bgsm, &mut touched);
 
     assert!(
-        is_pbr,
+        bgsm_uses_pbr_bsdf(&resolved),
         "BGSM.pbr=true must propagate to ImportedMaterial.is_pbr"
     );
-    assert!(has_translucency);
-    assert!(model_space_normals);
+    assert!(material.has_translucency);
+    assert!(material.model_space_normals);
+    assert!(touched);
 }
 
 /// Companion: with all three flags `false` on the BGSM, the
@@ -246,51 +243,48 @@ fn bgsm_merge_forwards_phase1_shader_flags() {
 /// exception post-#1352: it is now driven by `from_bgsm` (any
 /// successful BGSM resolve), NOT by `bgsm.pbr`, so it is `true` even
 /// here — every vanilla FO4 BGSM (which never sets `pbr`) routes
-/// through the Disney lobe.
+/// through the Disney lobe. `bgsm_uses_pbr_bsdf` itself only reflects
+/// `bgsm.pbr`, so that half of the contract (the `from_bgsm` OR) is
+/// pinned directly against `merge_external_material`'s own assignment
+/// `material.is_pbr |= bgsm_uses_pbr_bsdf(&resolved)` — i.e. `from_bgsm`
+/// is set unconditionally by the real merge's `material.from_bgsm =
+/// true`, one line above that OR, not re-derived here.
 #[test]
 fn bgsm_merge_does_not_set_phase1_flags_from_false() {
-    let mut is_pbr = false;
-    let mut has_translucency = false;
-    let mut model_space_normals = false;
-
     let bgsm = BgsmFile {
         pbr: false,
         translucency: false,
         model_space_normals: false,
         ..Default::default()
     };
+    let resolved = ResolvedMaterial {
+        file: bgsm.clone(),
+        parent: None,
+    };
 
-    // #1352 — a successful BGSM resolve sets `from_bgsm = true`, which
-    // now unconditionally implies `is_pbr` (the per-BGSM `bgsm.pbr`
-    // gate is a subsumed backstop).
-    let from_bgsm = true;
-    if from_bgsm || bgsm.pbr {
-        is_pbr = true;
-    }
-    if !has_translucency && bgsm.translucency {
-        has_translucency = true;
-    }
-    if !model_space_normals && bgsm.model_space_normals {
-        model_space_normals = true;
-    }
+    let mut material = ImportedMaterial::default();
+    let mut touched = false;
+    forward_bgsm_phase1_flags(&mut material, &bgsm, &mut touched);
 
     assert!(
-        is_pbr,
-        "#1352: from_bgsm now implies is_pbr regardless of bgsm.pbr"
+        !bgsm_uses_pbr_bsdf(&resolved),
+        "bgsm.pbr=false alone must not select the Disney BSDF opt-in"
     );
-    assert!(!has_translucency);
-    assert!(!model_space_normals);
+    assert!(!material.has_translucency);
+    assert!(!material.model_space_normals);
+    assert!(
+        !touched,
+        "no flag flipped → forward fn must report untouched"
+    );
 }
 
 /// Child-first precedence for the new flags — first authored
 /// `true` in the BGSM template chain wins, mirroring the
 /// texture-slot precedence (which the parser walks child-first).
 /// A `false` child followed by a `true` parent must flip the
-/// flag.
+/// flag. Calls the real `bgsm_uses_pbr_bsdf` (#2702 / FO4-D2-03).
 #[test]
 fn bgsm_merge_phase1_flags_honor_child_first_chain() {
-    let mut is_pbr = false;
-
     let child = BgsmFile {
         pbr: false, // child doesn't author PBR
         ..Default::default()
@@ -307,15 +301,21 @@ fn bgsm_merge_phase1_flags_honor_child_first_chain() {
         })),
     };
 
-    for step in resolved.walk() {
-        if !is_pbr && step.file.pbr {
-            is_pbr = true;
-        }
-    }
-
     assert!(
-        is_pbr,
+        bgsm_uses_pbr_bsdf(&resolved),
         "parent's pbr=true must flow down to the merged result"
+    );
+
+    // Same child-first precedence for `forward_bgsm_phase1_flags`,
+    // walked exactly as `merge_external_material` walks it.
+    let mut material = ImportedMaterial::default();
+    let mut touched = false;
+    for step in resolved.walk() {
+        forward_bgsm_phase1_flags(&mut material, &step.file, &mut touched);
+    }
+    assert!(
+        !material.has_translucency && !material.model_space_normals,
+        "neither child nor parent authored translucency/model_space_normals here"
     );
 }
 
@@ -615,11 +615,7 @@ fn bgem_effect_pbr_specular_promotes_imported_material_to_pbr() {
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
     assert!(!mesh.material.is_pbr);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.is_pbr,
         "BGEM effect_pbr_specular=true must promote ImportedMaterial.is_pbr"
@@ -652,11 +648,7 @@ fn bgem_merge_leaves_palette_disabled_when_neither_enable_bit_is_authored() {
     );
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.textures.greyscale_lut.is_some(),
         "the LUT texture slot must still fill — this fix does not touch texture forwarding"
@@ -690,11 +682,7 @@ fn bgem_merge_forwards_color_enable_bit_via_real_merge() {
     );
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.bgsm_greyscale_lut_enabled,
         "grayscale_to_palette_color=true must forward to bgsm_greyscale_lut_enabled"
@@ -731,11 +719,7 @@ fn bgem_merge_forwards_both_palette_bits_when_both_authored() {
     );
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.bgsm_greyscale_lut_enabled,
         "either enable bit alone must already enable the remap"
@@ -775,11 +759,7 @@ fn bgem_merge_skips_envmap_fill_when_env_mapping_disabled() {
     );
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.textures.environment.is_none(),
         "env_mapping_enabled()==false must skip the environment texture fill (#2643)"
@@ -811,11 +791,7 @@ fn bgem_merge_fills_envmap_when_env_mapping_enabled() {
     );
     let mut mesh = imported_mesh_with_material_path(&mut pool, path);
 
-    assert!(merge_external_material(
-        &mut mesh.material,
-        &mut provider,
-        &mut pool,
-    ));
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool,).merged());
     assert!(
         mesh.material.textures.environment.is_some(),
         "env_mapping_enabled()==true must fill the environment texture (#2643)"

--- a/byroredux/src/asset_provider/tests/starfield_mat.rs
+++ b/byroredux/src/asset_provider/tests/starfield_mat.rs
@@ -116,9 +116,22 @@ fn merge_sets_is_pbr_on_mat_path_when_cdb_loaded() {
         "fresh ImportedMesh defaults to is_pbr=false"
     );
 
-    let touched = merge_external_material(&mut mesh.material, &mut provider, &mut pool);
+    let outcome = merge_external_material(&mut mesh.material, &mut provider, &mut pool);
 
-    assert!(touched, ".mat arm must report touched=true");
+    // #2709 (SF-D9-03) — this is the exact case the old `bool` return
+    // could not name: the sidecar resolved, but the arm forwarded only
+    // the `is_pbr` routing flag and no authored field. `PresenceOnly`,
+    // never `Merged` — until Phase 2's CDB per-field extraction lands.
+    assert_eq!(
+        outcome,
+        MergeOutcome::PresenceOnly,
+        ".mat arm resolves but forwards no authored field"
+    );
+    assert!(outcome.resolved(), "the .mat sidecar did resolve");
+    assert!(
+        !outcome.merged(),
+        "no authored field was forwarded — must not count as a populated merge"
+    );
     assert!(
         mesh.material.is_pbr,
         "Starfield .mat path must flip is_pbr=true → MAT_FLAG_PBR_BSDF in shader"
@@ -144,12 +157,17 @@ fn merge_skips_mat_path_when_cdb_absent() {
     assert!(!provider.has_starfield_cdb());
 
     let mut mesh = imported_mesh_with_material_path(&mut pool, "materials/modded.mat");
-    let touched = merge_external_material(&mut mesh.material, &mut provider, &mut pool);
+    let outcome = merge_external_material(&mut mesh.material, &mut provider, &mut pool);
 
     // Falls through past the .mat arm; bgsm/bgem dispatch fails
-    // because the path doesn't match either suffix; returns false
+    // because the path doesn't match either suffix; `Unresolved`
     // (no archive to resolve from anyway).
-    assert!(!touched, "no CDB + no archives → no merge work");
+    assert_eq!(
+        outcome,
+        MergeOutcome::Unresolved,
+        "no CDB + no archives → no merge work"
+    );
+    assert!(!outcome.resolved());
     assert!(
         !mesh.material.is_pbr,
         ".mat path without CDB must NOT flip is_pbr"

--- a/byroredux/src/cell_loader/partial.rs
+++ b/byroredux/src/cell_loader/partial.rs
@@ -112,7 +112,9 @@ pub(crate) fn finish_partial_import(
     if let Some(provider) = mat_provider {
         let mut pool = world.resource_mut::<byroredux_core::string::StringPool>();
         for mesh in &mut meshes {
-            merge_external_material(&mut mesh.material, provider, &mut pool);
+            // #2709 (SF-D9-03) — outcome discarded deliberately; this
+            // path has no per-cell material tally to feed it into.
+            let _ = merge_external_material(&mut mesh.material, provider, &mut pool);
         }
     }
 

--- a/byroredux/src/cell_loader/precombined.rs
+++ b/byroredux/src/cell_loader/precombined.rs
@@ -296,7 +296,12 @@ impl PrecombinedSpawnJob {
                                             mesh.material.src_blend_mode,
                                             mesh.material.dst_blend_mode,
                                         );
-                                        crate::asset_provider::merge_external_material(
+                                        // #2709 (SF-D9-03) — outcome discarded
+                                        // deliberately; this path already
+                                        // selectively reverts part of the merge
+                                        // (the blend restore below) and has no
+                                        // per-cell material tally to feed.
+                                        let _ = crate::asset_provider::merge_external_material(
                                             &mut mesh.material,
                                             provider,
                                             &mut pool,

--- a/byroredux/src/cell_loader/references/import.rs
+++ b/byroredux/src/cell_loader/references/import.rs
@@ -110,7 +110,11 @@ pub(super) fn parse_and_import_nif(
     // resolved BGSM/BGEM chain.
     if let Some(provider) = mat_provider {
         for mesh in &mut meshes {
-            merge_external_material(&mut mesh.material, provider, pool);
+            // #2709 (SF-D9-03) — the merge mutates `mesh.material` in
+            // place; the outcome is a diagnostic signal this path has no
+            // sink for yet (there is no per-cell material tally to feed).
+            // Discarded deliberately, not overlooked.
+            let _ = merge_external_material(&mut mesh.material, provider, pool);
         }
     }
     let lights = byroredux_nif::import::import_nif_lights(&scene);

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -270,7 +270,9 @@ pub(super) fn parse_import_and_merge(
     // REFR overlays and per-mesh imports share the dedup table (#609).
     if let Some(provider) = mat_provider {
         for mesh in &mut imported.meshes {
-            merge_external_material(&mut mesh.material, provider, &mut pool);
+            // #2709 (SF-D9-03) — outcome discarded deliberately; the
+            // loose-NIF path has no per-cell material tally to feed.
+            let _ = merge_external_material(&mut mesh.material, provider, &mut pool);
         }
     }
     // #1215 / D2 FIND-1 — sibling of the cell-loader zero-contribution

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -237,9 +237,22 @@ pub struct GpuMaterial {
     /// generic dielectric — `F0 = 0.04` matches the pre-#1248 behaviour
     /// so legacy NIF content with no authored IOR renders unchanged).
     /// Other common values: water 1.33 (F0 ≈ 0.020), ice 1.31, polished
-    /// stone 1.54, diamond 2.42 (F0 ≈ 0.172). FO4 BGSM v9+ and
-    /// Starfield .mat materials author this explicitly; older NIF
-    /// content inherits the default. See #1248.
+    /// stone 1.54, diamond 2.42 (F0 ≈ 0.172).
+    ///
+    /// #2703 (FO4-D7-01) — **no current importer authors this field.**
+    /// It was previously documented as "FO4 BGSM v9+ and Starfield .mat
+    /// materials author this explicitly", which is false for both:
+    /// `crates/bgsm/src/bgsm.rs` decodes no IOR/refraction field at any
+    /// BGSM version (its v>=9 addition is `custom_porosity` +
+    /// `porosity_value`, unrelated), and Starfield's CDB material reader
+    /// (`crates/sfmaterial`) has no refractive-index component either.
+    /// `material_translate::translate_material` always resolves this via
+    /// `material_optical_scalar(material_kind, refraction_strength)` —
+    /// the generic dielectric default (or glass promotion) for every
+    /// game, every format. `MATERIAL_KIND_FIRE_REFRACTION` is the one
+    /// exception: it overloads this same field as an authored 0-1
+    /// distortion strength, not a physical IOR — see
+    /// `SurfaceBehavior::ior`'s doc in `crates/core`. See #1248.
     pub ior: f32, // offset 280
     // ── Disney diffuse lobe (vec4 #21; offsets 284-296) ──────────────
     /// Disney "subsurface" diffuse-lobe weight (0 = pure Burley


### PR DESCRIPTION
…:ior provenance, BGSM deferred-field comment, MergeOutcome return

#2702 (FO4-D2-03): the three BGSM Phase-1 flag-forwarding tests declared local `let mut is_pbr = false;` bools and hand-copied the production merge gates rather than calling `merge_external_material`, so they asserted their own copy of the logic and could not fail when production diverged — exactly how the FO4-D2-01 `is_pbr` contract flip landed with a green suite while a test comment stated the opposite behaviour. Extract the gate into `forward_bgsm_phase1_flags` and rewrite all three tests against it plus the real `bgsm_uses_pbr_bsdf`. Verified by sabotage: negating either production gate now fails the test, which it did not before.

#2703 (FO4-D7-01): `GpuMaterial::ior`'s doc claimed "FO4 BGSM v9+ and Starfield .mat materials author this explicitly". False for both — `crates/bgsm` decodes no IOR/refraction field at any version (v>=9 adds `custom_porosity`/`porosity_value`), and `crates/sfmaterial` has no refractive-index component either. No importer writes `ior`; every path resolves it through `material_optical_scalar`. Replace the claim with what actually happens, including the `MATERIAL_KIND_FIRE_REFRACTION` overload that reuses the same slot as a 0-1 distortion strength.

#2704 (FO4-D7-02): eleven BGSM scalars decode correctly but have no `ImportedMaterial` sink and carried no comment marking the omission as deliberate — unlike the BGEM glass-overlay suite next door. Add one grouped "Deferred: no consumer" comment in `merge_external_material` naming all eleven (the six wetness-control fields, the v>=9 porosity pair, `adaptive_emissive_exposure_offset`, `aniso_lighting`, `external_emittance`) so the next completeness sweep can tell "not yet wired" from "overlooked". The wetness suite is the authored input the ROADMAP M61 wet-surface feature would need.

#2709 (SF-D9-03): `merge_external_material` returned a `bool` documented as "flips to true on any merged field", but the Starfield `.mat` arm returned true having set only the `is_pbr` routing flag and forwarded no texture, scalar, or alpha state — indistinguishable downstream from a fully-populated merge, which is the state the dominant Starfield population is in. Replace with `MergeOutcome { Unresolved, PresenceOnly, Merged }` + `#[must_use]`, so the presence-gate case is nameable and call sites must be explicit. All four production sites still discard the outcome, now via `let _ =` with a stated reason (no per-cell material tally exists to feed yet); the `PresenceOnly` case is pinned by a rewritten `starfield_mat` assertion. Also removes a stray copy of `merge_external_material`'s doc — carrying that false "returns true" sentence — that had been misfiled onto `bgsm_blend_to_gamebryo`.

Scoped to `-p byroredux` plus the one renderer doc change; full workspace run is green apart from the pre-existing, unrelated `fire_lights::derived_reach_is_currently_oversized` failure that is already red on main.