### PR TITLE
Fix #2807 #2811 #2810: shader-pipeline doc errors, preset citation + …

### DIFF
--- a/.claude/issues/2807 2810 2809 2811/ISSUE.md
+++ b/.claude/issues/2807 2810 2809 2811/ISSUE.md
@@ -1,0 +1,95 @@
+# Issues 2807, 2810, 2809, 2811
+
+All filed from `docs/audits/AUDIT_RENDERER_2026-08-12b.md`. Domain: renderer
+(`byroredux-renderer`), plus one pure-docs file.
+
+## #2807 — REN-D9-2026-08-12-05: shader-pipeline.md doc errors
+
+(a) Compute table says `skin_vertices.comp` deforms "positions **/ normals**";
+it has been position-only since #2170 (`SKIN_OUTPUT_STRIDE_FLOATS = 3`), and the
+shader body itself says so — the doc contradicts the code's own explanation of a
+live behavioural gap.
+(b) `MAX_TOTAL_BONES` factorised as 144 x 1364 = 196,416 != 196,608, omitting the
+reserved identity slot 0.
+
+Location: `docs/engine/shader-pipeline.md`.
+
+Severity: low. Labels: documentation, renderer.
+
+## #2810 — REN-D17-08: anisotropic GGX contracts have no regression guard
+
+The #1250 isotropic-degeneracy contract and the #1254 anisotropic clamp have
+zero automated guards, unlike every sibling invariant in this dimension (#2243,
+#2244, #2472, #1190 all have string-mirror tests with negative assertions).
+`grep -rn "distributionGGXAniso\|deriveAxAy" --include=*.rs` returns nothing.
+Both contracts verified algebraically to hold today; exposure is purely
+regression, in a lobe with no CPU producer, so a break wouldn't be caught by
+eyeball either.
+
+Location: `crates/renderer/shaders/include/pbr.glsl` (`distributionGGXAniso`,
+`deriveAxAy`).
+
+Severity: low. Labels: bug, renderer, tech-debt.
+
+## #2809 — REN-D16-04: froxel temporal clamp uses history volume; emissive asymmetry
+
+(1) The 3x3 clamp statistics are gathered by sampling `previousFroxel` — the
+history volume itself — not the current frame. Unlike `taa.comp` (moments from
+`uCurrHdr`) and `svgf_temporal.comp` (firefly statistic from
+`currIndirectTex`), clamping a value to a neighbourhood that *includes that
+value* removes single-froxel spatial spikes but bounds nothing about
+disagreement with the current frame; a spatially smooth but temporally stale
+history passes untouched.
+
+(2) The only genuine current-vs-history rejections are the density term
+(`exp(-temporal_params.y * relativeDensityDelta)`, `DEFAULT_DENSITY_REJECTION =
+4.0`) and `emissionAgreement = exp(-2.5 * relativeRadianceDelta *
+emissionFraction)`. The second is multiplied by `emissionFraction`, derived from
+the **current** sample alone. On the trailing edge — a froxel a flame has just
+left — `emissionFraction -> 0`, so `emissionAgreement -> 1` AND
+`mix(steadyWeight, emissiveWeight, emissionFraction)` selects `steadyWeight =
+0.92` (~12-frame decay) rather than `emissiveWeight = 0.75` (~3.5 frames). The
+emissive time constant is asymmetric: fast on, slow off.
+
+Location: `crates/renderer/shaders/volumetrics_inject.comp` — the
+`params.prev_camera_pos.w > 0.5` / `reprojectHistory` block; constants in
+`crates/renderer/src/vulkan/volumetrics.rs`.
+
+**Partially self-disproved (issue states for honesty)**: when the departing
+volume also dominated that froxel's extinction, `relativeDensityDelta ~= 1` and
+`exp(-4) ~= 0.018` collapses `historyWeight`, suppressing the trail. Surviving
+case: a froxel where the ambient/global medium dominates `sigma_t` — fogged
+exteriors, or a bright but optically thin flame.
+
+**Non-findings established, do NOT re-derive**: `historyWeight` is
+`clamp(_, 0, 0.98)` times two `exp(-x) <= 1` factors and `mix(current, history,
+w<1)` is a contraction with fixed point `current` → no runaway accumulation;
+magnitudes far below RGBA16F 65504 ceiling; previous-slot index is the other FIF
+slot, barriered, so no slot reads its own in-flight write; `history_valid`
+starts false and gates the block via `prev_camera_pos.w`.
+
+Suggested fix: gather clamp statistics from the current frame's computed
+`inscatter`/`extinction` neighbourhood (needs shared-memory or second-pass
+restructure), OR — much cheaper — derive `emissionFraction` from `max(current
+emission luma, reprojected-history emission content)` so the trailing edge
+inherits the same short time constant as the leading edge.
+
+Severity: medium. Labels: bug, renderer, vulkan.
+
+## #2811 — REN-D17-09: presets have unverifiable citation + phantom fallback role
+
+(a) The module pins its values to `knightcrawler25/GLSL-PathTracer`, which the
+user-memory note *reference_glsl_pathtracer.md* records as cloned to
+`/mnt/data/src/reference/` — **it is not there**, so the Dim-17 checklist item
+"Disney preset constructors match documented values (cross-ref GLSL-PathTracer)"
+is not executable offline. Same for the four `pbr.glsl` doc references into
+`disney.glsl` line ranges.
+(b) The doc claims the presets are the "fallback when authored BGSM is absent";
+**no such fallback exists** — `translate_material` never consults `presets`, and
+the only hits outside `material.rs` are its own tests. A documented fallback role
+no code implements is an invitation to wire it in and bypass the NIFAL single
+boundary.
+
+Location: `crates/renderer/src/vulkan/material.rs` (`pub mod presets`).
+
+Severity: low. Labels: documentation, renderer.

--- a/crates/renderer/shaders/include/pbr.glsl
+++ b/crates/renderer/shaders/include/pbr.glsl
@@ -6,6 +6,16 @@
 // and in earlier includes. Do not compile on its own.
 
 // ── PBR: GGX / Cook-Torrance BRDF ──────────────────────────────────
+//
+// #2811 (REN-D17-09) — the `knightcrawler25/GLSL-PathTracer` (MIT)
+// file:line citations throughout this file are NOT verifiable offline:
+// that repo is not present under `/mnt/data/src/reference/` (which
+// holds Champollion, Gibbed.Starfield, Material-Editor, gamebryo-v26/
+// v32, havok-20070919/2013, nifly, nifxml, openmw). The line ranges
+// were accurate when transcribed and are kept as provenance, but they
+// cannot be re-checked until the repo is re-cloned — so treat the
+// Rust-side regression tests as the authority on these formulas, not
+// the citations. Same caveat on `vulkan/material.rs`'s `presets`.
 
 // Normal Distribution Function (GGX/Trowbridge-Reitz).
 float distributionGGX(float NdotH, float roughness) {

--- a/crates/renderer/shaders/volumetrics_inject.comp
+++ b/crates/renderer/shaders/volumetrics_inject.comp
@@ -702,6 +702,19 @@ void main() {
         vec3 previousUvw;
         if (reprojectHistory(world_pos, previousUvw)) {
             vec4 history = texture(previousFroxel, previousUvw);
+            // #2809 (REN-D16-04), KNOWN LIMITATION — the 3×3 statistics
+            // below are gathered from `previousFroxel`, i.e. the history
+            // volume itself, not the current frame. `taa.comp` takes its
+            // moments from `uCurrHdr` and `svgf_temporal.comp` its firefly
+            // statistic from `currIndirectTex`; clamping a value to a
+            // neighbourhood that CONTAINS that value removes single-froxel
+            // spatial spikes but places no bound whatever on disagreement
+            // with the current frame, so a spatially smooth but temporally
+            // stale history passes through untouched. Fixing it properly
+            // needs the current frame's computed inscatter/extinction
+            // neighbourhood, i.e. a shared-memory or second-pass
+            // restructure — deliberately not attempted blind, since the
+            // effect is quality-only and needs RenderDoc to evaluate.
             ivec3 historySize = textureSize(previousFroxel, 0);
             vec3 texel = 1.0 / vec3(historySize);
             vec3 historyMean = vec3(0.0);
@@ -747,6 +760,32 @@ void main() {
             // deterministic given the volume — so keying the shorter time
             // constant on how much of the source term is emissive isolates
             // the fast-changing signal without touching the noisy one.
+            // #2809 (REN-D16-04), KNOWN LIMITATION — this time constant is
+            // ASYMMETRIC: fast on, slow off. `emissionFraction` is derived
+            // from the CURRENT sample alone, so on a trailing edge (a froxel
+            // a flame has just left) `local_medium.emission → 0`, which both
+            // drives `emissionAgreement → 1` (disabling the only radiance-
+            // based rejection) and makes the `mix` below select
+            // `steadyWeight` (~12-frame decay) instead of `emissiveWeight`
+            // (~3.5 frames). Net effect: emissive smear trailing moving
+            // fire/explosion fronts.
+            //
+            // Partly self-limiting: when the departing volume also dominated
+            // the froxel's extinction, `relativeDensityDelta ≈ 1` and
+            // `exp(-DENSITY_REJECTION)` collapses `historyWeight` anyway. The
+            // case that survives is a froxel where the ambient/global medium
+            // dominates sigma_t — fogged exteriors, or a bright but optically
+            // thin flame.
+            //
+            // NOT fixable by reading history emission: the froxel image is
+            // RGBA16F with rgb = inscatter and a = extinction, so the
+            // emissive share is never stored and cannot be reprojected. A
+            // real fix needs an extra per-frame emission-share image.
+            // And do NOT "fix" it by folding in a history-vs-current
+            // radiance drop — that is exactly the radiance-delta rejection
+            // the paragraph below rules out, and it would suppress
+            // accumulation at the god-ray edges accumulation exists to clean
+            // up.
             float emissionLuma = dot(local_medium.emission, LUMA_REC709);
             float sourceLuma = dot(current.rgb, LUMA_REC709);
             float emissionFraction =

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -651,12 +651,35 @@ impl Eq for GpuMaterial {}
 /// `knightcrawler25/GLSL-PathTracer` (MIT) —
 /// `assets/hyperion_rect_lights.scene`.
 ///
-/// Use as the fallback when authored BGSM is absent (or as
-/// known-good test fixtures). Pre-#1251 the synthetic-material
-/// path picked `roughness=0.5, metallic=0.0, F0=0.04` from thin
-/// air — the `feedback_no_guessing` memory wants citable
-/// references for every physical constant, and the Hyperion
-/// preset table is the canonical Disney-BSDF reference.
+/// **Citation is not verifiable offline** (#2811 / REN-D17-09): the
+/// `reference_glsl_pathtracer` note records this repo as cloned to
+/// `/mnt/data/src/reference/`, but it is not present there (that
+/// directory holds Champollion, Gibbed.Starfield, Material-Editor,
+/// gamebryo-v26/v32, havok-20070919/2013, nifly, nifxml, openmw — no
+/// GLSL-PathTracer). Every scalar below is therefore *citable but
+/// unconfirmed* against the named source, and the Dim-17 audit
+/// checklist item "Disney preset constructors match documented values
+/// (cross-ref GLSL-PathTracer)" cannot be executed until the repo is
+/// re-cloned. The same caveat applies to `pbr.glsl`'s four references
+/// into `disney.glsl` line ranges. Treat the values as pinned by the
+/// per-preset tests below, not by a live cross-reference.
+///
+/// **These are test fixtures / reference values only — NOT a runtime
+/// fallback.** An earlier version of this doc described them as "the
+/// fallback when authored BGSM is absent"; no such fallback exists or
+/// should. `translate_material` never consults this module, and its
+/// only callers are the tests below. Wiring these into the runtime
+/// would put per-material selection in the renderer, bypassing the
+/// NIFAL parser→`Material` single boundary — see
+/// `feedback_format_translation` and `docs/engine/nifal.md`. The
+/// canonical no-authored-data path is `Material::resolve_pbr`'s
+/// NaN-sentinel keyword classifier, CPU-side.
+///
+/// Pre-#1251 the synthetic-material path picked
+/// `roughness=0.5, metallic=0.0, F0=0.04` from thin air — the
+/// `feedback_no_guessing` memory wants citable references for every
+/// physical constant, and the Hyperion preset table is the canonical
+/// Disney-BSDF reference.
 ///
 /// Each preset returns a fully-populated `GpuMaterial`. The base
 /// `Default::default()` values cover every field this audit's

--- a/crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs
+++ b/crates/renderer/src/vulkan/scene_buffer/gpu_instance_layout_tests.rs
@@ -1642,3 +1642,160 @@ fn bounded_path_preserves_the_accepted_segment_and_diffuse_budgets() {
         "bounded path must enforce both the hard and adaptive segment ceilings"
     );
 }
+
+/// #2810 (REN-D17-08) — the #1250 isotropic-degeneracy contract, checked
+/// numerically rather than by string mirror.
+///
+/// `distributionGGXAniso` documents that it "reduces exactly to
+/// `distributionGGX` when ax == ay". That is the property which lets the
+/// anisotropic lobe be the single NDF for both cases, so every legacy
+/// isotropic material keeps its exact pre-#1250 appearance. The reduction
+/// is not free algebra — it holds only because H is a unit vector in
+/// tangent space (`HdotX² + HdotY² + NdotH² = 1`), which lets
+///
+///   `HdotX²/a² + HdotY²/a² + NdotH²`  collapse to  `(1 + NdotH²(a²-1))/a²`
+///
+/// i.e. the isotropic `denom` scaled by `1/a²`, whose square then cancels
+/// against the `ax·ay = a²` prefactor. A future edit that drops the `ax*ay`
+/// prefactor, or squares `ax`/`ay` one time too many/few, breaks the
+/// identity while still compiling and still looking plausible — and this
+/// lobe has no CPU producer (`anisotropic` is reachable only through
+/// `mat.set`, see #2514), so nothing would catch it by eyeball either.
+///
+/// Ports both GLSL bodies verbatim so a divergence in either is caught.
+#[test]
+fn anisotropic_ggx_reduces_to_the_isotropic_ndf_at_zero_anisotropy() {
+    const PI: f64 = std::f64::consts::PI;
+
+    // Verbatim ports of `include/pbr.glsl`.
+    fn distribution_ggx(n_dot_h: f64, roughness: f64) -> f64 {
+        let a = roughness * roughness;
+        let a2 = a * a;
+        let denom = n_dot_h * n_dot_h * (a2 - 1.0) + 1.0;
+        a2 / (PI * denom * denom)
+    }
+    fn distribution_ggx_aniso(n_dot_h: f64, h_dot_x: f64, h_dot_y: f64, ax: f64, ay: f64) -> f64 {
+        let ax2 = ax * ax;
+        let ay2 = ay * ay;
+        let denom = h_dot_x * h_dot_x / ax2 + h_dot_y * h_dot_y / ay2 + n_dot_h * n_dot_h;
+        1.0 / (PI * ax * ay * denom * denom)
+    }
+    fn derive_ax_ay(roughness: f64, anisotropic: f64) -> (f64, f64) {
+        let alpha = roughness * roughness;
+        let aniso = anisotropic.clamp(0.0, 1.0);
+        let aspect = (1.0 - aniso * 0.9).sqrt();
+        (
+            (0.025f64 * 0.025).max(alpha / aspect),
+            (0.025f64 * 0.025).max(alpha * aspect),
+        )
+    }
+
+    // Sweep roughness above the `0.025² in α-units` floor so `deriveAxAy`
+    // returns the unclamped `alpha` and the identity is exercised rather
+    // than the floor. roughness ≥ 0.025 ⇒ alpha = roughness² ≥ 0.025².
+    for &roughness in &[0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0] {
+        let (ax, ay) = derive_ax_ay(roughness, 0.0);
+        assert!(
+            (ax - ay).abs() < 1e-15,
+            "anisotropic=0 must give ax == ay (roughness {roughness}): {ax} vs {ay}"
+        );
+
+        // Sample unit half-vectors in tangent space: the identity depends
+        // on `HdotX² + HdotY² + NdotH² == 1`.
+        for &n_dot_h in &[0.05, 0.2, 0.5, 0.8, 0.95, 1.0] {
+            let tangential = (1.0f64 - n_dot_h * n_dot_h).max(0.0).sqrt();
+            for &phi in &[0.0, 0.3, 0.7854, 1.2, PI / 2.0] {
+                let h_dot_x = tangential * phi.cos();
+                let h_dot_y = tangential * phi.sin();
+
+                let iso = distribution_ggx(n_dot_h, roughness);
+                let aniso = distribution_ggx_aniso(n_dot_h, h_dot_x, h_dot_y, ax, ay);
+                let rel = (aniso - iso).abs() / iso.max(1e-300);
+                assert!(
+                    rel < 1e-9,
+                    "anisotropic NDF must reduce to the isotropic NDF at anisotropic=0 \
+                     (roughness {roughness}, NdotH {n_dot_h}, phi {phi}): \
+                     iso {iso}, aniso {aniso}, rel err {rel}"
+                );
+            }
+        }
+    }
+
+    // The ported bodies must stay in lockstep with the GLSL they mirror.
+    let pbr = include_str!("../../../shaders/include/pbr.glsl");
+    assert!(
+        pbr.contains("return 1.0 / (PI * ax * ay * denom * denom);"),
+        "distributionGGXAniso's `ax*ay` prefactor is what cancels the `1/a²` in the \
+         collapsed denominator — dropping it silently breaks the #1250 reduction"
+    );
+    assert!(
+        pbr.contains("float denom = HdotX * HdotX / ax2 + HdotY * HdotY / ay2 + NdotH * NdotH;"),
+        "distributionGGXAniso's denominator drifted from the form the reduction assumes"
+    );
+    assert!(
+        pbr.contains("return a2 / (PI * denom * denom);"),
+        "distributionGGX (isotropic) drifted; the degeneracy target changed"
+    );
+}
+
+/// #2810 (REN-D17-08) — the #1254 anisotropic clamp.
+///
+/// `deriveAxAy` clamps `anisotropic` to [0, 1] before `sqrt(1 - 0.9·a)`.
+/// Without it an authored value > 1.0 (defense-in-depth against a future
+/// BGSM v9+ / Starfield `.mat` importer that forwards unclamped data)
+/// makes the radicand negative → `ax`/`ay` NaN → `distributionGGXAniso`
+/// NaN → black/undefined fragment. Negative inputs shrink `ax` below the
+/// intended floor. Pinned both numerically and at the source, since the
+/// guard is one line that a cleanup pass could plausibly delete.
+#[test]
+fn derive_ax_ay_clamps_anisotropic_against_nan_and_floor_escape() {
+    let pbr = include_str!("../../../shaders/include/pbr.glsl");
+
+    assert!(
+        pbr.contains("float aniso = clamp(anisotropic, 0.0, 1.0);")
+            && pbr.contains("float aspect = sqrt(1.0 - aniso * 0.9);"),
+        "deriveAxAy must clamp `anisotropic` to [0,1] BEFORE the sqrt (#1254) — an \
+         authored value > 1 otherwise makes the radicand negative and NaNs the lobe"
+    );
+    assert!(
+        !pbr.contains("sqrt(1.0 - anisotropic * 0.9)"),
+        "the sqrt must consume the clamped `aniso`, never the raw `anisotropic` (#1254)"
+    );
+    // The α-units floor is the other half of the contract — it mirrors
+    // `specularAaRoughness`'s effective roughness ≥ 0.025 (see #2471 and
+    // the #1250 closeout, which deferred the "drop to 0.001" suggestion).
+    assert!(
+        pbr.contains("ax = max(0.025 * 0.025, alpha / aspect);")
+            && pbr.contains("ay = max(0.025 * 0.025, alpha * aspect);"),
+        "deriveAxAy's 0.025² α-units floor must survive — it preserves the \
+         BSLightingShader gloss-cap behaviour (#1250 closeout / #2471)"
+    );
+
+    // Numeric: out-of-range inputs must stay finite and ordered.
+    fn derive_ax_ay(roughness: f64, anisotropic: f64) -> (f64, f64) {
+        let alpha = roughness * roughness;
+        let aniso = anisotropic.clamp(0.0, 1.0);
+        let aspect = (1.0 - aniso * 0.9).sqrt();
+        (
+            (0.025f64 * 0.025).max(alpha / aspect),
+            (0.025f64 * 0.025).max(alpha * aspect),
+        )
+    }
+    for &anisotropic in &[-5.0, -1.0, -0.001, 0.0, 0.5, 1.0, 1.001, 2.0, 1e6] {
+        let (ax, ay) = derive_ax_ay(0.5, anisotropic);
+        assert!(
+            ax.is_finite() && ay.is_finite(),
+            "anisotropic {anisotropic} produced a non-finite lobe: ax {ax}, ay {ay}"
+        );
+        assert!(
+            ax >= 0.025 * 0.025 && ay >= 0.025 * 0.025,
+            "anisotropic {anisotropic} escaped the α-units floor: ax {ax}, ay {ay}"
+        );
+        // `aspect ≤ 1` for every clamped input, so the tangent axis is
+        // never the narrower of the two.
+        assert!(
+            ax >= ay - 1e-15,
+            "ax must remain the stretched axis for anisotropic {anisotropic}: {ax} < {ay}"
+        );
+    }
+}

--- a/docs/engine/shader-pipeline.md
+++ b/docs/engine/shader-pipeline.md
@@ -30,7 +30,7 @@ renderer architecture (BLAS/TLAS, sync, swapchain, teardown ordering) see
 | File | Role |
 |------|------|
 | `skin_palette.comp` | Build per-slot bone-matrix palette from world transforms + bind inverses |
-| `skin_vertices.comp` | Deform skinned vertex positions / normals via palette lookup; output drives per-entity BLAS refit |
+| `skin_vertices.comp` | Deform skinned vertex **positions only** (`SKIN_OUTPUT_STRIDE_FLOATS` = 3 since #2170 — the skinned normal/tangent writes were dropped with their unread consumers); output drives per-entity BLAS refit |
 | `cluster_cull.comp` | Build per-froxel light lists (clustered shading) |
 | `ssao.comp` | Screen-space ambient occlusion texture generation |
 | `svgf_temporal.comp` | Temporal denoiser — motion-vector reprojection + color/moments accumulation for indirect lighting |
@@ -316,7 +316,7 @@ Prefixed by a 16-byte header (`u32 count` + 3 × `u32` padding). Up to
 | `MAX_LIGHTS` | 512 | Per-frame point/spot/directional lights |
 | `MAX_INSTANCES` | 262 144 | One indirect draw command per instance worst-case |
 | `MAX_MATERIALS` | 16 384 | 348 B each; deduplicated per frame |
-| `MAX_TOTAL_BONES` | 196 608 | 144 slots × 1 364 skinned meshes (M29.6) |
+| `MAX_TOTAL_BONES` | 196 608 | `floor(196 608 / 144)` = 1 365 palette slots, minus reserved slot 0 → **1 364 allocatable** skinned meshes (M29.6). Not an exact product: 1 365 × 144 = 196 560 leaves a 48-bone unused tail |
 | `MAX_PENDING_BIND_INVERSE_UPLOADS_PER_FRAME` | 1 366 | First-sight bind-inverse upload cap |
 | `MAX_TERRAIN_TILES` | 1 024 | 32 B each |
 | `IDENTITY_BONE_SLOT` | 0 | Slot 0 is always the identity matrix |


### PR DESCRIPTION
…phantom fallback, anisotropic GGX regression guards

#2807 (REN-D9-2026-08-12-05): two doc errors in shader-pipeline.md. (a) The compute table claimed `skin_vertices.comp` deforms "positions / normals"; it has been position-only since #2170
(`SKIN_OUTPUT_STRIDE_FLOATS = 3`) and the shader body says so, so the doc contradicted the code's own explanation of a live behavioural gap. (b) `MAX_TOTAL_BONES` was factorised as 144 x 1364 = 196,416 != 196,608. The real relationship is floor division with a remainder, not a product: floor(196608/144) = 1365 palette slots, minus reserved slot 0 -> 1364 allocatable, leaving a 48-bone unused tail. Matches `skin_slot_pool.rs`'s own wording and the `skin_pool_max = 1364` figure recorded in AUDIT_RUNTIME_2026-06-14.

#2811 (REN-D17-09): (a) verified `knightcrawler25/GLSL-PathTracer` is absent from `/mnt/data/src/reference/`, so every preset scalar and the five GLSL-PathTracer file:line citations in `pbr.glsl` are citable but unverifiable offline, and the Dim-17 checklist item that cross-refs them is non-executable. Recorded the caveat at both sites and pointed readers at the regression tests as the standing authority. (b) The `presets` module doc claimed the values are "the fallback when authored BGSM is absent"; no such fallback exists — `translate_material` never consults the module and its only callers are its own tests. Replaced with an explicit "test fixtures / reference values only, NOT a runtime fallback" plus why wiring it in would bypass the NIFAL single boundary.

#2810 (REN-D17-08): the #1250 isotropic-degeneracy contract and the #1254 anisotropic clamp had zero automated guards, in a lobe with no CPU producer (`anisotropic` is reachable only via `mat.set`), so a regression would be caught neither by tests nor by eyeball. Adds two. The degeneracy guard is numeric rather than a string mirror: it ports both GLSL NDF bodies and asserts `distributionGGXAniso` reduces to `distributionGGX` across a roughness x NdotH x phi sweep, since the reduction holds only via the unit-H identity
`HdotX^2 + HdotY^2 + NdotH^2 = 1` and is broken by an edit that drops the `ax*ay` prefactor or mis-squares ax/ay while still compiling. The clamp guard pins the pre-sqrt `clamp(anisotropic, 0, 1)` and the 0.025^2 alpha-units floor at source, with negative assertions, plus a numeric sweep over out-of-range inputs. Both verified by sabotage: removing the clamp and dropping the prefactor each fail their test.

#2809 (REN-D16-04) is NOT fixed here — see below.

Its suggested "cheap fix" (derive `emissionFraction` from `max(current emission luma, reprojected-history emission content)`) is not implementable as written: the froxel image is RGBA16F carrying rgb = inscatter and a = extinction, so the emissive share is never stored and cannot be reprojected. Nothing in the current frame distinguishes "flame just left this froxel" from "never had flame". The other option (clamp statistics from the current frame) is a shared-memory or second-pass restructure. Both are unverifiable without RenderDoc, in a path where sibling #2241 is still open, so neither was attempted blind. Instead both confirmed mechanisms — the clamp being gathered from the history volume itself, and the asymmetric emissive time constant — are recorded in `volumetrics_inject.comp` alongside the storage constraint and an explicit warning against the radiance-delta "fix" the surrounding comment already rules out. Issue stays open.

Both GLSL edits are comment-only: verified `volumetrics_inject.comp` compiles to byte-identical SPIR-V before and after, so no `.spv` was regenerated (the checked-in binaries differ from a local rebuild only by toolchain flags, and rewriting them would be unrelated churn).