### PR TITLE
Fix #2460 #2452 #2454 #2451: shared BLAS scratch peak, baked-LOD predicate, OFST drop, per-cell XCCM climate

### DIFF
--- a/.claude/commands/audit-legacy-compat/SKILL.md
+++ b/.claude/commands/audit-legacy-compat/SKILL.md
@@ -177,10 +177,12 @@ table, §5 LOD, §7 rollout status).
   because FO3/FNV ship **zero** `distantlod\*.lod` files in any vanilla archive
   (FO3-D4-01 / #2086) — "FO3/FNV distant-object LOD is missing" is a real gap but
   not a `PlacementLodProvider` gap. `docs/engine/exal.md` §5 is the coverage
-  source of truth for what remains open here. WRLD `NAM3`/`NAM4` LOD-water +
-  `OFST` are now **parsed** (#1849, onto `WorldspaceRecord::lod_water_form` /
-  `lod_water_height` / `cell_offsets`) but not yet consumed — a consumer gap,
-  not a parse gap.
+  source of truth for what remains open here. WRLD `NAM3`/`NAM4` LOD-water are
+  **parsed** (#1849, onto `WorldspaceRecord::lod_water_form` /
+  `lod_water_height`) **and consumed** (#2449 / EXAL-01). WRLD `OFST` is
+  deliberately **not** captured (#2454 / EXAL-08) — the LAND streamer resolves
+  cells from the parsed index, not by file offset; a finding that "OFST is
+  dropped" is a premise error, not a parse gap.
   Per `exal.md` §5.4: runtime LOD is asset-driven — neither NIF LOD nodes nor STAT `MNAM`
   unblock it. The **VWD / "Has Distant LOD" record-header flag** is now parsed and exposed
   (`RecordHeader::is_visible_when_distant()`, #1731) but has zero consumers — wiring it

--- a/byroredux/src/app_step.rs
+++ b/byroredux/src/app_step.rs
@@ -56,6 +56,22 @@ impl App {
         };
         let player_grid = streaming::world_pos_to_grid(player_pos.x, player_pos.z);
         let state = self.streaming.as_mut().unwrap();
+        // #2451 / EXAL-03 — a cell may pin its own CLMT via XCCM, which
+        // re-resolves sky + weather (through the same crossfade a
+        // worldspace change uses) when it differs from what is installed.
+        // Deliberately OUTSIDE the `grid_changed` guard below: bootstrap
+        // seeds `last_player_grid` before the first step, so a session
+        // starting *inside* an override cell would otherwise never apply
+        // it until the player left and came back. Costs one map lookup
+        // and an `Option<u32>` compare on every other frame.
+        crate::scene::apply_cell_climate_override(
+            &mut self.world,
+            ctx,
+            &state.tex_provider,
+            &state.wctx,
+            player_grid,
+            &mut state.applied_climate_form,
+        );
         let grid_changed = state.last_player_grid != Some(player_grid);
         if grid_changed {
             let dispatch_started = Instant::now();

--- a/byroredux/src/cell_loader/exterior.rs
+++ b/byroredux/src/cell_loader/exterior.rs
@@ -862,19 +862,15 @@ pub fn build_exterior_world_context(
         );
     });
     let default_weather = climate.as_ref().and_then(|climate| {
-        let best = climate
-            .weathers
-            .iter()
-            .filter(|w| w.chance >= 0)
-            .max_by_key(|w| w.chance)?;
-        let wthr = record_index.weathers.get(&best.weather_form_id)?.clone();
+        let (wthr, chance) =
+            crate::env_translate::resolve_default_weather(climate, &record_index.weathers)?;
         log::info!(
             "Default weather: '{}' ({:08X}, chance {})",
             wthr.editor_id,
             wthr.form_id,
-            best.chance,
+            chance,
         );
-        Some(wthr)
+        Some(wthr.clone())
     });
 
     // Resolve the worldspace-default water once (#1305 / OBL-D6-NEW-02).

--- a/byroredux/src/cell_loader/lod_support.rs
+++ b/byroredux/src/cell_loader/lod_support.rs
@@ -32,6 +32,25 @@ pub(crate) struct LodReconcileInput<'a> {
     pub(crate) max_full_cell_radius: i32,
 }
 
+/// Whether `game` ships Bethesda's prebaked **combined** distant LOD —
+/// the `.bto` object quads and `.btr` terrain quads named by quadtree
+/// level and quad coordinate. Skyrim (LE/SE) and FO4 only; Oblivion and
+/// FO3/FNV predate the scheme and keep the synthesized heightmap ring
+/// plus, on Oblivion, `DistantLOD\*.lod` placement
+/// ([`super::placement_lod::placement_lod_supported`], its per-game
+/// sibling).
+///
+/// One named decision per quirk, per exal.md §4: the same
+/// `Skyrim | Fallout4` literal was previously written inline at each
+/// consumer, which is exactly the drift the doctrine forbids — a title
+/// gaining or losing baked LOD would have to be found in every provider
+/// rather than changed here. [`LodBandLadder::for_game`] answers the
+/// same question in data form (a ladder exists ⟺ baked LOD exists); the
+/// tests below pin the two to agree. #2452 / EXAL-04.
+pub(crate) fn baked_lod_supported(game: GameKind) -> bool {
+    matches!(game, GameKind::Skyrim | GameKind::Fallout4)
+}
+
 /// Canonical baked-LOD grid origin for the active worldspace (#2586).
 ///
 /// Skyrim+/FO4 align `.bto` and `.btr` quad coordinates relative to the
@@ -40,10 +59,7 @@ pub(crate) struct LodReconcileInput<'a> {
 /// back to the component-wise minimum of their explicit exterior cells.
 /// Older games keep their existing absolute synth/placement grids.
 pub(crate) fn worldspace_lod_grid_origin(wctx: &ExteriorWorldContext) -> (i32, i32) {
-    if !matches!(
-        wctx.record_index.game,
-        GameKind::Skyrim | GameKind::Fallout4
-    ) {
+    if !baked_lod_supported(wctx.record_index.game) {
         return (0, 0);
     }
 
@@ -310,6 +326,42 @@ mod tests {
             Vec::new(), // uvs
             Vec::new(), // indices
         )
+    }
+
+    /// #2452 / EXAL-04 — per-variant, mirroring
+    /// `placement_lod_supported_is_oblivion_only`. Skyrim and FO4 ship
+    /// `.bto`/`.btr`; every other title falls to the synth ring.
+    #[test]
+    fn baked_lod_supported_is_skyrim_and_fo4_only() {
+        assert!(baked_lod_supported(GameKind::Skyrim));
+        assert!(baked_lod_supported(GameKind::Fallout4));
+        assert!(!baked_lod_supported(GameKind::Oblivion));
+        assert!(!baked_lod_supported(GameKind::Fallout3NV));
+        assert!(!baked_lod_supported(GameKind::Fallout76));
+        assert!(!baked_lod_supported(GameKind::Starfield));
+    }
+
+    /// The predicate and the band ladder answer the same question in
+    /// two forms — a title with baked LOD has a quadtree ladder and
+    /// vice versa. Pinned so the two can't drift apart the way the
+    /// inline `matches!` copies did.
+    #[test]
+    fn baked_lod_predicate_agrees_with_the_band_ladder() {
+        use super::super::lod_bands::LodBandLadder;
+        for game in [
+            GameKind::Oblivion,
+            GameKind::Fallout3NV,
+            GameKind::Skyrim,
+            GameKind::Fallout4,
+            GameKind::Fallout76,
+            GameKind::Starfield,
+        ] {
+            assert_eq!(
+                baked_lod_supported(game),
+                LodBandLadder::for_game(game).is_some(),
+                "{game:?}: baked-LOD predicate and band ladder disagree"
+            );
+        }
     }
 
     #[test]

--- a/byroredux/src/cell_loader/terrain_lod.rs
+++ b/byroredux/src/cell_loader/terrain_lod.rs
@@ -37,7 +37,9 @@ use crate::components::IsLodTerrain;
 use crate::streaming::LodBlock;
 
 use super::lod_bands::{self, quad_min_chebyshev, LodBandLadder, LodBandSelection};
-use super::lod_support::{worldspace_cell_bounds, LodReconcileInput, LodWorkBudget};
+use super::lod_support::{
+    baked_lod_supported, worldspace_cell_bounds, LodReconcileInput, LodWorkBudget,
+};
 
 /// Cells per LOD-block edge. A block is one merged mesh covering
 /// `LOD_BLOCK_CELLS²` cells (4×4 = 16 cells = 16384×16384 BU). Bigger
@@ -506,7 +508,7 @@ pub(crate) fn stream_lod_blocks(
         // Coarse bands (`level > k`) exist *only* as `.btr`: the descent
         // above only proposes them where one is baked, and the synth builder
         // is finest-band-only (its hole mask is a `u16`, one bit per cell).
-        let btr_block = if mask == 0 && matches!(game, GameKind::Skyrim | GameKind::Fallout4) {
+        let btr_block = if mask == 0 && baked_lod_supported(game) {
             super::terrain_lod_btr::spawn_btr_block(
                 world,
                 ctx,

--- a/byroredux/src/env_translate.rs
+++ b/byroredux/src/env_translate.rs
@@ -300,6 +300,66 @@ pub(crate) fn resolve_worldspace_climate(
     }
 }
 
+/// Resolve the climate in effect for one exterior cell: its own `XCCM`
+/// override when it authors one, otherwise the worldspace climate
+/// [`resolve_worldspace_climate`] settled (#2451 / EXAL-03).
+///
+/// Skyrim+ cells can pin a CLMT for one cell — scripted weather pockets,
+/// boss arenas, exteriors meant to feel enclosed. Pre-fix `XCCM` was
+/// parsed onto `CellData::climate_override` and read by nothing, so every
+/// such cell silently rendered the worldspace default.
+///
+/// An override that doesn't resolve to a parsed CLMT (missing master, a
+/// FormID the load order never supplied) falls back to the worldspace
+/// climate rather than to no climate at all: the alternative would drop a
+/// cell with an authored-but-broken override into the procedural fallback
+/// sky, which is strictly further from what the author asked for. Logged
+/// at `warn` so the broken link is diagnosable.
+///
+/// Takes the already-extracted `CellData::climate_override` rather than the
+/// cell: the decision is about two FormIDs and their resolvability, and
+/// keeping the record out of the signature keeps it pure and testable
+/// without an ESM or a Vulkan context.
+pub(crate) fn resolve_cell_climate(
+    cell_climate_override: Option<u32>,
+    worldspace_climate: Option<u32>,
+    climates: &HashMap<u32, ClimateRecord>,
+) -> Option<u32> {
+    let Some(override_fid) = cell_climate_override else {
+        return worldspace_climate;
+    };
+    if climates.contains_key(&override_fid) {
+        return Some(override_fid);
+    }
+    log::warn!(
+        "resolve_cell_climate: cell XCCM climate {override_fid:08X} is not among parsed CLMT \
+         records — falling back to the worldspace climate {worldspace_climate:08X?}",
+    );
+    worldspace_climate
+}
+
+/// The default weather for `climate`: its highest-chance WTHR entry that
+/// resolves to a parsed record.
+///
+/// Negative chances are mod sentinels / subtractive weights and are
+/// filtered before the max (#476). Shared by the once-per-worldspace
+/// resolve in `build_exterior_world_context` and the per-cell XCCM
+/// re-resolve (#2451), so a cell override picks its weather by exactly the
+/// same rule the worldspace default did.
+pub(crate) fn resolve_default_weather<'a>(
+    climate: &ClimateRecord,
+    weathers: &'a HashMap<u32, WeatherRecord>,
+) -> Option<(&'a WeatherRecord, i32)> {
+    let best = climate
+        .weathers
+        .iter()
+        .filter(|w| w.chance >= 0)
+        .max_by_key(|w| w.chance)?;
+    weathers
+        .get(&best.weather_form_id)
+        .map(|wthr| (wthr, best.chance))
+}
+
 /// Every worldspace key from `start_key` up its `WNAM` parent chain, most
 /// specific first.
 ///
@@ -1128,6 +1188,139 @@ mod tests {
             default_water_for_worldspace(&map, "c", GameKind::Oblivion),
             (Some(0.0), Some(0x0000_00CD)),
         );
+    }
+
+    // ── resolve_cell_climate (#2451 / EXAL-03) ────────────────────
+
+    /// The parsed CLMT set the override has to resolve against.
+    fn climate_records(form_ids: &[u32]) -> HashMap<u32, ClimateRecord> {
+        form_ids
+            .iter()
+            .map(|&form_id| {
+                (
+                    form_id,
+                    ClimateRecord {
+                        form_id,
+                        editor_id: format!("CLMT{form_id:08X}"),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// The finding itself: a cell that authors XCCM must resolve to the
+    /// override, not to the worldspace default. Pre-#2451
+    /// `CellData::climate_override` was parsed on both CELL walk paths
+    /// and read by nothing, so every such cell rendered the worldspace
+    /// sky.
+    #[test]
+    fn cell_xccm_override_wins_over_the_worldspace_climate() {
+        let climates = climate_records(&[0x0001_A2B3, 0x0000_1234]);
+        assert_eq!(
+            resolve_cell_climate(Some(0x0001_A2B3), Some(0x0000_1234), &climates),
+            Some(0x0001_A2B3),
+        );
+    }
+
+    /// No XCCM — inherit the worldspace climate unchanged. This is the
+    /// overwhelmingly common case (vanilla content authors XCCM on a
+    /// handful of cells), so it must stay a pure pass-through.
+    #[test]
+    fn cell_without_xccm_inherits_the_worldspace_climate() {
+        let climates = climate_records(&[0x0000_1234]);
+        assert_eq!(
+            resolve_cell_climate(None, Some(0x0000_1234), &climates),
+            Some(0x0000_1234),
+        );
+        // Climateless worldspace + no override stays climateless (the
+        // caller's procedural-fallback sky), not fabricated.
+        assert_eq!(resolve_cell_climate(None, None, &climates), None);
+    }
+
+    /// An override pointing at a CLMT the load order never supplied
+    /// (missing master, stale mod edit) falls back to the worldspace
+    /// climate rather than to `None` — dropping into the procedural
+    /// fallback sky would be further from the author's intent than the
+    /// worldspace's own weather.
+    #[test]
+    fn unresolvable_override_falls_back_to_the_worldspace_climate() {
+        let climates = climate_records(&[0x0000_1234]);
+        assert_eq!(
+            resolve_cell_climate(Some(0xDEAD_BEEF), Some(0x0000_1234), &climates),
+            Some(0x0000_1234),
+        );
+        assert_eq!(
+            resolve_cell_climate(Some(0xDEAD_BEEF), None, &climates),
+            None,
+        );
+    }
+
+    // ── resolve_default_weather (#2451) ───────────────────────────
+
+    /// Highest chance wins, negative chances are mod sentinels and are
+    /// filtered out entirely (#476), and an entry whose WTHR the load
+    /// order never supplied yields `None` rather than a lower-chance
+    /// substitute — the caller keeps the sky it has instead.
+    #[test]
+    fn default_weather_picks_the_highest_resolvable_chance() {
+        use byroredux_plugin::esm::records::climate::ClimateWeather;
+
+        let weathers = HashMap::from([
+            (
+                0x0000_0011,
+                WeatherRecord {
+                    form_id: 0x0000_0011,
+                    editor_id: "Clear".to_string(),
+                    ..Default::default()
+                },
+            ),
+            (
+                0x0000_0022,
+                WeatherRecord {
+                    form_id: 0x0000_0022,
+                    editor_id: "Storm".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let climate = ClimateRecord {
+            weathers: vec![
+                ClimateWeather {
+                    weather_form_id: 0x0000_0011,
+                    chance: 30,
+                },
+                ClimateWeather {
+                    weather_form_id: 0x0000_0022,
+                    chance: 70,
+                },
+                // Negative sentinel — must never win despite being last.
+                ClimateWeather {
+                    weather_form_id: 0x0000_0099,
+                    chance: -1,
+                },
+            ],
+            ..Default::default()
+        };
+        let (wthr, chance) = resolve_default_weather(&climate, &weathers).expect("resolves");
+        assert_eq!(wthr.form_id, 0x0000_0022);
+        assert_eq!(chance, 70);
+
+        // Winner unresolvable → None, not the runner-up.
+        let dangling = ClimateRecord {
+            weathers: vec![
+                ClimateWeather {
+                    weather_form_id: 0x0000_0011,
+                    chance: 30,
+                },
+                ClimateWeather {
+                    weather_form_id: 0xDEAD_BEEF,
+                    chance: 90,
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(resolve_default_weather(&dangling, &weathers).is_none());
     }
 
     // ── resolve_worldspace_climate ────────────────────────────────

--- a/byroredux/src/scene.rs
+++ b/byroredux/src/scene.rs
@@ -321,7 +321,8 @@ mod world_setup;
 // reuse them on Interior→Exterior swaps — same boot-path code, no
 // duplication. See cell_loader::transition.
 pub(crate) use world_setup::{
-    apply_worldspace_weather, stream_initial_radius, ExteriorBootstrapMode,
+    apply_cell_climate_override, apply_worldspace_weather, stream_initial_radius,
+    ExteriorBootstrapMode,
 };
 // The four `scene/*_tests.rs` child modules reach for these helpers
 // via `use super::*;` so they need to be in scope at the parent

--- a/byroredux/src/scene/world_setup.rs
+++ b/byroredux/src/scene/world_setup.rs
@@ -208,6 +208,32 @@ pub(crate) fn apply_worldspace_weather(
     tex_provider: &TextureProvider,
     wctx: &cell_loader::ExteriorWorldContext,
 ) {
+    apply_environment(
+        world,
+        ctx,
+        tex_provider,
+        wctx.climate.as_ref(),
+        wctx.default_weather.as_ref(),
+    );
+    install_ground_cover(world, wctx);
+}
+
+/// Install the canonical lighting / sky / weather resources for one
+/// resolved `(climate, weather)` pair.
+///
+/// Split out of [`apply_worldspace_weather`] (#2451) because the pair is
+/// not always the worldspace's: a cell with an `XCCM` override supplies
+/// its own, via [`apply_cell_climate_override`]. Everything here is
+/// climate-scoped — the sky textures, the TOD breakpoints, the weather
+/// crossfade. Ground cover stays with the worldspace wrapper: it is
+/// keyed by the worldspace name chain, not by the climate in effect.
+fn apply_environment(
+    world: &mut World,
+    ctx: &mut VulkanContext,
+    tex_provider: &TextureProvider,
+    climate: Option<&byroredux_plugin::esm::records::ClimateRecord>,
+    default_weather: Option<&byroredux_plugin::esm::records::WeatherRecord>,
+) {
     // Bootstrap sun direction from the canonical sun model (EXAL step 4):
     // `tod_hours` + the engine south-tilt drive `compute_sun_arc` — the same
     // model `weather_system` runs every frame — so the initial resources seed
@@ -236,10 +262,10 @@ pub(crate) fn apply_worldspace_weather(
     // (procedural-fallback branch). See the function doc for the two
     // failure modes this prevents.
     collapse_weather_transition(world);
-    if let Some(ref wthr) = wctx.default_weather {
+    if let Some(wthr) = default_weather {
         let sun_dir = compute_sun_arc(
             bootstrap_hour,
-            crate::env_translate::climate_tod_hours(wctx.climate.as_ref()),
+            crate::env_translate::climate_tod_hours(climate),
         )
         .0;
         // Canonical day-slot lighting (EXAL boundary). The per-frame
@@ -279,7 +305,7 @@ pub(crate) fn apply_worldspace_weather(
                 ctx,
             ),
         ];
-        let sun_sprite = resolve_sun_sprite(wctx.climate.as_ref(), tex_provider, ctx);
+        let sun_sprite = resolve_sun_sprite(climate, tex_provider, ctx);
         let sky = crate::env_translate::translate_sky(
             wthr,
             sun_dir,
@@ -322,7 +348,7 @@ pub(crate) fn apply_worldspace_weather(
         }
         // Full NAM0 table + per-climate TOD breakpoints + Skyrim DALC cube
         // (Z-up→Y-up once), all resolved at the EXAL boundary.
-        let new_weather = crate::env_translate::translate_weather(wthr, wctx.climate.as_ref());
+        let new_weather = crate::env_translate::translate_weather(wthr, climate);
         // First-time bootstrap: insert directly. A subsequent worldspace
         // change (door-walking interior↔exterior, M40 Phase 2) will
         // trigger the 8-second crossfade via WeatherTransitionRes.
@@ -362,8 +388,85 @@ pub(crate) fn apply_worldspace_weather(
             ctx.texture_registry.drop_texture(&ctx.device, handle);
         }
     }
+}
 
-    install_ground_cover(world, wctx);
+/// Re-resolve the climate in effect for the cell the player just entered,
+/// re-applying sky + weather when it differs from what is installed
+/// (#2451 / EXAL-03 — the per-cell `XCCM` hook).
+///
+/// `applied_climate` is the CLMT FormID currently driving the installed
+/// resources (`None` = climateless / procedural fallback); the caller owns
+/// it across boundary crossings (`WorldStreamingState::applied_climate_form`,
+/// seeded from the worldspace climate at bootstrap). Returns `true` when
+/// the environment was re-applied.
+///
+/// Runs only on a real climate change, which on vanilla content means
+/// entering or leaving one of the handful of cells that author `XCCM` — so
+/// the common crossing costs one map lookup and a comparison. The re-apply
+/// itself goes through [`apply_environment`], so an override transition
+/// gets the same 8-second `WeatherTransitionRes` crossfade and the same
+/// acquire-new-then-release-old sky-texture handling as a worldspace
+/// change; it does not snap.
+///
+/// Ground cover is deliberately not re-installed: it is keyed by the
+/// worldspace name chain, which a per-cell climate override does not
+/// change.
+pub(crate) fn apply_cell_climate_override(
+    world: &mut World,
+    ctx: &mut VulkanContext,
+    tex_provider: &TextureProvider,
+    wctx: &cell_loader::ExteriorWorldContext,
+    player_grid: (i32, i32),
+    applied_climate: &mut Option<u32>,
+) -> bool {
+    let cell = wctx
+        .record_index
+        .cells
+        .exterior_cells
+        .get(&wctx.worldspace_key)
+        .and_then(|cells| cells.get(&player_grid));
+    let effective = crate::env_translate::resolve_cell_climate(
+        cell.and_then(|c| c.climate_override),
+        wctx.climate.as_ref().map(|c| c.form_id),
+        &wctx.record_index.climates,
+    );
+    if effective == *applied_climate {
+        return false;
+    }
+
+    let climate = effective.and_then(|fid| wctx.record_index.climates.get(&fid));
+    let weather = climate
+        .and_then(|c| crate::env_translate::resolve_default_weather(c, &wctx.record_index.weathers))
+        .map(|(wthr, _chance)| wthr);
+    if climate.is_some() && weather.is_none() {
+        // The override resolves to a CLMT whose weather list is empty or
+        // points at WTHR records this load order never supplied. Applying
+        // it would drop the sky into the procedural fallback — further
+        // from the author's intent than the sky already showing. Leave
+        // `applied_climate` untouched so a later fix (or a different cell)
+        // is still re-evaluated.
+        log::warn!(
+            "Cell ({},{}) climate override {:08X?} resolves no default weather — keeping the \
+             current sky",
+            player_grid.0,
+            player_grid.1,
+            effective,
+        );
+        return false;
+    }
+
+    log::info!(
+        "Cell ({},{}) climate change: {:08X?} → {:08X?} ('{}', weather '{}')",
+        player_grid.0,
+        player_grid.1,
+        *applied_climate,
+        effective,
+        climate.map(|c| c.editor_id.as_str()).unwrap_or("<none>"),
+        weather.map(|w| w.editor_id.as_str()).unwrap_or("<none>"),
+    );
+    apply_environment(world, ctx, tex_provider, climate, weather);
+    *applied_climate = effective;
+    true
 }
 
 /// EXAL ground-cover translate site (#2369, design §7).

--- a/byroredux/src/streaming.rs
+++ b/byroredux/src/streaming.rs
@@ -659,6 +659,16 @@ pub struct WorldStreamingState {
     /// suppress no-op streaming work when the player hasn't crossed a
     /// cell boundary.
     pub last_player_grid: Option<(i32, i32)>,
+    /// CLMT FormID currently driving the installed sky / weather
+    /// resources — the worldspace climate at bootstrap, or a cell's own
+    /// `XCCM` override once the player walks into a cell that authors
+    /// one. `None` means no climate resolved (procedural fallback sky).
+    ///
+    /// Owned here rather than recomputed because it records what was
+    /// *applied*, which is the only thing a boundary crossing can compare
+    /// against to know whether re-applying is needed. See
+    /// `scene::apply_cell_climate_override` (#2451 / EXAL-03).
+    pub applied_climate_form: Option<u32>,
     /// Whether the three distant-LOD rings still have deferred reconcile
     /// work. Foreground-first bootstrap and cell-boundary movement set this;
     /// idle frames clear it progressively through the shared LOD budget.
@@ -717,6 +727,12 @@ impl WorldStreamingState {
         // accept; clamping here means a future caller passing
         // `radius_unload = radius_load` doesn't cause boundary thrash.
         let radius_load = radius_load.max(0);
+        // Seed the applied-climate tracker from the worldspace resolve
+        // (#2451): bootstrap installs that climate's sky, so the first
+        // boundary crossing must compare against it, not against `None`
+        // — otherwise every crossing in a worldspace with no XCCM cells
+        // would read as a change and re-apply the same environment.
+        let wctx_climate_form = wctx.climate.as_ref().map(|c| c.form_id);
         let (request_tx, request_rx) = mpsc::channel::<LoadCellRequest>();
         let (payload_tx, payload_rx) = mpsc::channel::<LoadCellPayload>();
         let worker = std::thread::Builder::new()
@@ -740,6 +756,7 @@ impl WorldStreamingState {
             radius_load,
             radius_unload: radius_load + 1,
             last_player_grid: None,
+            applied_climate_form: wctx_climate_form,
             lod_reconcile_pending: false,
             telemetry: StreamingTelemetry::default(),
             worker: Some(worker),

--- a/crates/plugin/src/esm/cell/mod.rs
+++ b/crates/plugin/src/esm/cell/mod.rs
@@ -843,13 +843,26 @@ pub struct TextureSet {
 /// - `DNAM` — default land/water height (2 × f32); only the second
 ///   (water) is kept, as [`default_water_height`](Self::default_water_height).
 /// - `NAM3`/`NAM4` — LOD water type FormID + LOD water height (#1849).
-/// - `OFST` — per-cell offset table (#1849).
 ///
 /// Sub-records not consumed here (parsed-past by the walker so the
 /// next record still aligns): `WCTR` (TES5 centre cell), `MNAM` (map
 /// camera data), `RNAM` (region overrides), `MHDT` (Skyrim+ map
-/// height data), `CLSZ`/`WLEV` (FO4). See OpenMW reference
+/// height data), `CLSZ`/`WLEV` (FO4), and `OFST` (per-cell offset
+/// table — see below). See OpenMW reference
 /// `components/esm4/loadwrld.cpp` and audit OBL-D3-NEW-01 / #965.
+///
+/// `OFST` was captured verbatim as raw `u32` words by #1849, on the
+/// stated premise that a future LAND streamer would interpret the
+/// table. That streamer exists now (`byroredux::cell_loader`) and
+/// enumerates `EsmIndex.cells.exterior_cells` keys instead — it never
+/// needed the offsets, because this engine indexes the CELL records it
+/// has already parsed rather than seeking into the plugin by file
+/// offset the way the original engine's streamer did. The capture was
+/// therefore pure cost: up to ~44k `u32` per worldspace held for the
+/// process lifetime (the sub-record runs to 177 KB on FalloutNV.esm),
+/// plus a parsed field that read as a live capability. Dropped by
+/// #2454 / EXAL-08; restore it alongside a real consumer, not ahead of
+/// one. See exal.md §5.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct WorldspaceRecord {
     /// FormID of the WRLD record itself.
@@ -907,19 +920,6 @@ pub struct WorldspaceRecord {
     /// they differ on 22 of 30 Skyrim.esm worldspaces and 6 of 28
     /// Fallout3.esm. `None` on Oblivion (no NAM4). See #1849.
     pub lod_water_height: Option<f32>,
-    /// Per-cell offset table (OFST) as raw little-endian `u32`s.
-    ///
-    /// Captured verbatim: the table's *grid* interpretation is
-    /// game-specific and not settled (sizes observed on disk range
-    /// from 36 B to 177 KB and are only guaranteed to be a multiple of
-    /// 4), so the parser stores the words and leaves the layout to a
-    /// future LAND streamer rather than inventing a shape. Empty when
-    /// the sub-record is absent or zero-length (Oblivion authors a
-    /// 0-byte OFST on some worldspaces). Note the sub-record routinely
-    /// exceeds the 16-bit sub-record size field and arrives via the
-    /// `XXXX` extended-size escape — see `EsmReader::read_sub_records`.
-    /// See #1849.
-    pub cell_offsets: Vec<u32>,
 }
 
 impl WorldspaceRecord {

--- a/crates/plugin/src/esm/cell/tests/wrld.rs
+++ b/crates/plugin/src/esm/cell/tests/wrld.rs
@@ -443,9 +443,12 @@ fn wrld_short_dnam_leaves_default_water_none() {
     assert_eq!(w.default_water_height, None);
 }
 
-/// #1849 — WRLD `NAM3` (LOD water type FormID), `NAM4` (LOD water
-/// height f32) and `OFST` (per-cell offset table) previously fell to
-/// the walker's `_ => {}` default arm and were dropped.
+/// #1849 — WRLD `NAM3` (LOD water type FormID) and `NAM4` (LOD water
+/// height f32) previously fell to the walker's `_ => {}` default arm
+/// and were dropped. `OFST` stays in the fixture on purpose: #2454
+/// stopped capturing it (no consumer ever materialised), so this now
+/// also pins that an unconsumed OFST is walked past without disturbing
+/// the sub-records around it.
 ///
 /// Values are the real FO3 `Wasteland` shape: NAM3 diverging from NAM2
 /// and NAM4 diverging from the DNAM water height, which is the case
@@ -453,7 +456,7 @@ fn wrld_short_dnam_leaves_default_water_none() {
 /// aliasing the full-detail siblings (18/28 Fallout3.esm worldspaces
 /// author a NAM3 ≠ NAM2; 22/30 Skyrim.esm author a NAM4 ≠ DNAM water).
 #[test]
-fn wrld_nam3_nam4_ofst_captured() {
+fn wrld_nam3_nam4_captured_across_an_unconsumed_ofst() {
     let mut dnam = Vec::new();
     dnam.extend_from_slice(&(-2048.0f32).to_le_bytes()); // default land height
     dnam.extend_from_slice(&(10_500.0f32).to_le_bytes()); // default water height
@@ -468,8 +471,11 @@ fn wrld_nam3_nam4_ofst_captured() {
             (b"NAM2", 0x0003_0009_u32.to_le_bytes().to_vec()),
             (b"NAM3", 0x0000_0018_u32.to_le_bytes().to_vec()),
             (b"NAM4", (-14_000.0f32).to_le_bytes().to_vec()),
-            (b"DNAM", dnam),
+            // OFST deliberately sits BETWEEN two consumed sub-records:
+            // the DNAM assertion below is what proves the walker steps
+            // over the unconsumed table by its declared size.
             (b"OFST", ofst),
+            (b"DNAM", dnam),
         ],
     );
     let buf = build_wrld_group(&[wrld]);
@@ -487,11 +493,6 @@ fn wrld_nam3_nam4_ofst_captured() {
         w.default_water_height,
         Some(10_500.0),
         "DNAM water height untouched by NAM4"
-    );
-    assert_eq!(
-        w.cell_offsets,
-        vec![0x0000_0000, 0x0000_8E6F, 0xDEAD_BEEF],
-        "OFST captured verbatim as LE u32 words"
     );
 }
 
@@ -514,5 +515,6 @@ fn wrld_oblivion_shape_leaves_lod_water_none() {
     let w = worldspaces.get("tamrielobl").expect("decoded");
     assert_eq!(w.lod_water_form, None);
     assert_eq!(w.lod_water_height, None);
-    assert!(w.cell_offsets.is_empty(), "empty OFST yields no words");
+    // NAM2 still decodes across the zero-length OFST that follows it.
+    assert_eq!(w.water_form, Some(0x0000_0018));
 }

--- a/crates/plugin/src/esm/cell/wrld.rs
+++ b/crates/plugin/src/esm/cell/wrld.rs
@@ -167,23 +167,19 @@ pub(crate) fn parse_wrld_group(
                                 sub.data[3],
                             ]));
                         }
-                        // OFST — per-cell offset table. Stored as raw u32
-                        // words; the grid interpretation is game-specific
-                        // and unsettled, so the parser captures without
-                        // inventing a shape (#1849). Routinely oversized
-                        // (177 KB in FalloutNV.esm) and therefore arriving
+                        // OFST — per-cell offset table. Deliberately NOT
+                        // captured: #1849 stored the raw u32 words for a
+                        // future LAND streamer, and the streamer that
+                        // arrived enumerates parsed CELL records instead of
+                        // seeking by file offset, so the words had no
+                        // reader. Falls to the `_ => {}` arm below like
+                        // every other unconsumed sub-record — it is still
+                        // walked past correctly (routinely oversized at
+                        // 177 KB in FalloutNV.esm and therefore arriving
                         // through the XXXX extended-size escape, which
-                        // `read_sub_records` already handles. A trailing
-                        // partial word (never observed on vanilla content —
-                        // every sampled OFST is a multiple of 4) is dropped
-                        // by `chunks_exact`.
-                        b"OFST" => {
-                            record.cell_offsets = sub
-                                .data
-                                .chunks_exact(4)
-                                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                                .collect();
-                        }
+                        // `read_sub_records` handles either way). #2454 /
+                        // EXAL-08; see `WorldspaceRecord` docs.
+                        //
                         // ICON — pause-menu map texture (zstring).
                         b"ICON" => {
                             record.map_texture = read_zstring(&sub.data);

--- a/crates/renderer/src/vulkan/acceleration/blas_skinned.rs
+++ b/crates/renderer/src/vulkan/acceleration/blas_skinned.rs
@@ -513,6 +513,19 @@ impl AccelerationManager {
         let scratch_buffer = self.blas_scratch_buffer.as_ref().context(
             "blas_scratch_buffer absent — must be allocated by build_skinned_blas_batched_on_cmd first",
         )?;
+        // #2460 — this UPDATE submits the shared scratch address with no
+        // size re-query and no growth path, so an under-sized buffer is
+        // a silent GPU-side overrun. `shrink_blas_scratch_to_fit` is the
+        // only writer that can shrink it beneath this entry's needs;
+        // trip in debug if a future change reintroduces a peak walk that
+        // misses `skinned_blas`.
+        debug_assert!(
+            scratch_buffer.size >= entry.build_scratch_size,
+            "skinned BLAS refit for entity {entity_id}: shared scratch is {} B but this entry \
+             was built against {} B — see #2460",
+            scratch_buffer.size,
+            entry.build_scratch_size,
+        );
 
         // #2170 — the skinned slot output is position-only, so the AS
         // build strides by 12 B, not by the 104 B `Vertex`. These two

--- a/crates/renderer/src/vulkan/acceleration/memory.rs
+++ b/crates/renderer/src/vulkan/acceleration/memory.rs
@@ -6,7 +6,8 @@ use super::super::allocator::SharedAllocator;
 use super::super::buffer::GpuBuffer;
 use super::constants::WORKING_SET_FLOOR;
 use super::predicates::{
-    scratch_should_shrink, tlas_instance_should_shrink, tlas_scratch_should_shrink,
+    scratch_alignment_padding, scratch_should_shrink, shared_blas_scratch_peak,
+    tlas_instance_should_shrink, tlas_scratch_should_shrink,
 };
 use super::AccelerationManager;
 use crate::deferred_destroy::DEFAULT_COUNTDOWN;
@@ -17,6 +18,14 @@ impl AccelerationManager {
     /// current surviving BLAS set, if the high-water mark has grown
     /// disproportionately vs the current peak (see
     /// [`scratch_should_shrink`] for the threshold).
+    ///
+    /// "Surviving BLAS set" means **both** maps that share this one
+    /// buffer — static `blas_entries` and per-entity `skinned_blas`
+    /// (see [`shared_blas_scratch_peak`]). A static-only peak walk
+    /// under-sizes the buffer beneath a live skinned entity's next
+    /// `refit_skinned_blas`, which validates no size and grows nothing:
+    /// an AS build-scratch overrun, not just wasted VRAM. #2460 /
+    /// AS-D1-NEW-01.
     ///
     /// Call at cell-unload boundaries — **not** from inside a BLAS
     /// build path.
@@ -57,18 +66,22 @@ impl AccelerationManager {
             None => return, // nothing to shrink
         };
 
-        let peak: vk::DeviceSize = self
-            .blas_entries
-            .iter()
-            .flatten()
-            .map(|e| e.build_scratch_size)
-            .max()
-            .unwrap_or(0);
+        let peak: vk::DeviceSize = shared_blas_scratch_peak(
+            self.blas_entries
+                .iter()
+                .flatten()
+                .map(|e| e.build_scratch_size),
+            self.skinned_blas.values().map(|e| e.build_scratch_size),
+        );
 
         if peak == 0 {
-            // No BLAS survives — drop the scratch entirely. Next build
-            // will allocate fresh (via `scratch_needs_growth`'s None
-            // arm) at whatever the new build's peak is.
+            // Neither map holds a BLAS — drop the scratch entirely. Next
+            // build will allocate fresh (via `scratch_needs_growth`'s
+            // None arm) at whatever the new build's peak is. The union
+            // walk is what makes this arm safe: on a static-only walk it
+            // fired with skinned entities still resident, and every one
+            // of their refits then failed the `blas_scratch_buffer
+            // absent` context until a first-sight rebuild.
             //
             // #1782: deferred, not immediate — see this fn's doc.
             if let Some(old) = self.blas_scratch_buffer.take() {
@@ -88,20 +101,31 @@ impl AccelerationManager {
         // Reallocate to the current peak size. A future build that
         // exceeds the new capacity will grow via `scratch_needs_growth`.
         // #1782: deferred, not immediate — see this fn's doc.
+        //
+        // Carries the same `scratch_alignment_padding` headroom every
+        // build path allocates (#1386): consumers round the buffer's
+        // device address up to `scratch_align` before submitting, and
+        // the skinned refit has no growth check to correct a buffer
+        // sized to the bare peak. Immaterial to the shrink decision
+        // above — `align` is 128–256 bytes against a 16 MB slack.
+        let target = peak.saturating_add(scratch_alignment_padding(self.scratch_align));
         if let Some(old) = self.blas_scratch_buffer.take() {
             self.pending_destroy_scratch.push(old, DEFAULT_COUNTDOWN);
         }
         match GpuBuffer::create_device_local_uninit(
             device,
             allocator,
-            peak,
+            target,
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::SHADER_DEVICE_ADDRESS,
         ) {
             Ok(new_buf) => {
                 log::debug!(
-                    "BLAS scratch shrunk: {:.1} MB → {:.1} MB (peak survivor)",
+                    "BLAS scratch shrunk: {:.1} MB → {:.1} MB (peak survivor across {} static \
+                     + {} skinned BLAS)",
                     current as f64 / (1024.0 * 1024.0),
-                    peak as f64 / (1024.0 * 1024.0),
+                    target as f64 / (1024.0 * 1024.0),
+                    self.live_static_blas_count(),
+                    self.skinned_blas.len(),
                 );
                 self.blas_scratch_buffer = Some(new_buf);
             }

--- a/crates/renderer/src/vulkan/acceleration/predicates.rs
+++ b/crates/renderer/src/vulkan/acceleration/predicates.rs
@@ -291,6 +291,37 @@ pub(super) fn scratch_needs_growth(
     }
 }
 
+/// The scratch capacity a shrink must preserve: the largest
+/// `build_scratch_size` across **both** BLAS sets that share
+/// `blas_scratch_buffer`.
+///
+/// The buffer is one allocation serving the static (mesh-keyed) builders
+/// *and* the per-entity skinned builder/refitter, so a shrink target
+/// derived from `blas_entries` alone can drop it below what a live
+/// skinned entity's next `refit_skinned_blas` needs — and that refit
+/// path re-queries nothing and grows nothing, it just submits `mode =
+/// UPDATE` against the buffer's device address. Walking only the static
+/// map is therefore an AS build-scratch overrun, not merely an
+/// under-shrink. Both call sites that could fire with skinned BLAS
+/// resident are reachable: `recreate_swapchain_core` (window resize,
+/// every skinned BLAS survives) and `finish_unload_batch` (the outgoing
+/// cell's skinned BLAS are only queued for unload, drained a later
+/// frame). See #2460 / AS-D1-NEW-01.
+///
+/// Skinned entries carry the *build* scratch size and an UPDATE never
+/// needs more than its BUILD did, so taking the build size for them is
+/// conservative in the safe direction.
+pub(super) fn shared_blas_scratch_peak(
+    static_sizes: impl IntoIterator<Item = vk::DeviceSize>,
+    skinned_sizes: impl IntoIterator<Item = vk::DeviceSize>,
+) -> vk::DeviceSize {
+    static_sizes
+        .into_iter()
+        .chain(skinned_sizes)
+        .max()
+        .unwrap_or(0)
+}
+
 /// Decide whether a persisted scratch buffer is disproportionately
 /// large and should be shrunk to match the post-eviction peak.
 ///

--- a/crates/renderer/src/vulkan/acceleration/tests.rs
+++ b/crates/renderer/src/vulkan/acceleration/tests.rs
@@ -872,6 +872,59 @@ fn scratch_shrink_skipped_on_exactly_2x_ratio() {
     assert!(!scratch_should_shrink(64 * MB, 32 * MB));
 }
 
+// ── shared_blas_scratch_peak (#2460 / AS-D1-NEW-01) ──────────────
+//
+// `blas_scratch_buffer` is ONE allocation shared by the static
+// (mesh-keyed) builders and the per-entity skinned builder/refitter.
+// The shrink target must therefore be the max over both maps: the
+// skinned refit re-queries no sizes and grows nothing, so a peak
+// walked over `blas_entries` alone reallocates the buffer below what
+// a live NPC's next `mode = UPDATE` writes into it.
+
+#[test]
+fn shared_scratch_peak_takes_the_max_across_both_blas_maps() {
+    // A live skinned entity out-scratching every static survivor is
+    // the reachable failure shape: interior cell whose static peak is
+    // ~1 MB, NPCs from the outgoing cell still resident at 40 MB.
+    let static_sizes = [MB, 512 * 1024];
+    let skinned_sizes = [40 * MB, 3 * MB];
+    assert_eq!(
+        shared_blas_scratch_peak(static_sizes, skinned_sizes),
+        40 * MB,
+        "skinned entries must not be ignored — they share the buffer"
+    );
+
+    // …and symmetrically, a large static survivor still wins over a
+    // small skinned set.
+    assert_eq!(shared_blas_scratch_peak([80 * MB], [2 * MB, MB]), 80 * MB,);
+}
+
+#[test]
+fn shared_scratch_peak_is_zero_only_when_both_maps_are_empty() {
+    // The `peak == 0` arm drops the buffer outright, so it must not
+    // fire while a skinned BLAS is still resident — pre-#2460 that
+    // failed every refit with "blas_scratch_buffer absent" until a
+    // first-sight rebuild.
+    assert_eq!(shared_blas_scratch_peak([], [7 * MB]), 7 * MB);
+    assert_eq!(shared_blas_scratch_peak([7 * MB], []), 7 * MB);
+    assert_eq!(shared_blas_scratch_peak([], []), 0);
+}
+
+#[test]
+fn shrink_decision_uses_the_union_peak_not_the_static_one() {
+    // The #2460 scenario end-to-end at the predicate level: 40 MB
+    // buffer, 1 MB static survivors, 30 MB skinned survivor. On the
+    // static-only peak the hysteresis fires (40 > 2 MB and excess
+    // 39 MB > 16 MB slack) and the buffer is reallocated at 1 MB —
+    // beneath the skinned entry's build scratch. On the union peak it
+    // correctly declines.
+    let static_only = shared_blas_scratch_peak([MB], []);
+    assert!(scratch_should_shrink(40 * MB, static_only));
+
+    let union = shared_blas_scratch_peak([MB], [30 * MB]);
+    assert!(!scratch_should_shrink(40 * MB, union));
+}
+
 // ── tlas_scratch_should_shrink (#1226) ────────────────────────────
 //
 // Pre-#1226 the TLAS scratch shrink path called `scratch_should_shrink`
@@ -1705,7 +1758,10 @@ mod tlas_commit_ordering_tests {
             .find("if let Some(mut old) = self.tlas[frame_index].take()")
             .expect("ensure_tlas_state must still retire the old slot");
         for (needle, what) in [
-            ("GpuBuffer::create_host_visible(", "the instance staging buffer"),
+            (
+                "GpuBuffer::create_host_visible(",
+                "the instance staging buffer",
+            ),
             (
                 "let mut instance_buffer_device = GpuBuffer::create_device_local_uninit(",
                 "the device-local instance buffer",
@@ -1774,8 +1830,14 @@ mod tlas_commit_ordering_tests {
                 "std::mem::swap(\n            &mut tlas.last_blas_addresses,",
                 "the last_blas_addresses promotion",
             ),
-            ("tlas.needs_full_rebuild = false;", "the needs_full_rebuild clear"),
-            ("tlas.last_blas_map_gen = map_gen;", "the map-generation stamp"),
+            (
+                "tlas.needs_full_rebuild = false;",
+                "the needs_full_rebuild clear",
+            ),
+            (
+                "tlas.last_blas_map_gen = map_gen;",
+                "the map-generation stamp",
+            ),
         ] {
             let commit_pos = TLAS_RS
                 .find(needle)

--- a/docs/engine/exal.md
+++ b/docs/engine/exal.md
@@ -120,6 +120,18 @@ cross-fades. The `Option<DalcCubeYup>` is **not** a leak — it is the canonical
 encoding of "this game has no DALC ambient cube", consumed uniformly. **Status:
 canonical.** EXAL only moves the WTHR→`WeatherDataRes` decode under the boundary.
 
+Climate resolution has two inputs, both settled at the boundary in
+`env_translate`: the worldspace `CNAM` (chasing the `WNAM` parent chain when the
+`PNAM` climate-inherit bit is set — `resolve_worldspace_climate`, #2450 /
+EXAL-02) and the **per-cell `XCCM` override** (`resolve_cell_climate`, #2451 /
+EXAL-03). The override is re-resolved on each cell-boundary crossing by
+`scene::apply_cell_climate_override`, which re-applies sky + weather through the
+same `apply_environment` path a worldspace change uses — so an override
+transition gets the normal 8-second crossfade and the normal sky-texture
+acquire/release, not a snap. An `XCCM` pointing at an unparsed CLMT falls back to
+the worldspace climate (never to the procedural sky), and an override climate
+with no resolvable default weather leaves the current sky in place.
+
 ### Water (WATR) — **carved out into [WATAL](watal.md) (its own double-ended layer)**
 
 > **Moved (2026-06-19):** water graduated from an EXAL sub-category to its own
@@ -376,10 +388,16 @@ NIF-hint-driven:
 
 What runtime LOD **does** need that we don't parse yet (new, small parser work):
 the **VWD / "Has Distant LOD" record-header flag** (§5.2, tracked by #1731).
-The WRLD `NAM3`/`NAM4` LOD-water fields + `OFST` cell-offset table **are now
-parsed** (#1849) onto `WorldspaceRecord::lod_water_form` / `lod_water_height` /
-`cell_offsets`. `OFST` stays captured-but-unconsumed (its per-cell offset
-grid interpretation is unsettled — #1849). `NAM3`/`NAM4` are consumed as of
+The WRLD `NAM3`/`NAM4` LOD-water fields **are now parsed** (#1849) onto
+`WorldspaceRecord::lod_water_form` / `lod_water_height`. The `OFST`
+cell-offset table, parsed alongside them by #1849 for "a future LAND
+streamer", is **no longer captured** (#2454 / EXAL-08): that streamer landed
+and resolves cells by enumerating the parsed `exterior_cells` index rather
+than seeking into the plugin by file offset, so the words — up to ~44k `u32`
+per worldspace, 177 KB on FalloutNV.esm — were held for no reader while
+reading as a live capability. `OFST` is now walked past like any other
+unconsumed sub-record; re-add the capture with its first real consumer, not
+before. `NAM3`/`NAM4` are consumed as of
 #2449 / EXAL-01: `env_translate::translate_lod_water` reads them, and
 `cell_loader::water::spawn_lod_water_plane` spawns a single worldspace-wide
 LOD water quad (a hole-cut annulus excluding the full-detail streamed area)


### PR DESCRIPTION
Four issues from the recent EXAL / AS audits.

## #2460 (HIGH) — `shrink_blas_scratch_to_fit` ignored skinned BLAS
`blas_scratch_buffer` is one allocation shared by the static builders **and** the per-entity skinned builder/refitter, but the shrink target was walked over `blas_entries` only. A live skinned entity out-scratching the static survivors got the buffer reallocated beneath what its next `refit_skinned_blas` writes — and that path re-queries no sizes and grows nothing.

- peak now unions both maps (`shared_blas_scratch_peak`)
- realloc carries the `scratch_alignment_padding` headroom every build path allocates (the refit rounds its address up to `scratch_align` with no growth check to correct a bare-peak buffer)
- `debug_assert!` in `refit_skinned_blas` so a future regression trips at `cargo test`, not on the GPU

**Not verifiable by `cargo test`** — no live device. Confirming the driver actually faults (vs silently over-reserving) needs RenderDoc / `BYRO_VALIDATION=1`.

## #2452 — baked-LOD predicate duplicated inline
`baked_lod_supported(GameKind)` added next to its `placement_lod_supported` sibling; both former inline `matches!` sites call it. Tests: per-variant, plus one pinning agreement with `LodBandLadder::for_game`.

## #2454 — WRLD OFST captured with no consumer
Dropped. The LAND streamer #1849 was holding the table for resolves cells from the parsed index, not by file offset. Tests now pin that a consumed sub-record following an oversized OFST still decodes.

## #2451 — CELL XCCM parsed with no consumer
Wired at the EXAL boundary: `resolve_cell_climate` + a shared `resolve_default_weather`, applied by `apply_cell_climate_override` through the same `apply_environment` a worldspace change uses (so overrides crossfade, not snap). Unresolvable override → worldspace climate, never the procedural sky.

## Verification
`cargo test --no-fail-fast` green across the workspace except the pre-existing `fire_lights::derived_reach_is_currently_oversized_pending_a_unit_correct_derivation` canary, which also fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)