### PR TITLE
Fix #2701 #2710 #2711 #2712: BGSM cycle-cache pollution, effect-shader glass provenance gate, telemetry doc drift, unsampled role lanes

### DIFF
--- a/byroredux/src/helpers.rs
+++ b/byroredux/src/helpers.rs
@@ -53,12 +53,17 @@ fn is_mirror_pane(
 /// [`GLASS_SURFACE_BEHAVIOR`] supplies metalness, roughness, and IOR. Authored
 /// texture-map paths and their parameters remain untouched overlays.
 ///
-/// Existing engine-synthesized kinds are preserved unless an authoritative
-/// FO4+ `bgem_glass` flag explicitly replaces an effect-shader carrier with
-/// glass behavior. A name/texture keyword alone cannot override an authored
-/// shader type: Skyrim's alchemy workbench intentionally maps its emissive
-/// `InnerHaze` effect layers to `plainglasstile01.dds`. Promoting those layers
-/// to glass erases their emission and turns the enclosing apparatus black.
+/// Existing engine-synthesized kinds are preserved unless the material is an
+/// effect-shader carrier authoring an explicit glass surface — either through
+/// the authoritative FO4+ `bgem_glass` flag, or through a glass keyword on
+/// content that resolved an external material file (`from_bgsm`). A keyword
+/// alone, with no external material, cannot override an authored shader type:
+/// Skyrim's alchemy workbench intentionally maps its emissive `InnerHaze`
+/// effect layers to `plainglasstile01.dds`, and promoting those layers to
+/// glass erases their emission and turns the enclosing apparatus black.
+/// `from_bgsm` is the provenance signal that separates the two — `.bgem` does
+/// not exist pre-FO4, so Skyrim's inline effect shaders never set it. See
+/// #2710 for why the keyword arm is gated rather than absent.
 /// Call AFTER `Material::resolve_pbr` so the behavior write wins over
 /// source-derived PBR scalars.
 pub(crate) fn classify_glass_into_material(
@@ -68,11 +73,32 @@ pub(crate) fn classify_glass_into_material(
     has_transparent_coverage: bool,
     is_decal: bool,
     bgem_glass: bool,
+    from_bgsm: bool,
 ) {
     let keyword_match = texture_path.is_some_and(is_glass_keyword_path)
         || mesh_name.is_some_and(is_glass_keyword_path);
-    let effect_glass_carrier =
-        material.material_kind == byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER && bgem_glass;
+    // #2710 — the effect-shader carrier is promoted to glass by an
+    // authored BGEM glass flag, or by a glass keyword **on external-material
+    // content only**. `from_bgsm` is the provenance discriminator, not a
+    // game check: an external `.bgsm`/`.bgem` resolved for this material.
+    // That is what separates the two real cases, both of which are
+    // effect-shader carriers with a glass keyword:
+    //
+    //   * FO4+ authors ordinary glass on `BSEffectShaderProperty` with a
+    //     `.bgem` beside it (Nuka-Cola `nukacola_glass.dds`), sometimes
+    //     without setting the BGEM glass flag. That should be glass.
+    //   * Skyrim's alchemy bench authors emissive `InnerHaze` layers on the
+    //     same carrier and shares `plainglasstile01.dds` with the
+    //     surrounding shells — with no `.bgem`, because the format does not
+    //     exist pre-FO4. Promoting those erases their emission and turns the
+    //     apparatus black (`322f33a8`).
+    //
+    // `322f33a8` fixed the second case by deleting the keyword arm outright,
+    // which made the first structurally unreachable for any effect material
+    // whose BGEM misses `bgem_uses_glass_behavior`'s heuristic.
+    let effect_glass_carrier = material.material_kind
+        == byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER
+        && (bgem_glass || (keyword_match && from_bgsm));
 
     // Engine-synthesized behavior already selected — preserve it unless this
     // is the source-format effect carrier used to author an explicit glass
@@ -154,6 +180,7 @@ mod glass_classification_tests {
             true,
             false,
             false,
+            false,
         );
         assert_eq!(m.material_kind, GLASS);
         assert!(m.roughness <= 0.11, "forced glass-smooth");
@@ -170,6 +197,7 @@ mod glass_classification_tests {
             Some("DrinkingGlass:0"),
             Some("textures/clutter/junk/kitchenutensils01.dds"),
             true,
+            false,
             false,
             false,
         );
@@ -192,6 +220,7 @@ mod glass_classification_tests {
             true,
             false,
             false,
+            false,
         );
         assert_eq!(m.material_kind, 0);
         assert_eq!(m.metalness, MIRROR_METALNESS);
@@ -208,6 +237,7 @@ mod glass_classification_tests {
             Some("BrokenWindowPane:1"),
             Some("textures/clutter/junk/brokenglasssheet01.dds"),
             true,
+            false,
             false,
             false,
         );
@@ -229,6 +259,7 @@ mod glass_classification_tests {
             false, // no alpha blend
             false,
             false,
+            false,
         );
         assert_eq!(m.material_kind, 0, "opaque window stays non-glass");
         assert_eq!(m.roughness, 0.80, "roughness untouched");
@@ -248,6 +279,7 @@ mod glass_classification_tests {
             true,
             false,
             false,
+            false,
         );
         assert_eq!(m.material_kind, 0);
     }
@@ -265,6 +297,7 @@ mod glass_classification_tests {
             true,
             false,
             false,
+            false,
         );
         assert_eq!(
             m.material_kind,
@@ -277,6 +310,13 @@ mod glass_classification_tests {
         // Skyrim's alchemy workbench authors InnerHaze as BSEffectShader but
         // shares plainglasstile01.dds with the surrounding glass shells. The
         // explicit shader role outranks this ambiguous texture keyword.
+        //
+        // `from_bgsm = false` is the load-bearing input (#2710): Skyrim has
+        // no `.bgem`, so nothing external corroborates the keyword. The FO4
+        // twin of this test is
+        // `glass_keyword_promotes_effect_shader_carrier_with_external_material`
+        // below — the two directions must be pinned together, which is what
+        // `322f33a8` lost when it rewrote this test in place.
         let mut m = mat();
         m.material_kind = byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER;
         m.texture_path = Some("textures/clutter/plainglasstile01.dds".into());
@@ -287,6 +327,7 @@ mod glass_classification_tests {
             Some("InnerHaze01:8"),
             texture_path.as_deref(),
             true,
+            false,
             false,
             false,
         );
@@ -301,6 +342,67 @@ mod glass_classification_tests {
         );
     }
 
+    /// #2710 — the FO4 direction, restored beside the Skyrim one rather
+    /// than replacing it. FO4 commonly authors ordinary glass on a
+    /// `BSEffectShaderProperty` whose `.bgem` does not set the glass flag
+    /// (`bgem_uses_glass_behavior` is a heuristic bundle, see #2626), and
+    /// the explicit semantic name/texture is then the only signal there is.
+    /// The external material is what makes that signal trustworthy here.
+    #[test]
+    fn glass_keyword_promotes_effect_shader_carrier_with_external_material() {
+        let mut m = mat();
+        m.material_kind = byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER;
+        m.texture_path = Some("textures/clutter/nukacola_glass.dds".into());
+        let texture_path = m.texture_path.clone();
+
+        classify_glass_into_material(
+            &mut m,
+            Some("NukaCola_Glass:3"),
+            texture_path.as_deref(),
+            true,
+            false,
+            false, // BGEM resolved, but its glass flag is NOT set
+            true,  // …and that resolution is the provenance signal
+        );
+
+        assert_eq!(m.material_kind, GLASS);
+        assert_eq!(m.roughness, GLASS_SURFACE_BEHAVIOR.roughness);
+        assert_eq!(m.ior, GLASS_SURFACE_BEHAVIOR.ior);
+        assert_eq!(
+            m.texture_path.as_deref(),
+            Some("textures/clutter/nukacola_glass.dds"),
+            "promotion must not disturb the authored texture overlay"
+        );
+    }
+
+    /// #2710 — the discriminator is provenance, not game. The same FO4-shaped
+    /// carrier and keyword with no external material resolved stays an effect
+    /// surface, so a future refactor can't quietly turn `from_bgsm` back into
+    /// "is this FO4" and get the Skyrim case right by accident.
+    #[test]
+    fn glass_keyword_alone_does_not_promote_an_inline_effect_carrier() {
+        let mut m = mat();
+        m.material_kind = byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER;
+        m.texture_path = Some("textures/clutter/nukacola_glass.dds".into());
+        let texture_path = m.texture_path.clone();
+
+        classify_glass_into_material(
+            &mut m,
+            Some("NukaCola_Glass:3"),
+            texture_path.as_deref(),
+            true,
+            false,
+            false,
+            false, // no `.bgem` resolved for this mesh
+        );
+
+        assert_eq!(
+            m.material_kind,
+            byroredux_renderer::MATERIAL_KIND_EFFECT_SHADER,
+            "an uncorroborated keyword must not outrank the authored carrier"
+        );
+    }
+
     #[test]
     fn decal_and_opaque_non_keyword_are_not_glass() {
         // Decal with glass keyword + alpha → excluded by the decal gate.
@@ -312,6 +414,7 @@ mod glass_classification_tests {
             true,
             true,
             false,
+            false,
         );
         assert_eq!(m.material_kind, 0);
         // Plain alpha-blend wood (no keyword) stays non-glass — guards the
@@ -322,6 +425,7 @@ mod glass_classification_tests {
             Some("WoodTable01"),
             Some("textures/furniture/woodtable01.dds"),
             true,
+            false,
             false,
             false,
         );
@@ -346,6 +450,7 @@ mod glass_classification_tests {
             true,
             false,
             true, // bgem_glass
+            false,
         );
         assert_eq!(
             m.material_kind, GLASS,
@@ -377,6 +482,7 @@ mod glass_classification_tests {
             texture_path.as_deref(),
             true,
             false,
+            true,
             true,
         );
 
@@ -414,6 +520,7 @@ mod glass_classification_tests {
             false, // no alpha
             false,
             true, // bgem_glass
+            false,
         );
         assert_eq!(m.material_kind, 0);
     }
@@ -431,6 +538,7 @@ mod glass_classification_tests {
             true,
             true, // is_decal
             true, // bgem_glass
+            false,
         );
         assert_eq!(m.material_kind, 0);
     }
@@ -452,6 +560,7 @@ mod glass_classification_tests {
             true,
             false,
             true, // bgem_glass
+            false,
         );
         assert_eq!(m.material_kind, 0);
     }

--- a/byroredux/src/material_translate.rs
+++ b/byroredux/src/material_translate.rs
@@ -234,6 +234,11 @@ pub(crate) fn translate_material(
         source.has_alpha || source.alpha_test,
         source.is_decal,
         source.bgem_glass,
+        // #2710 — external-material provenance. Gates the glass-keyword
+        // promotion of an effect-shader carrier to FO4+ content, where a
+        // `.bgem` exists beside the mesh; Skyrim's inline effect shaders
+        // never set it, so their keyword-sharing haze layers stay effects.
+        source.from_bgsm,
     );
     material
 }

--- a/crates/bgsm/src/template.rs
+++ b/crates/bgsm/src/template.rs
@@ -140,6 +140,11 @@ impl TemplateCache {
     /// Resolve a BGSM + its template chain. The same path is guaranteed
     /// to return `Arc::ptr_eq`-identical results between calls as long
     /// as the entry stays in the cache.
+    ///
+    /// **Cyclic chains are the exception** and are deliberately never
+    /// cached — see [`Self::resolve_depth`] (#2701). They re-parse on
+    /// every resolve, which is the price of load-order-independent
+    /// results on broken authoring.
     pub fn resolve<R: TemplateResolver>(
         &mut self,
         resolver: &mut R,
@@ -148,9 +153,37 @@ impl TemplateCache {
         const DEPTH_LIMIT: usize = 16;
         let mut visited: Vec<String> = Vec::new();
         self.resolve_depth(resolver, path, DEPTH_LIMIT, &mut visited)
+            .map(|(resolved, _truncated)| resolved)
     }
 
     /// Recursive resolve with cycle detection.
+    ///
+    /// Returns `(resolved, truncated)`, where `truncated` is `true` when
+    /// this node's chain was cut short by cycle detection — either here
+    /// or anywhere below it. A truncated chain is **not** cached (#2701):
+    /// where a walk breaks a cycle depends on which node it entered from,
+    /// so a cached truncation would leak one root's answer to another.
+    ///
+    /// Concretely, with the cycle `B → C → B`:
+    ///
+    /// * entering at `A` (`A → B → C → B`) breaks at `C`, giving
+    ///   `A → B → C(end)`;
+    /// * entering at `D` (`D → C → B → C`) breaks at `B`, giving
+    ///   `D → C → B(end)`.
+    ///
+    /// Both are correct for their own root. Caching either one hands the
+    /// other root a chain it would never have resolved: pre-fix, the
+    /// A-walk left `c.bgsm` cached with `parent: None`, so a later
+    /// standalone `resolve("c.bgsm")` — whose correct chain is
+    /// `C → B(end)` — hit the cache and got depth 1 instead of 2, losing
+    /// every field `b.bgsm` authored. Which chain a material got depended
+    /// on which material the cell happened to load first.
+    ///
+    /// The flag propagates up rather than suppressing only the detecting
+    /// node, because an ancestor's entry embeds the truncated `Arc`: with
+    /// `B` cached as `B → C(end)` from the A-walk, the later D-walk would
+    /// resolve `C` fresh, hit that cached `B`, and produce
+    /// `D → C → B → C(end)` — a chain with `C` on it twice.
     ///
     /// `visited` tracks the canonicalised (lowercase) keys of every
     /// ancestor on the current walk. When a parent's key matches an
@@ -171,11 +204,14 @@ impl TemplateCache {
         path: &str,
         remaining: usize,
         visited: &mut Vec<String>,
-    ) -> Result<Arc<ResolvedMaterial>, ResolveError> {
+    ) -> Result<(Arc<ResolvedMaterial>, bool), ResolveError> {
         let key = path.to_ascii_lowercase();
 
         if let Some(hit) = self.entries.get(&key) {
-            return Ok(Arc::clone(hit));
+            // Cache entries are cycle-free by construction (the insert
+            // below is skipped for truncated chains), so a hit never
+            // carries a truncation up to its caller.
+            return Ok((Arc::clone(hit), false));
         }
 
         if remaining == 0 {
@@ -196,6 +232,7 @@ impl TemplateCache {
 
         // Capture the parent path BEFORE moving `file` into the Arc.
         let parent_path = file.root_material_path.clone();
+        let mut truncated = false;
         let parent = match parent_path {
             Some(pp) if !pp.is_empty() => {
                 let parent_key = pp.to_ascii_lowercase();
@@ -207,20 +244,28 @@ impl TemplateCache {
                     // first-Some-wins, so the cycle anchor's fields
                     // surfaced when it was first walked). Terminating
                     // here just prevents the loop.
+                    truncated = true;
                     None
                 } else {
                     visited.push(key.clone());
                     let result = self.resolve_depth(resolver, &pp, remaining - 1, visited);
                     visited.pop();
-                    Some(result?)
+                    let (parent, parent_truncated) = result?;
+                    truncated |= parent_truncated;
+                    Some(parent)
                 }
             }
             _ => None,
         };
 
         let resolved = Arc::new(ResolvedMaterial { file, parent });
-        self.insert(key, Arc::clone(&resolved));
-        Ok(resolved)
+        // #2701 — a chain cut by cycle detection is only valid for the
+        // walk that produced it; see this fn's doc. Caching it would make
+        // a material's resolved chain depend on cell load order.
+        if !truncated {
+            self.insert(key, Arc::clone(&resolved));
+        }
+        Ok((resolved, truncated))
     }
 
     fn insert(&mut self, key: String, value: Arc<ResolvedMaterial>) {
@@ -572,26 +617,105 @@ mod tests {
         assert!(chain[2].parent.is_none());
     }
 
+    /// #2701 — the real invariant this test was always named for. The
+    /// previous version asserted the opposite: that a self-referential
+    /// file *is* cached (`Arc::ptr_eq` + `len() == 1`), and its own
+    /// comment conceded it only held "if it was discovered via the cycle
+    /// path". A truncated chain is valid only for the walk that produced
+    /// it, so caching it makes a material's resolved chain depend on
+    /// which material the cell loaded first.
     #[test]
     fn cycle_break_does_not_pollute_cache_with_partial_chains() {
-        // The cycle-broken parent must NOT be cached as a partial
-        // chain — another root resolving the same path with a
-        // different visited prefix would see incorrect terminal-None.
-        // Today: cycle-break sets parent = None on the LEAF that
-        // detects the cycle; that leaf already has a valid cache
-        // entry, but only if it was discovered via the cycle path.
-        //
-        // The simplest invariant: a self-referential file resolves
-        // once and the same Arc is returned on repeat. Verifies the
-        // cache survives the cycle path.
+        // A → B → C → B. The A-rooted walk breaks at C, so C's entry
+        // would read `parent: None` — but C's *own* correct chain is
+        // C → B(end). Pre-fix the second resolve hit that cache entry
+        // and got depth 1: every field b.bgsm authored vanished, and
+        // which of the two chains C received depended on load order.
+        let mut resolver = StubResolver::new();
+        resolver.add("a.bgsm", bgsm_with_template("b.bgsm"));
+        resolver.add("b.bgsm", bgsm_with_template("c.bgsm"));
+        resolver.add("c.bgsm", bgsm_with_template("b.bgsm"));
+
+        let mut cache = TemplateCache::new(16);
+        let from_a = cache.resolve(&mut resolver, "a.bgsm").unwrap();
+        assert_eq!(from_a.depth(), 3, "A → B → C(end)");
+        assert_eq!(
+            cache.len(),
+            0,
+            "nothing on a cycle-truncated chain may be cached — not the \
+             detecting node, and not the ancestors whose entries embed it"
+        );
+
+        // The standalone resolve now sees C's own chain, not A's leftovers.
+        let standalone_c = cache.resolve(&mut resolver, "c.bgsm").unwrap();
+        assert_eq!(
+            standalone_c.depth(),
+            2,
+            "C → B(end) — resolving C on its own must not inherit the \
+             A-rooted walk's truncation point"
+        );
+        let chain: Vec<_> = standalone_c.walk().collect();
+        assert_eq!(chain[0].file.root_material_path.as_deref(), Some("b.bgsm"));
+        assert!(chain[1].parent.is_none(), "cycle break at B this time");
+    }
+
+    /// #2701 — the truncation flag must propagate to ancestors, not just
+    /// suppress the detecting node. An ancestor's entry embeds the
+    /// truncated `Arc`, so caching it hands the next root a chain it
+    /// would never have resolved.
+    #[test]
+    fn cycle_truncation_does_not_leak_through_a_cached_ancestor() {
+        // Same B ⇄ C cycle, entered from both sides.
+        let mut resolver = StubResolver::new();
+        resolver.add("a.bgsm", bgsm_with_template("b.bgsm"));
+        resolver.add("b.bgsm", bgsm_with_template("c.bgsm"));
+        resolver.add("c.bgsm", bgsm_with_template("b.bgsm"));
+        resolver.add("d.bgsm", bgsm_with_template("c.bgsm"));
+
+        let mut cache = TemplateCache::new(16);
+        let from_a = cache.resolve(&mut resolver, "a.bgsm").unwrap();
+        assert_eq!(from_a.depth(), 3, "A → B → C(end)");
+
+        // If B had been cached as `B → C(end)` by the walk above, this
+        // D-rooted walk would resolve C fresh, hit that B, and build
+        // D → C → B → C(end): four nodes with C on the chain twice.
+        let from_d = cache.resolve(&mut resolver, "d.bgsm").unwrap();
+        assert_eq!(from_d.depth(), 3, "D → C → B(end)");
+        let chain: Vec<_> = from_d.walk().collect();
+        assert_eq!(chain[0].file.root_material_path.as_deref(), Some("c.bgsm"));
+        assert_eq!(chain[1].file.root_material_path.as_deref(), Some("b.bgsm"));
+        assert!(chain[2].parent.is_none(), "cycle break at B, not at C");
+    }
+
+    /// #2701 follow-on: the price of the rule above is that cyclic
+    /// chains re-parse on every resolve. Pinned so the cost is a
+    /// decision rather than a surprise — and so that *clean* chains are
+    /// shown to still cache normally, which is the case that matters for
+    /// vanilla content.
+    #[test]
+    fn cyclic_chains_reparse_while_clean_chains_still_cache() {
         let mut resolver = StubResolver::new();
         resolver.add("self.bgsm", bgsm_with_template("self.bgsm"));
+        resolver.add("clean.bgsm", bgsm_with_template("root.bgsm"));
+        resolver.add("root.bgsm", bgsm_with_template(""));
 
         let mut cache = TemplateCache::new(16);
         let first = cache.resolve(&mut resolver, "self.bgsm").unwrap();
         let second = cache.resolve(&mut resolver, "self.bgsm").unwrap();
-        assert!(Arc::ptr_eq(&first, &second), "second resolve hits cache");
-        assert_eq!(cache.len(), 1);
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a self-referential file re-resolves rather than returning a \
+             cached truncation"
+        );
+        assert_eq!(first.depth(), second.depth(), "…and resolves identically");
+        assert_eq!(cache.len(), 0, "the cycle contributed no entries");
+
+        // A clean chain is unaffected: both nodes cached, repeat resolve
+        // is Arc-identical.
+        let clean_first = cache.resolve(&mut resolver, "clean.bgsm").unwrap();
+        let clean_second = cache.resolve(&mut resolver, "clean.bgsm").unwrap();
+        assert!(Arc::ptr_eq(&clean_first, &clean_second));
+        assert_eq!(cache.len(), 2, "clean.bgsm + root.bgsm");
     }
 
     #[test]

--- a/crates/core/src/ecs/resources/mod.rs
+++ b/crates/core/src/ecs/resources/mod.rs
@@ -428,16 +428,27 @@ impl ScratchRow {
 #[derive(Debug, Default)]
 pub struct ScratchTelemetry {
     pub rows: Vec<ScratchRow>,
-    /// R1 / #780 — unique materials at end of last `build_render_data`
-    /// (== `MaterialTable::len()`). Pairs with `materials_interned` to
-    /// compute the dedup ratio.
+    /// R1 / #780 — unique materials at end of last `build_render_data`.
+    ///
+    /// `== MaterialTable::unique_user_count()`, i.e. `len()` minus the
+    /// seeded neutral default at slot 0 (#1032). The producer in
+    /// `byroredux::main` assigns exactly that, deliberately: counting the
+    /// seed would put a floor of 1 under the denominator and skew the
+    /// dedup ratio on frames with no user materials. This doc previously
+    /// said `len()`, contradicting `unique_user_count`'s own doc in
+    /// `crates/renderer/src/vulkan/material.rs` (#2711).
+    ///
+    /// Pairs with `materials_interned` to compute the dedup ratio.
     pub materials_unique: usize,
     /// R1 / #780 — total `intern()` calls during last
     /// `build_render_data` (== `MaterialTable::interned_count()`,
     /// one tick per emitted `DrawCommand`). Dedup ratio =
     /// `materials_interned / materials_unique` — how many intern calls
     /// each unique material absorbs (higher = better dedup). Displayed by
-    /// the `mat.stats` console command. A drop here flags a regression
+    /// the `ctx.scratch` console command — there is no `mat.stats`
+    /// (#2711); `ctx.scratch`'s handler is what prints the
+    /// `materials: N unique / M interned (R× dedup)` line and the
+    /// overflow tail. A drop here flags a regression
     /// (alignment hole, non-deterministic float in the producer) that
     /// breaks byte-equality dedup before VRAM pressure shows it.
     /// (#1066 / REN-D14-NEW-06 — corrected from the prior inverted formula)

--- a/crates/renderer/shaders/include/bindings.glsl
+++ b/crates/renderer/shaders/include/bindings.glsl
@@ -163,12 +163,21 @@ struct GpuMaterial {
     float anisotropic;
     // Common supplemental semantic texture roles (offsets 300-344).
     // Source-game slot numbering has already been translated away.
+    //
+    // #2712 — `lightingMapIndex`, `flowMapIndex` and `wrinkleMapIndex`
+    // are declared here for layout parity with the Rust `GpuMaterial`
+    // (the struct is a byte contract; the fields cannot be omitted) but
+    // are sampled by NO shader. That is deliberate, not an oversight:
+    // lighting-map semantics are undecided for an RT-lit frame, flow
+    // needs a settled UV-advection convention, and wrinkle needs
+    // per-expression weights the animation path doesn't deliver yet.
+    // See the field notes in crates/renderer/src/vulkan/material.rs.
     uint tintMapIndex;
     uint innerLayerMapIndex;
     uint specularMapIndex;
-    uint lightingMapIndex;
-    uint flowMapIndex;
-    uint wrinkleMapIndex;
+    uint lightingMapIndex; // unsampled — see #2712 above
+    uint flowMapIndex;     // unsampled — see #2712 above
+    uint wrinkleMapIndex;  // unsampled — see #2712 above
     uint reflectanceMapIndex;
     uint emittanceGradientMapIndex;
     uint decalMap0Index;

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -292,18 +292,45 @@ pub struct GpuMaterial {
     // These are source-format agnostic. The NIF translation layer maps
     // legacy slots, BSShader texture sets, BGSM/BGEM, and effect shaders
     // into the same role names before a material reaches this record.
-    pub tint_map_index: u32,               // offset 300
-    pub inner_layer_map_index: u32,        // offset 304
-    pub specular_map_index: u32,           // offset 308
-    pub lighting_map_index: u32,           // offset 312
-    pub flow_map_index: u32,               // offset 316
-    pub wrinkle_map_index: u32,            // offset 320
-    pub reflectance_map_index: u32,        // offset 324
+    //
+    // Nine of the twelve are sampled by `triangle.frag`. Three —
+    // `lighting_map_index`, `flow_map_index`, `wrinkle_map_index` — are
+    // **imported, uploaded, hashed and mirrored in GLSL but deliberately
+    // unsampled**, pending the semantics each one needs (see their own
+    // notes below). #2712 moved that deferral out of a one-off audit
+    // report and into the code: it had already failed to propagate once,
+    // with a sibling audit tabulating all three as fully wired lanes.
+    //
+    // Cost of the deferral, so it stays a decision rather than a
+    // surprise: one otherwise-unused DDS upload per authored lane, and a
+    // dedup-key lane (`hash_gpu_material_fields`) that can split two
+    // materials rendering byte-identically. No visual effect.
+    pub tint_map_index: u32,        // offset 300
+    pub inner_layer_map_index: u32, // offset 304
+    pub specular_map_index: u32,    // offset 308
+    /// **Captured, not yet shaded** (#2712). Populated from
+    /// `BSEffectShaderProperty.lighting_texture` and BGSM/BGEM
+    /// `lighting_texture`. Blocked on deciding what the lane means to
+    /// this renderer: the source games use it as a baked-lighting /
+    /// light-mask overlay authored against their own forward pipeline,
+    /// which has no direct equivalent in an RT-lit frame.
+    pub lighting_map_index: u32, // offset 312
+    /// **Captured, not yet shaded** (#2712). Populated from BGSM
+    /// `flow_texture`. Blocked on flow-map coordinate semantics — the
+    /// UV-advection convention (and its pairing with the water/animation
+    /// path) has to be settled before the lane can drive anything.
+    pub flow_map_index: u32, // offset 316
+    /// **Captured, not yet shaded** (#2712). Populated from BGSM
+    /// `wrinkles_texture`. Blocked on actor control: wrinkle maps are
+    /// blended by per-expression facial-animation weights that the
+    /// animation path does not deliver to the material yet.
+    pub wrinkle_map_index: u32, // offset 320
+    pub reflectance_map_index: u32, // offset 324
     pub emittance_gradient_map_index: u32, // offset 328
-    pub decal_map_0_index: u32,            // offset 332
-    pub decal_map_1_index: u32,            // offset 336
-    pub decal_map_2_index: u32,            // offset 340
-    pub decal_map_3_index: u32,            // offset 344 → total 348
+    pub decal_map_0_index: u32,     // offset 332
+    pub decal_map_1_index: u32,     // offset 336
+    pub decal_map_2_index: u32,     // offset 340
+    pub decal_map_3_index: u32,     // offset 344 → total 348
 }
 
 impl Default for GpuMaterial {
@@ -1361,6 +1388,53 @@ mod tests {
     /// was lifted out of `triangle.frag` into the shared
     /// `include/bindings.glsl` under #1583/#1590 — `triangle.frag`
     /// now `#include`s it.)
+    /// #2712 — pin which supplemental role lanes are actually sampled.
+    ///
+    /// Three of the twelve (`lightingMapIndex`, `flowMapIndex`,
+    /// `wrinkleMapIndex`) are produced, uploaded and hashed but read by
+    /// no shader — a deliberate deferral that previously lived only in a
+    /// one-off audit report and had already failed to propagate to a
+    /// sibling report. This pins it in both directions: a lane silently
+    /// going dead fails here, and so does implementing one of the three
+    /// without removing its "captured, not yet shaded" note.
+    ///
+    /// `triangle.frag` is the only pass that reads the supplemental
+    /// roles (checked across `shaders/`), and it `#include`s the struct
+    /// rather than declaring it, so a name appearing in this file means
+    /// the lane is genuinely sampled.
+    #[test]
+    fn supplemental_role_lanes_sampled_by_triangle_frag_are_exactly_the_nine() {
+        let src = include_str!("../../shaders/triangle.frag");
+
+        for name in &[
+            "tintMapIndex",
+            "innerLayerMapIndex",
+            "specularMapIndex",
+            "reflectanceMapIndex",
+            "emittanceGradientMapIndex",
+            "decalMap0Index",
+            "decalMap1Index",
+            "decalMap2Index",
+            "decalMap3Index",
+        ] {
+            assert!(
+                src.contains(name),
+                "{name} is a wired supplemental role — if this pass stopped \
+                 sampling it, the lane is now uploaded and hashed for nothing \
+                 (#2712)"
+            );
+        }
+
+        for name in &["lightingMapIndex", "flowMapIndex", "wrinkleMapIndex"] {
+            assert!(
+                !src.contains(name),
+                "{name} is now sampled — good, but the deferral notes on \
+                 GpuMaterial and in include/bindings.glsl say it is not. \
+                 Remove them together with this assertion (#2712)"
+            );
+        }
+    }
+
     #[test]
     fn gpu_material_glsl_field_names_pinned() {
         let src = include_str!("../../shaders/include/bindings.glsl");
@@ -1673,7 +1747,7 @@ mod tests {
     }
 
     /// #1032 / REN-D14-NEW-01 — `unique_user_count` excludes the
-    /// seeded slot 0 so `mat.stats` reports actual user-distinct
+    /// seeded slot 0 so `ctx.scratch` reports actual user-distinct
     /// material counts. Pin the contract on the four shapes that
     /// matter:
     ///   * fresh table (no user interns) → 0
@@ -1698,7 +1772,7 @@ mod tests {
         assert_eq!(
             table.unique_user_count(),
             1,
-            "one user material — pre-fix `mat.stats` reported 2 here"
+            "one user material — pre-fix `ctx.scratch` reported 2 here"
         );
         assert_eq!(table.len(), 2, "sanity: len() = seeded + 1 user");
 


### PR DESCRIPTION
Four findings from the FO4 and renderer audits of 2026-08-12.

## #2701 (MEDIUM) — cycle-truncated BGSM chains were cached
A truncation is valid only for the walk that produced it. With `A → B → C → B`, the A-rooted walk left `c.bgsm` cached as `parent: None`; a later standalone `resolve("c.bgsm")` — correct chain `C → B(end)` — hit that entry and got depth 1, losing everything `b.bgsm` authored. Which chain a material got depended on cell load order.

**One step past the filed fix:** the truncation flag propagates to ancestors, not just the detecting node. An ancestor's entry embeds the truncated `Arc`, so caching `B` as `B → C(end)` would hand a later `D → C → B → C` walk the chain `D → C → B → C(end)` — `C` on it twice. Cyclic chains now re-parse per resolve (broken authoring only); clean chains cache as before, pinned by test.

The guard test *named* for this hazard asserted its opposite (`Arc::ptr_eq` + `len() == 1`, with a comment conceding the entry was only valid "if it was discovered via the cycle path"). Replaced with the standalone-resolve check the name promises, plus the ancestor-leak case and the re-parse/clean-cache split.

SIBLING: `resolve_shape` in the NIF collision importer runs the same visited-stack break but memoises nothing — no equivalent exposure.

## #2710 (MEDIUM) — effect-shader glass promotion, both directions pinned
`322f33a8` fixed Skyrim's `InnerHaze` case by deleting the keyword arm outright and rewriting the FO4 test in place, leaving the promotion unreachable for any BGEM that misses `bgem_uses_glass_behavior`'s heuristic and no guard in either direction. Restored the arm gated on `from_bgsm` (external-material provenance — `.bgem` doesn't exist pre-FO4), the deleted Nuka-Cola assertions as a **second** test, and a third pinning that the discriminator is provenance rather than game shape.

## #2711 (LOW) — `ScratchTelemetry` doc drift
`materials_unique` claimed `== MaterialTable::len()` while the producer assigns `unique_user_count()` (`len()` minus the seeded neutral, #1032) — contradicting that function's own doc. Both fields named a `mat.stats` command that has never existed; the real one is `ctx.scratch`. Corrected, with the reason the seed is excluded (it floors the dedup denominator).

## #2712 (LOW) — unsampled role lanes, deferral moved into the code
`lighting`/`flow`/`wrinkle` map indices are imported, uploaded, hashed and mirrored in GLSL but sampled by nothing. Deliberate — but recorded only in a one-off audit report, which had already failed to propagate (the FO4 audit tabulates all three as fully wired). Now a per-field note naming the blocking work, the matching GLSL note, the stated cost, and a test pinning exactly which nine lanes `triangle.frag` samples so the notes can't go stale in either direction.

No SPIR-V recompile — the `bindings.glsl` change is comments only; verified `triangle.frag` still compiles against the edited include.

## Verification
`cargo test --no-fail-fast` green workspace-wide except the pre-existing `fire_lights` canary that fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)