### PR TITLE
Fix #2515 Fix #2516 Fix #2517 Fix #2518: light-animation rate, FSR DO…

### DIFF
--- a/byroredux/src/cornell.rs
+++ b/byroredux/src/cornell.rs
@@ -556,9 +556,20 @@ fn pbr_bsdf_lobes(
 /// `materialKind == MATERIAL_KIND_GLASS && roughness < 0.35`, not `alpha`),
 /// matching the spawn-time `classify_glass_into_material` contract.
 /// `alpha: 0.25` below sets `finalAlpha` for these probes to ~0.25 (not
-/// 1.0) — currently unconsumed downstream (`taa.comp`/`composite.frag`
-/// don't read it), but latent-fragile if a future composite branch keys
-/// on alpha for glass/decal classification. See #676 / DEN-6.
+/// 1.0). It is unconsumed by the *composite/TAA passes* specifically
+/// (`taa.comp`/`composite.frag` don't read it), and latent-fragile if a
+/// future composite branch keys on alpha for glass/decal classification.
+/// See #676 / DEN-6.
+///
+/// It is NOT inert engine-wide (#2515): the value reaches
+/// `GpuMaterial.material_alpha` through `to_gpu_material` and is hashed by
+/// `hash_gpu_material_fields` (`material.rs` writes
+/// `mat.material_alpha.to_bits()`), which `MaterialTable::intern_by_hash`
+/// keys on. So it is part of the material dedup identity, and changing it
+/// splits or merges material-table slots — these glass probes already
+/// occupy a slot distinct from an otherwise identical opaque dielectric
+/// purely because of it. Relevant to anyone measuring dedup ratio via
+/// `ctx.scratch` (#780 / PERF-N1) against the Cornell scene.
 fn glass(color: [f32; 3]) -> Material {
     let mut material = Material {
         diffuse_color: color,

--- a/byroredux/src/systems/light_anim.rs
+++ b/byroredux/src/systems/light_anim.rs
@@ -89,6 +89,34 @@ pub(crate) fn canonical_light_animation_flags(game: GameKind, source_flags: u32)
 /// gated. A verified per-game divergence gets its own `match` arm here,
 /// exactly like `GameKind::Fallout4` does above.
 ///
+/// ## The asymmetry with the animation sibling is deliberate (#2517)
+///
+/// These two canonicalizers apply *opposite* defaults to bits that a
+/// game's own LIGH layout does not name, and that is a decision rather
+/// than drift:
+///
+/// * **Animation decode is strict-by-default.** `FO4`/`FO76` are narrowed
+///   to `FLICKER|PULSE` precisely because `0x40`/`0x100` are unnamed
+///   there, and an unnamed bit must not decode into *motion* — a light
+///   that visibly pulses when the record never asked for it is an obvious,
+///   reported artifact.
+/// * **Shadow decode is permissive-by-default.** Dropping a shadow bit
+///   that a game *does* name is the strictly worse error: the light
+///   silently stops casting RT shadows and the scene just looks flat, with
+///   nothing to trace it back to. So an unverified bit stays enabled.
+///
+/// The concrete open question this leaves: of the three bits, only `0x400`
+/// (Spot Shadow) is believed to be named in the Oblivion / FO3 / FNV
+/// layouts, so an Oblivion LIGH carrying `0x800`/`0x1000` as reserved junk
+/// would be promoted to "casts shadows". Narrowing those games to
+/// `LIGHT_FLAG_SHADOW_SPOTLIGHT` alone requires reading xEdit's
+/// `wbDefinitionsTES4.pas` / `wbDefinitionsFNV.pas` LIGH flag lists
+/// directly — the same authority `equip.rs` cites for biped slots. Those
+/// files are not vendored in this tree, and narrowing on the *assumption*
+/// that the bits are unnamed would be exactly the guess the shadow-side
+/// default exists to avoid. Left permissive pending that evidence; see
+/// #2517 for the measurement that would settle it.
+///
 /// `GameKind::Starfield` is excluded from that default for the same
 /// reason `canonical_light_animation_flags` excludes it (#2251): SF1Edit's
 /// live LIGH definition has no named Flags field at all in the
@@ -205,6 +233,23 @@ pub(crate) fn translate_light(
 /// instead of touching this constant.
 const FLICKER_INTENSITY_DAMPING: f32 = 0.5;
 
+/// Noise samples per authored flicker period (#2516).
+///
+/// The FLICKER path interpolates between hash buckets; this sets how many
+/// buckets one authored `period_secs` spans. `6.0` is picked so Skyrim's
+/// vanilla 0.5 s candle steps at `6 / 0.5 = 12` Hz — exactly the rate
+/// Phase 19 arrived at by eye (Phase 17's 24 Hz read as a jerky strobe
+/// rather than a candle's gentle dance) — while a longer authored period
+/// now actually flickers more slowly instead of being ignored.
+const FLICKER_BUCKETS_PER_PERIOD: f32 = 6.0;
+
+/// Fallback period for a `LightFlicker` that somehow carries a
+/// non-positive `period_secs`. Matches the vanilla Skyrim candle default
+/// `attach.rs` already substitutes for pre-Skyrim records (#2478), so the
+/// two agree; this copy exists only to keep [`flicker_intensity`] total
+/// for direct unit-test callers.
+const DEFAULT_FLICKER_PERIOD_SECS: f32 = 0.5;
+
 /// Cheap deterministic hash → `[-1.0, 1.0]`. Wang-style integer hash;
 /// flicker is purely cosmetic so a real PRNG would be overkill.
 fn hash_to_unit(seed: u32) -> f32 {
@@ -260,7 +305,32 @@ fn flicker_intensity(entity: EntityId, flicker: &LightFlicker, total_time: f32) 
         let phase = phase_secs / effective_period;
         (phase * std::f32::consts::TAU).sin()
     } else if flags & (LIGHT_FLAG_FLICKER | LIGHT_FLAG_FLICKER_SLOW) != 0 {
-        let raw = (total_time + flicker.phase_offset_secs) * 12.0 * speed_scale;
+        // Derive the bucket rate from the authored period (#2516). Before
+        // this the flicker branch stepped at a hardcoded 12 Hz and never
+        // read `period_secs` at all, so every flickering light in a scene
+        // ran at an identical rate no matter what its FNAM asked for —
+        // `phase_offset_secs` was the only per-light variation left, and a
+        // roomful of mixed fixtures flickered homogeneously. The pulse
+        // branch immediately above always honoured the period; this is the
+        // asymmetry, not a deliberate override.
+        //
+        // `FLICKER_BUCKETS_PER_PERIOD / period_secs` is chosen so Skyrim's
+        // vanilla 0.5 s candle still lands on exactly the 12 Hz that Phase
+        // 19 tuned by eye (24 Hz read as a jerky strobe), while a longer
+        // authored period now genuinely steps slower. Pre-Skyrim games are
+        // safe here: #2478 / REN-D22-03 made `attach.rs` substitute the
+        // vanilla 0.5 s candle default when a record authors no period, so
+        // `period_secs` is always a real value by the time it reaches this
+        // function — which is why this fix had to wait for that one.
+        let period_secs = if flicker.period_secs > 0.0 {
+            flicker.period_secs
+        } else {
+            // Defensive only — `attach.rs` guarantees a positive period.
+            // Keeps this pure function total for direct unit-test callers.
+            DEFAULT_FLICKER_PERIOD_SECS
+        };
+        let buckets_per_sec = FLICKER_BUCKETS_PER_PERIOD / period_secs;
+        let raw = (total_time + flicker.phase_offset_secs) * buckets_per_sec * speed_scale;
         let bucket = raw.floor() as u32;
         let bucket_t = raw.fract();
         // Smoothstep on the lerp factor — Hermite curve hides the
@@ -444,6 +514,68 @@ mod tests {
         let f = flicker(0, 0.25, 0.5);
         assert_eq!(flicker_intensity(1, &f, 0.0), 1.0);
         assert_eq!(flicker_intensity(1, &f, 3.7), 1.0);
+    }
+
+    /// #2516 — the FLICKER path stepped its hash buckets at a hardcoded
+    /// 12 Hz and never read `period_secs`, so every flickering light ran at
+    /// an identical rate whatever its FNAM authored. Count zero-crossings
+    /// of the modulation over a fixed window: a short authored period must
+    /// produce strictly more of them than a long one.
+    #[test]
+    fn flicker_rate_follows_the_authored_period() {
+        fn crossings(period: f32) -> usize {
+            let f = flicker(LIGHT_FLAG_FLICKER, 0.25, period);
+            let mut prev = flicker_intensity(7, &f, 0.0) - 1.0;
+            let mut n = 0;
+            // 4 s window, 1 ms resolution — fine enough to resolve 60 Hz.
+            for i in 1..4000 {
+                let cur = flicker_intensity(7, &f, i as f32 * 0.001) - 1.0;
+                if prev.signum() != cur.signum() {
+                    n += 1;
+                }
+                prev = cur;
+            }
+            n
+        }
+
+        let fast = crossings(0.25);
+        let candle = crossings(0.5);
+        let slow = crossings(4.0);
+        assert!(
+            fast > candle && candle > slow,
+            "flicker rate must track the authored period: \
+             0.25s={fast} 0.5s={candle} 4.0s={slow}"
+        );
+        // The long period must be *visibly* slower, not marginally so.
+        assert!(
+            slow * 4 < candle,
+            "a 4 s period should flicker far slower than a 0.5 s candle: \
+             {slow} vs {candle}"
+        );
+    }
+
+    /// The 0.5 s vanilla Skyrim candle must still step at the 12 Hz that
+    /// Phase 19 tuned by eye — `FLICKER_BUCKETS_PER_PERIOD` is chosen for
+    /// exactly this, so a future retune cannot silently drift it.
+    #[test]
+    fn vanilla_candle_period_still_steps_at_twelve_hz() {
+        let rate = FLICKER_BUCKETS_PER_PERIOD / 0.5;
+        assert!(
+            (rate - 12.0).abs() < 1e-6,
+            "expected the tuned 12 Hz for a 0.5 s candle, got {rate}"
+        );
+    }
+
+    /// A non-positive period must not divide by zero or produce a NaN
+    /// intensity — `attach.rs` guarantees a positive value, but this pure
+    /// function is called directly by tests and must stay total.
+    #[test]
+    fn flicker_survives_a_non_positive_authored_period() {
+        for bad in [0.0_f32, -1.0] {
+            let f = flicker(LIGHT_FLAG_FLICKER, 0.25, bad);
+            let v = flicker_intensity(3, &f, 1.234);
+            assert!(v.is_finite(), "period {bad} produced {v}");
+        }
     }
 
     #[test]

--- a/crates/renderer/src/vulkan/context/draw.rs
+++ b/crates/renderer/src/vulkan/context/draw.rs
@@ -1315,6 +1315,23 @@ pub struct FrameInputs<'a> {
 }
 
 impl VulkanContext {
+    /// Whether FSR is not merely the *selected* upscaler mode but is
+    /// actually dispatching this frame (#2518).
+    ///
+    /// `self.fsr_temporal.is_some()` answers a different question: it stays
+    /// `Some` for the whole of `UpscalerMode::Fsr3(..)`, including when the
+    /// FSR context never got created or `dispatch_failure` has latched. In
+    /// those states the frame falls back to an unjittered native blit, so
+    /// every "is FSR's projection jitter in play?" decision — the camera
+    /// jitter itself and the DOF gate that exists to avoid conflicting with
+    /// it — must key on this, not on mode selection. Sharing one accessor
+    /// is what keeps the two from drifting apart again.
+    fn is_fsr_dispatch_active(&self) -> bool {
+        self.frame_upscaler
+            .as_ref()
+            .is_some_and(|upscaler| upscaler.is_fsr_dispatch_active())
+    }
+
     pub fn draw_frame(&mut self, inputs: FrameInputs) -> Result<bool> {
         let FrameInputs {
             clear_color,
@@ -1731,11 +1748,7 @@ impl VulkanContext {
                 (jx, jy, None, false)
             }
             super::super::upscaling::UpscalerMode::Fsr3(_) => {
-                if !self
-                    .frame_upscaler
-                    .as_ref()
-                    .is_some_and(|upscaler| upscaler.is_fsr_dispatch_active())
-                {
+                if !self.is_fsr_dispatch_active() {
                     (0.0, 0.0, None, false)
                 } else {
                     let fsr = self
@@ -1774,7 +1787,19 @@ impl VulkanContext {
         // rationale and the #1525 degenerate-`focus_dist` guard live in
         // `dof_effective_view_proj`.
         // FSR forces the pinhole path — rationale in `fsr_gated_dof`.
-        let active_dof = fsr_gated_dof(dof, self.fsr_temporal.is_some());
+        //
+        // #2518 — gate on FSR actually *dispatching*, not merely on FSR
+        // mode being selected. `fsr_temporal` is `Some` for the whole of
+        // `UpscalerMode::Fsr3(..)`, including when the FSR context never got
+        // created or `dispatch_failure` has latched. In those states the
+        // frame runs completely unjittered on the native blit (the jitter
+        // gate above sets `fsr_jitter_pixel = None` and `jx/jy = 0.0` on
+        // exactly this predicate), so the stated rationale — that the
+        // independent Halton(5,7) lens sequence would conflict with FSR's
+        // own projection jitter — does not apply, yet authored DOF was
+        // still being silently dropped. Both facts now come from one
+        // predicate so they cannot diverge again.
+        let active_dof = fsr_gated_dof(dof, self.is_fsr_dispatch_active());
         let (effective_vp, effective_cam_pos) = dof_effective_view_proj(
             &active_dof,
             self.frame_counter,

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -1333,6 +1333,30 @@ impl MaterialTable {
 
 #[cfg(test)]
 mod tests {
+    /// #2515 — `Material::alpha` reaches `GpuMaterial.material_alpha` and is
+    /// hashed by `hash_gpu_material_fields`, so it is part of the dedup
+    /// identity `MaterialTable::intern_by_hash` keys on. The Cornell
+    /// harness's `glass()` doc comment used to call the value "currently
+    /// unconsumed downstream", which is true only of `taa.comp` /
+    /// `composite.frag`; read as "inert" it invites a future edit that
+    /// silently splits or merges material-table slots. Pin the fact.
+    #[test]
+    fn material_alpha_participates_in_the_dedup_hash() {
+        let mut a = GpuMaterial {
+            material_alpha: 1.0,
+            ..Default::default()
+        };
+        let opaque = super::hash_gpu_material_fields(&a);
+        a.material_alpha = 0.25; // the Cornell glass() probe value
+        let glassy = super::hash_gpu_material_fields(&a);
+        assert_ne!(
+            opaque, glassy,
+            "material_alpha must change the dedup hash — two otherwise \
+             identical materials differing only in alpha have to occupy \
+             distinct MaterialTable slots"
+        );
+    }
+
     use super::*;
 
     /// Pin the std430 layout. Any growth must be intentional and


### PR DESCRIPTION
…F gate, and two decode-policy docs

Four LOW findings from the 2026-08-07 renderer audits. Two are real behaviour fixes, two are documentation of facts the code already relies on.

#2516 — the FLICKER path ignored the authored period. The pulse branch honoured `flicker.period_secs`; the flicker branch stepped its hash buckets at a hardcoded 12 Hz and never read the period at all, so every flickering light in a scene ran at an identical rate no matter what its FNAM asked for — `phase_offset_secs` was the only per-light variation left, and a roomful of mixed fixtures flickered homogeneously. Derive the bucket rate as `FLICKER_BUCKETS_PER_PERIOD / period_secs`, with the constant picked so Skyrim's vanilla 0.5 s candle still lands on exactly the 12 Hz that Phase 19 tuned by eye (Phase 17's 24 Hz read as a jerky strobe). This depended on #2478 / REN-D22-03, now closed: pre-Skyrim LIGH DATA authors no flicker parameters, and that fix made `attach.rs` substitute the vanilla candle default, so `period_secs` is always a real value here. Fixing this first would have made FNV worse, which is why the issue said so.

#2518 — DOF was dropped in the FSR-failed fallback. `fsr_gated_dof` was fed `self.fsr_temporal.is_some()`, which stays true for the whole of `UpscalerMode::Fsr3(..)` including when the FSR context never got created or `dispatch_failure` has latched. In those states the frame runs unjittered on the native blit, so the stated rationale — that the independent Halton(5,7) lens sequence would conflict with FSR's own projection jitter — does not apply, yet authored DOF was still silently suppressed. The jitter gate twenty lines above already keyed on the right fact. Add a `VulkanContext::is_fsr_dispatch_active` accessor and route both gates through it, so "FSR mode selected" and "FSR actually running" cannot diverge again by construction. `fsr_temporal.is_some()` no longer appears as a live predicate anywhere in the crate.

#2515 — Cornell `glass()`'s alpha is not inert.
The doc comment called `alpha: 0.25` "currently unconsumed downstream". That is true of `taa.comp`/`composite.frag` only: the value reaches `GpuMaterial.material_alpha` via `to_gpu_material` and is hashed by `hash_gpu_material_fields`, which `MaterialTable::intern_by_hash` keys on — so it is part of the dedup identity and already forces the glass probes into a slot distinct from an otherwise identical opaque dielectric. Reading it as inert invites an edit that silently splits or merges table slots, which matters to anyone measuring dedup ratio via `ctx.scratch` (#780 / PERF-N1).

#2517 — the shadow/animation policy asymmetry is now stated, not narrowed. The two canonicalizers apply opposite defaults to bits a game's LIGH layout does not name: animation decode is strict (FO4/FO76 masked to FLICKER|PULSE because 0x40/0x100 are unnamed there), shadow decode is permissive (all of 0x400/0x800/0x1000 for Oblivion/FO3/FNV). That is defensible and is now written down: an unnamed bit decoding into *motion* is an obvious reported artifact, whereas dropping a shadow bit a game does name is silent — the light just stops casting and the scene looks flat.

The issue's alternative — narrowing Oblivion/FO3/FNV to SHADOW_SPOTLIGHT alone — is deliberately NOT taken. It rests on the claim that 0x800/0x1000 are unnamed in those layouts, which the issue itself marks unconfirmed and which cannot be checked here: xEdit's wbDefinitionsTES4.pas / wbDefinitionsFNV.pas are not vendored in this tree, and no LIGH flag list for those games exists in-repo. Narrowing on the assumption would be exactly the guess the permissive default exists to avoid, and would silently remove RT shadows if the bits turn out to be named. `every_game_shares_the_same_ shadow_mask_today` is therefore unchanged and still correct.

Tests: 4 new. The flicker-rate test counts modulation zero-crossings over a fixed window and is verified to fail against the old hardcoded rate (all three periods produced an identical 19 crossings). #2518's runtime check needs a Vulkan device (BYRO_FSR_FORCE_DISPATCH_FAIL=1 smoke path, out of cargo test scope) — its single-predicate property is structural instead. byroredux-renderer 610 -> 611; workspace 1125 passed.

Pre-existing and untouched: render::fire_lights::tests:: derived_reach_is_currently_oversized_pending_a_unit_correct_derivation fails on main independently of these changes.