### PR TITLE
Fix #2866 #2867 #2868 #2869: physics local/world contract, registration order, ragdoll scale, door-arrival grounding

### DIFF
--- a/byroredux/src/app_step.rs
+++ b/byroredux/src/app_step.rs
@@ -711,14 +711,20 @@ impl App {
                         let dest_rot =
                             cell_loader::rotation_zup_to_yup_quat(pending.destination_rotation_zup);
                         cell_loader::reposition_camera(&mut self.world, dest_pos, dest_rot);
-                        // #1874 — see the doc comment on
-                        // `snap_character_body_to_camera`: without this,
+                        // #1874 — without a body move here,
                         // `camera_follow_system` snaps the camera back
                         // toward the stale (pre-transition) capsule
                         // position on the next tick, fighting this
                         // reposition every frame and producing a stuck
                         // TAA/SVGF ghost.
-                        crate::systems::snap_character_body_to_camera(&mut self.world);
+                        //
+                        // #2869 — and it must GROUND the body against the
+                        // floor-level XTEL destination, not derive it from
+                        // the camera by subtracting `eye_height`
+                        // (`snap_character_body_to_camera`, whose
+                        // camera-is-at-eye-height premise does not hold
+                        // here). See `ground_character_body_at`.
+                        crate::systems::ground_character_body_at(&mut self.world, dest_pos);
 
                         log::info!(
                             "Cell transition applied: → {} at world ({:.1}, {:.1}, {:.1})",

--- a/byroredux/src/cell_loader/transition.rs
+++ b/byroredux/src/cell_loader/transition.rs
@@ -418,9 +418,15 @@ pub fn load_interior_cell(
     // fight, not a single bad motion vector, is what let a ghosted/
     // doubled TAA-SVGF history artifact "stick" indefinitely after a
     // door transition. No-ops harmlessly in FlyCam mode (no player
-    // body to snap). See `snap_character_body_to_camera`'s doc comment
-    // for the full mechanism.
-    crate::systems::snap_character_body_to_camera(world);
+    // body to snap).
+    //
+    // #2869 — this was `snap_character_body_to_camera`, which derives the
+    // body from the camera by subtracting `eye_height`. The camera has just
+    // been placed at the FLOOR-level XTEL destination, so that buried the
+    // capsule ~116 BU below the destination floor. `dest_pos` is the floor,
+    // so ground the body against it directly and let the camera follow from
+    // the body — the same direction cold start works in.
+    crate::systems::ground_character_body_at(world, dest_pos);
     Ok(dest_pos)
 }
 

--- a/byroredux/src/ragdoll.rs
+++ b/byroredux/src/ragdoll.rs
@@ -306,7 +306,12 @@ pub fn activate_ragdoll(world: &World, actor: EntityId) -> Result<usize, String>
                 // with, regardless of any later live GlobalTransform.scale
                 // mutation.
                 scale: gt.scale,
-                shape: b.shape.clone(),
+                // #2868 — the seed translation above is composed WITH
+                // `gt.scale`, so the collider must be resized by the same
+                // factor or a scaled actor ragdolls with bind-size limbs at
+                // scaled-apart positions. Rapier colliders carry no scale of
+                // their own; the geometry itself has to change.
+                shape: b.shape.scaled(gt.scale),
                 mass: b.mass,
                 linear_damping: b.linear_damping,
                 angular_damping: b.angular_damping,
@@ -314,13 +319,29 @@ pub fn activate_ragdoll(world: &World, actor: EntityId) -> Result<usize, String>
                 restitution: b.restitution,
             });
         }
+        // #2868 — the joint pivots are authored in the same bind space as the
+        // shapes and must be seeded against the same scale as the body poses
+        // above. `activate_ragdoll` is the one boundary where the live actor
+        // scale and the authored spec meet, so the multiplication belongs
+        // here; `build_joint` stays unit-agnostic. Each side takes its own
+        // endpoint body's scale, since each pivot is in that body's frame.
+        // A constraint naming an out-of-range body index is left unscaled —
+        // `orient_tree` drops it, and fabricating a scale for a body that
+        // doesn't exist would hide the upstream defect.
         let constraints = template
             .constraints
             .iter()
-            .map(|c| RagdollConstraintSpec {
-                body_a: c.body_a,
-                body_b: c.body_b,
-                joint: c.joint.clone(),
+            .map(|c| {
+                let scale_of = |index: usize| bodies.get(index).map(|b: &RagdollBodySpec| b.scale);
+                let joint = match (scale_of(c.body_a), scale_of(c.body_b)) {
+                    (Some(scale_a), Some(scale_b)) => c.joint.scaled_pivots(scale_a, scale_b),
+                    _ => c.joint.clone(),
+                };
+                RagdollConstraintSpec {
+                    body_a: c.body_a,
+                    body_b: c.body_b,
+                    joint,
+                }
             })
             .collect();
         RagdollSpec {
@@ -739,6 +760,110 @@ mod tests {
             end.y < init_y - 1.0,
             "writeback should move the bone down under gravity: {init_y} → {}",
             end.y
+        );
+    }
+
+    /// Regression for #2868 — the end-to-end half. `activate_ragdoll` is the
+    /// single boundary where the live actor scale meets the authored template,
+    /// so it owns scaling both the collider geometry and the joint pivots.
+    ///
+    /// Two bones of a 2x actor sit 100 apart with authored ±25 pivots (bind
+    /// separation 50). Pre-fix the pivots went through verbatim and multibody
+    /// forward kinematics pulled the child back to 50 on the first step — a
+    /// scaled NPC's corpse crushed to bind proportions while the writeback
+    /// kept stretching its bones to 2x, the "visibly crushed, interpenetrating
+    /// corpse" symptom. `scale = 1.0` is the majority case every other test
+    /// covers, which is exactly why this one was invisible.
+    #[test]
+    fn scaled_actor_ragdoll_keeps_its_seeded_bone_separation() {
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<RagdollTemplate>();
+        world.register::<RagdollActive>();
+        world.register::<Ragdoll>();
+        world.insert_resource(PhysicsWorld::new());
+
+        const ACTOR_SCALE: f32 = 2.0;
+        const SEEDED_SEPARATION: f32 = 100.0;
+
+        let actor = world.spawn();
+        let bones: Vec<_> = (0..2)
+            .map(|index| {
+                let bone = world.spawn();
+                world.insert(
+                    bone,
+                    GlobalTransform {
+                        translation: Vec3::new(index as f32 * SEEDED_SEPARATION, 1000.0, 0.0),
+                        rotation: Quat::IDENTITY,
+                        scale: ACTOR_SCALE,
+                    },
+                );
+                bone
+            })
+            .collect();
+
+        world.insert(
+            actor,
+            RagdollTemplate {
+                bodies: bones
+                    .iter()
+                    .map(|&bone| RagdollTemplateBody {
+                        bone,
+                        local_translation: Vec3::ZERO,
+                        local_rotation: Quat::IDENTITY,
+                        shape: CollisionShape::Ball { radius: 5.0 },
+                        mass: 4.0,
+                        linear_damping: 0.05,
+                        angular_damping: 0.05,
+                        friction: 0.5,
+                        restitution: 0.0,
+                    })
+                    .collect(),
+                // Authored in BIND units: ±25 → a bind separation of 50, half
+                // the distance the 2x bones are actually seeded apart.
+                constraints: vec![RagdollTemplateConstraint {
+                    body_a: 0,
+                    body_b: 1,
+                    joint: RagdollJointSpec::Ragdoll {
+                        twist_a: Vec3::X,
+                        plane_a: Vec3::Y,
+                        pivot_a: Vec3::new(25.0, 0.0, 0.0),
+                        twist_b: Vec3::X,
+                        plane_b: Vec3::Y,
+                        pivot_b: Vec3::new(-25.0, 0.0, 0.0),
+                        cone_max: std::f32::consts::PI,
+                        twist_min: -std::f32::consts::PI,
+                        twist_max: std::f32::consts::PI,
+                    },
+                }],
+            },
+        );
+
+        activate_ragdoll(&world, actor).expect("activation should succeed");
+
+        let handles: Vec<_> = {
+            let ragdolls = world.query::<Ragdoll>().unwrap();
+            let ragdoll = ragdolls.get(actor).unwrap();
+            ragdoll
+                .bodies
+                .iter()
+                .map(|(_, handle, _)| *handle)
+                .collect()
+        };
+        {
+            let mut pw = world.resource_mut::<PhysicsWorld>();
+            pw.step(PHYSICS_DT);
+        }
+
+        let pw = world.resource::<PhysicsWorld>();
+        let root = body_pose(&pw, handles[0]).unwrap().0;
+        let child = body_pose(&pw, handles[1]).unwrap().0;
+        let separation = (child - root).length();
+        assert!(
+            (separation - SEEDED_SEPARATION).abs() < 1.0,
+            "the 2x actor's bones collapsed toward bind separation: \
+             {SEEDED_SEPARATION} → {separation}"
         );
     }
 

--- a/byroredux/src/scene.rs
+++ b/byroredux/src/scene.rs
@@ -143,7 +143,69 @@ fn capsule_center_y_on_surface(
     surface_y + half_height + radius + kcc_offset_bu
 }
 
-fn character_spawn_center_y(
+/// #2858 — a downward capsule sweep must START above the floor it is looking
+/// for. The probe capsule's own half-extent is `half_height + radius`, so
+/// lifting the origin by that plus a clearance margin keeps the door's own
+/// floor out of the initial-penetration blind zone. Derived from the
+/// controller rather than hard-coded so a `CharacterController` re-tune cannot
+/// reintroduce the blind zone.
+const FLOOR_PROBE_CLEARANCE_BU: f32 = 16.0;
+/// How far below the reference height the probe keeps searching.
+const FLOOR_PROBE_REACH_BELOW_DOOR_BU: f32 = 164.0;
+
+fn floor_probe_lift(cc: byroredux_physics::CharacterController) -> f32 {
+    cc.half_height + cc.radius + FLOOR_PROBE_CLEARANCE_BU
+}
+
+fn min_walkable_normal_y(cc: byroredux_physics::CharacterController) -> f32 {
+    cc.max_slope_climb_deg.to_radians().cos()
+}
+
+/// Probe for the nearest walkable floor beneath `(x, z)`, searching a bounded
+/// band around `reference_y`.
+///
+/// The shared rung of the spawn-grounding ladder. Doors and XTEL destinations
+/// sit at floor level by construction, so a band centred on that height finds
+/// the real local floor — or correctly reports nothing nearby, rather than a
+/// false hit far above.
+///
+/// `exclude` is the entity whose own rigid body must not count as floor. Cold
+/// start passes `None` (the capsule does not exist yet); the runtime
+/// door-transition path passes the player, whose capsule is very much alive
+/// and standing in the sweep (#2869).
+///
+/// Requires a fresh query pipeline — see
+/// [`byroredux_physics::PhysicsWorld::update_query_pipeline`].
+pub(crate) fn probe_walkable_floor_near(
+    world: &World,
+    x: f32,
+    z: f32,
+    reference_y: f32,
+    cc: byroredux_physics::CharacterController,
+    exclude: Option<byroredux_core::ecs::storage::EntityId>,
+) -> Option<f32> {
+    // Resolve the exclusion handle and release the component guard before
+    // taking the `PhysicsWorld` lock — `RapierHandles` → `PhysicsWorld` is the
+    // order `push_kinematic` uses, and holding the query across the resource
+    // would be a second edge for the same pair.
+    let excluded_body = exclude.and_then(|entity| {
+        world
+            .query::<byroredux_physics::RapierHandles>()
+            .and_then(|handles| handles.get(entity).map(|h| h.body))
+    });
+    let probe_lift = floor_probe_lift(cc);
+    let pw = world.resource::<byroredux_physics::PhysicsWorld>();
+    pw.cast_capsule_down_onto_walkable_surface(
+        Vec3::new(x, reference_y + probe_lift, z),
+        cc.half_height,
+        cc.radius,
+        FLOOR_PROBE_CLEARANCE_BU + FLOOR_PROBE_REACH_BELOW_DOOR_BU,
+        min_walkable_normal_y(cc),
+        excluded_body,
+    )
+}
+
+pub(crate) fn character_spawn_center_y(
     world: &World,
     surface_y: f32,
     cc: byroredux_physics::CharacterController,
@@ -1009,25 +1071,10 @@ pub(crate) fn setup_scene(
             // a `CharacterController` re-tune cannot reintroduce the blind
             // zone, and extend the range by the same amount so the band
             // searched BELOW the door is unchanged.
-            const FLOOR_PROBE_CLEARANCE_BU: f32 = 16.0;
-            const FLOOR_PROBE_REACH_BELOW_DOOR_BU: f32 = 164.0;
-            let probe_lift = cc.half_height + cc.radius + FLOOR_PROBE_CLEARANCE_BU;
-            let floor_probe_range = FLOOR_PROBE_CLEARANCE_BU + FLOOR_PROBE_REACH_BELOW_DOOR_BU;
-            let min_walkable_normal_y = cc.max_slope_climb_deg.to_radians().cos();
-            let near_door_floor_y = {
-                let pw = world.resource::<byroredux_physics::PhysicsWorld>();
-                let probe_origin = Vec3::new(nudged_x, door_pos.y + probe_lift, nudged_z);
-                pw.cast_capsule_down_onto_walkable_surface(
-                    probe_origin,
-                    cc.half_height,
-                    cc.radius,
-                    floor_probe_range,
-                    min_walkable_normal_y,
-                    // No player body exists yet — the capsule is spawned
-                    // later in `setup_scene`, so there is nothing to self-hit.
-                    None,
-                )
-            };
+            // No player body exists yet on this path — the capsule is spawned
+            // later in `setup_scene` — so there is nothing to self-hit.
+            let near_door_floor_y =
+                probe_walkable_floor_near(world, nudged_x, nudged_z, door_pos.y, cc, None);
             // Second rung — the nudge itself can be the problem. It moves
             // the XZ 64 BU into the room, and when that lands over a hole
             // (Skyrim's `BleakFallsBarrow01`: the nudged XZ has no floor
@@ -1038,16 +1085,7 @@ pub(crate) fn setup_scene(
             // Standing on the threshold is a better spawn than the bottom
             // of whatever shaft the nudge happened to point at.
             let door_xz_floor_y = near_door_floor_y.or_else(|| {
-                let pw = world.resource::<byroredux_physics::PhysicsWorld>();
-                let probe_origin = Vec3::new(door_pos.x, door_pos.y + probe_lift, door_pos.z);
-                pw.cast_capsule_down_onto_walkable_surface(
-                    probe_origin,
-                    cc.half_height,
-                    cc.radius,
-                    floor_probe_range,
-                    min_walkable_normal_y,
-                    None,
-                )
+                probe_walkable_floor_near(world, door_pos.x, door_pos.z, door_pos.y, cc, None)
             });
 
             // Third rung — neither XZ has floor near door height, so the
@@ -1073,6 +1111,7 @@ pub(crate) fn setup_scene(
                     // (#2858), so a floor sitting near the cell's own AABB
                     // ceiling is inside the swept band rather than behind
                     // the probe's starting penetration.
+                    let probe_lift = floor_probe_lift(cc);
                     let probe_origin = Vec3::new(nudged_x, max[1] + probe_lift, nudged_z);
                     let max_distance = (max[1] - min[1]).max(1.0) + probe_lift + 100.0;
                     pw.cast_capsule_down_onto_walkable_surface(
@@ -1080,7 +1119,7 @@ pub(crate) fn setup_scene(
                         cc.half_height,
                         cc.radius,
                         max_distance,
-                        min_walkable_normal_y,
+                        min_walkable_normal_y(cc),
                         None,
                     )
                 })

--- a/byroredux/src/systems/character.rs
+++ b/byroredux/src/systems/character.rs
@@ -644,6 +644,135 @@ pub fn snap_character_body_to_camera(world: &mut byroredux_core::ecs::World) -> 
     true
 }
 
+/// Ground the character capsule at a **floor-level** destination — the arrival
+/// half of a runtime door transition.
+///
+/// #2869. The transition path used to call [`snap_character_body_to_camera`]
+/// right after [`reposition_camera`](crate::cell_loader::reposition_camera)
+/// had placed the camera at the raw XTEL destination. That helper is correct
+/// for its original caller (`toggle_player_mode`, where the camera genuinely
+/// *is* at eye height) but wrong here: it subtracts `eye_height` from a pose
+/// that is already at floor level, putting the capsule *centre* at
+/// `dest.y - eye_height` and its feet a further `half_height + radius` below
+/// that. Cold start, meanwhile, places the capsule centre at
+/// `floor + half_height + radius + kcc_offset` — so the two engine paths
+/// disagreed by ~120 BU for the very same door, and the transition path ran no
+/// ground probe, no walkable-normal check and no grounded verification at all.
+/// It handed a capsule buried in the destination floor to gravity, and since
+/// the body is kinematic and Rapier's penetration recovery is a stub, nothing
+/// pushed it back out.
+///
+/// Routes through the same two pieces cold start uses —
+/// [`probe_walkable_floor_near`](crate::scene::probe_walkable_floor_near) then
+/// [`character_spawn_center_y`](crate::scene::character_spawn_center_y) — so
+/// the door-arrival ladder cannot drift from the boot ladder again. The probe
+/// excludes the player's own capsule, which (unlike at cold start) already
+/// exists and is standing in the sweep.
+///
+/// A probe miss falls back to the authored destination height, matching the
+/// cold-start ladder's own fallback: the destination is floor level by
+/// construction, so standing on it beats sinking below it.
+///
+/// The camera is pulled to `body + eye_height` here rather than left for
+/// `camera_follow_system` to fix next tick — the caller has just signalled a
+/// temporal discontinuity for this jump, and letting the camera spend a frame
+/// at the floor-level pose would produce exactly the unsignalled second jump
+/// #1874 was about.
+pub fn ground_character_body_at(world: &mut byroredux_core::ecs::World, destination: Vec3) -> bool {
+    let Some(player) = world.try_resource::<PlayerEntity>().and_then(|r| r.0) else {
+        log::warn!(
+            "ground_character_body_at: no PlayerEntity registered — \
+             fly-cam-only boot, nothing to ground. No-op."
+        );
+        return false;
+    };
+    let Some(cc) = world
+        .query::<byroredux_physics::CharacterController>()
+        .and_then(|q| q.get(player).copied())
+    else {
+        log::warn!("ground_character_body_at: player has no CharacterController. Aborting.");
+        return false;
+    };
+
+    // The destination cell's colliders were inserted into `ColliderSet` by the
+    // load, but the query pipeline only learns about them via a pipeline step —
+    // without this flush the probe sweeps an empty BVH and always misses. Same
+    // dt=0 register-then-flush the cold-start probe does.
+    byroredux_physics::physics_sync_system(world, 0.0);
+    {
+        let mut pw = world.resource_mut::<byroredux_physics::PhysicsWorld>();
+        pw.update_query_pipeline();
+    }
+
+    let floor_y = crate::scene::probe_walkable_floor_near(
+        world,
+        destination.x,
+        destination.z,
+        destination.y,
+        cc,
+        Some(player),
+    );
+    let center_y =
+        crate::scene::character_spawn_center_y(world, floor_y.unwrap_or(destination.y), cc);
+    let body_pos = Vec3::new(destination.x, center_y, destination.z);
+    log::info!(
+        "Transition arrival: grounding capsule at ({:.1}, {:.1}, {:.1}) — floor {} \
+         (destination y={:.1})",
+        body_pos.x,
+        body_pos.y,
+        body_pos.z,
+        match floor_y {
+            Some(y) => format!("probed at {y:.1}"),
+            None => "probe MISSED, using destination height".to_string(),
+        },
+        destination.y,
+    );
+
+    {
+        let Some(mut tq) = world.query_mut::<Transform>() else {
+            return false;
+        };
+        if let Some(t) = tq.get_mut(player) {
+            t.translation = body_pos;
+            t.rotation = Quat::IDENTITY;
+        }
+    }
+    {
+        let Some(mut cq) = world.query_mut::<byroredux_physics::CharacterController>() else {
+            return false;
+        };
+        if let Some(c) = cq.get_mut(player) {
+            c.vertical_velocity = 0.0;
+            c.is_grounded = false;
+            c.wants_jump = false;
+        }
+    }
+    byroredux_physics::set_kinematic_translation(world, player, body_pos);
+    pin_camera_above_body(world, body_pos, cc.eye_height);
+    true
+}
+
+/// Move the active camera to `body + eye_height` without disturbing its
+/// rotation, writing `Transform` and `GlobalTransform` together the way
+/// `camera_follow_system` does — the transition path runs outside the
+/// scheduler, so there is no propagation pass left to refresh the global.
+fn pin_camera_above_body(world: &mut byroredux_core::ecs::World, body_pos: Vec3, eye_height: f32) {
+    let Some(cam_entity) = world.try_resource::<ActiveCamera>().map(|active| active.0) else {
+        return;
+    };
+    let cam_pos = body_pos + Vec3::Y * eye_height;
+    if let Some(mut tq) = world.query_mut::<Transform>() {
+        if let Some(t) = tq.get_mut(cam_entity) {
+            t.translation = cam_pos;
+        }
+    }
+    if let Some(mut gq) = world.query_mut::<GlobalTransform>() {
+        if let Some(g) = gq.get_mut(cam_entity) {
+            g.translation = cam_pos;
+        }
+    }
+}
+
 pub fn toggle_player_mode(world: &mut byroredux_core::ecs::World) {
     let current = world
         .try_resource::<PlayerMode>()
@@ -731,6 +860,146 @@ mod tests {
             byroredux_scripting::ActorControlState { restrained: true },
         );
         assert!(!player_accepts_movement_input(&world, player));
+    }
+
+    /// #2869 — a door arrival must land the capsule ON the destination floor,
+    /// standing at the same height cold start would place it, not `eye_height`
+    /// below the floor-level XTEL pose.
+    ///
+    /// The two engine paths disagreed by ~120 BU for the same door: cold start
+    /// puts the capsule *centre* at `floor + half_height + radius +
+    /// kcc_offset` (= +68 for HUMAN), while the transition path handed the
+    /// floor-level camera pose to `snap_character_body_to_camera`, which
+    /// subtracts `eye_height` (= -52). The assertion is written against the
+    /// cold-start formula rather than a literal so a controller re-tune moves
+    /// both together, plus an explicit floor-not-below check that fails on the
+    /// pre-fix number for any tuning.
+    #[test]
+    fn door_arrival_grounds_the_capsule_on_the_destination_floor() {
+        const FLOOR_Y: f32 = 200.0;
+
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<byroredux_core::ecs::components::collision::CollisionShape>();
+        world.register::<byroredux_core::ecs::components::collision::RigidBodyData>();
+        world.register::<byroredux_physics::CharacterController>();
+        world.register::<byroredux_physics::RapierHandles>();
+        world.insert_resource(byroredux_physics::PhysicsWorld::new());
+
+        // A wide static slab whose TOP surface is the destination floor.
+        let floor = world.spawn();
+        let slab_half_height = 10.0;
+        let slab_center = Vec3::new(0.0, FLOOR_Y - slab_half_height, 0.0);
+        world.insert(floor, Transform::new(slab_center, Quat::IDENTITY, 1.0));
+        world.insert(
+            floor,
+            GlobalTransform::new(slab_center, Quat::IDENTITY, 1.0),
+        );
+        world.insert(
+            floor,
+            byroredux_core::ecs::components::collision::CollisionShape::Cuboid {
+                half_extents: Vec3::new(500.0, slab_half_height, 500.0),
+            },
+        );
+        world.insert(
+            floor,
+            byroredux_core::ecs::components::collision::RigidBodyData::STATIC,
+        );
+
+        // The player capsule, parked far away in the "source cell".
+        let cc = byroredux_physics::CharacterController::HUMAN;
+        let player = world.spawn();
+        let stale = Vec3::new(-9000.0, -9000.0, -9000.0);
+        world.insert(player, Transform::new(stale, Quat::IDENTITY, 1.0));
+        world.insert(player, GlobalTransform::new(stale, Quat::IDENTITY, 1.0));
+        world.insert(player, cc);
+        world.insert_resource(PlayerEntity(Some(player)));
+
+        let camera = world.spawn();
+        world.insert(camera, Transform::IDENTITY);
+        world.insert(camera, GlobalTransform::IDENTITY);
+        world.insert_resource(ActiveCamera(camera));
+
+        // The XTEL destination: floor level, as authored.
+        let destination = Vec3::new(0.0, FLOOR_Y, 0.0);
+        assert!(ground_character_body_at(&mut world, destination));
+
+        let body_y = world
+            .query::<Transform>()
+            .unwrap()
+            .get(player)
+            .unwrap()
+            .translation
+            .y;
+        let kcc_offset = byroredux_physics::ContactConfig::DEFAULT.kcc_offset_bu;
+        let expected = FLOOR_Y + cc.half_height + cc.radius + kcc_offset;
+        assert!(
+            (body_y - expected).abs() < 1.0,
+            "capsule centre landed at {body_y}, want the cold-start height {expected}"
+        );
+
+        // The pre-fix path put the capsule CENTRE below the floor (and its
+        // feet a further `half_height + radius` under that). Independent of
+        // any tuning, the feet must end up at or above the floor.
+        let feet_y = body_y - cc.half_height - cc.radius;
+        assert!(
+            feet_y >= FLOOR_Y - 0.5,
+            "capsule feet at {feet_y} are below the destination floor {FLOOR_Y} — \
+             buried, exactly the #2869 failure"
+        );
+
+        // The camera follows FROM the body, not the other way round.
+        let camera_y = world
+            .query::<Transform>()
+            .unwrap()
+            .get(camera)
+            .unwrap()
+            .translation
+            .y;
+        assert!((camera_y - (body_y + cc.eye_height)).abs() < 1e-3);
+    }
+
+    /// A destination with no floor beneath it must fall back to the authored
+    /// height rather than to the eye-height subtraction — the cold-start
+    /// ladder's own fallback. Nothing is spawned to stand on here, so the
+    /// probe misses by construction.
+    #[test]
+    fn door_arrival_with_no_probe_hit_falls_back_to_the_authored_height() {
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<byroredux_core::ecs::components::collision::CollisionShape>();
+        world.register::<byroredux_core::ecs::components::collision::RigidBodyData>();
+        world.register::<byroredux_physics::CharacterController>();
+        world.register::<byroredux_physics::RapierHandles>();
+        world.insert_resource(byroredux_physics::PhysicsWorld::new());
+
+        let cc = byroredux_physics::CharacterController::HUMAN;
+        let player = world.spawn();
+        world.insert(player, Transform::IDENTITY);
+        world.insert(player, GlobalTransform::IDENTITY);
+        world.insert(player, cc);
+        world.insert_resource(PlayerEntity(Some(player)));
+
+        let destination = Vec3::new(12.0, 500.0, -34.0);
+        assert!(ground_character_body_at(&mut world, destination));
+
+        let body = world
+            .query::<Transform>()
+            .unwrap()
+            .get(player)
+            .unwrap()
+            .translation;
+        let kcc_offset = byroredux_physics::ContactConfig::DEFAULT.kcc_offset_bu;
+        let expected = destination.y + cc.half_height + cc.radius + kcc_offset;
+        assert!(
+            (body.y - expected).abs() < 1e-3,
+            "probe miss should stand ON the authored destination height, got {}",
+            body.y
+        );
+        assert!((body.x - destination.x).abs() < 1e-3);
+        assert!((body.z - destination.z).abs() < 1e-3);
     }
 
     /// Free-fall: gravity accumulates frame-by-frame, capped at

--- a/crates/core/src/ecs/components/collision.rs
+++ b/crates/core/src/ecs/components/collision.rs
@@ -48,6 +48,70 @@ pub enum CollisionShape {
     },
 }
 
+impl CollisionShape {
+    /// Uniformly scale the geometry about the shape's own origin.
+    ///
+    /// Collision shapes are authored in a NIF's bind space, but a placed
+    /// instance carries a uniform `GlobalTransform.scale` (REFR `XSCL`, or a
+    /// non-unit node scale on the skeleton chain). Rapier colliders have no
+    /// scale of their own — the geometry itself has to be resized — so any
+    /// site that turns an authored shape into a collider for a scaled
+    /// instance must pass it through here first, or the collider silently
+    /// keeps bind-scale proportions (#2868).
+    ///
+    /// `Compound` child *offsets* scale along with the child geometry;
+    /// child rotations are unaffected. A non-finite or non-positive factor is
+    /// treated as "don't scale" rather than collapsing the shape into a
+    /// zero-volume collider, which parry cannot build a sensible inertia
+    /// tensor from.
+    pub fn scaled(&self, scale: f32) -> Self {
+        if !scale.is_finite() || scale <= 0.0 {
+            return self.clone();
+        }
+        match self {
+            Self::Ball { radius } => Self::Ball {
+                radius: radius * scale,
+            },
+            Self::Cuboid { half_extents } => Self::Cuboid {
+                half_extents: *half_extents * scale,
+            },
+            Self::Capsule {
+                half_height,
+                radius,
+            } => Self::Capsule {
+                half_height: half_height * scale,
+                radius: radius * scale,
+            },
+            Self::Cylinder {
+                half_height,
+                radius,
+            } => Self::Cylinder {
+                half_height: half_height * scale,
+                radius: radius * scale,
+            },
+            Self::ConvexHull { vertices } => Self::ConvexHull {
+                vertices: vertices.iter().map(|v| *v * scale).collect(),
+            },
+            Self::TriMesh { vertices, indices } => Self::TriMesh {
+                vertices: vertices.iter().map(|v| *v * scale).collect(),
+                indices: indices.clone(),
+            },
+            Self::Compound { children } => Self::Compound {
+                children: children
+                    .iter()
+                    .map(|(translation, rotation, child)| {
+                        (
+                            *translation * scale,
+                            *rotation,
+                            Box::new(child.scaled(scale)),
+                        )
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
 impl Component for CollisionShape {
     type Storage = SparseSetStorage<Self>;
 }
@@ -138,6 +202,126 @@ mod tests {
         match shape {
             CollisionShape::Ball { radius } => assert!((radius - 1.5).abs() < 1e-6),
             _ => panic!("wrong variant"),
+        }
+    }
+
+    /// #2868 — every variant's extents must scale, or a scaled instance gets
+    /// bind-size colliders. Covered variant-by-variant because a `match` arm
+    /// that forgets one field (a `Capsule`'s radius, say) still compiles and
+    /// still produces a plausible-looking shape.
+    #[test]
+    fn scaled_resizes_every_primitive_variant() {
+        match (CollisionShape::Ball { radius: 3.0 }).scaled(2.0) {
+            CollisionShape::Ball { radius } => assert!((radius - 6.0).abs() < 1e-6),
+            other => panic!("variant changed: {other:?}"),
+        }
+        match (CollisionShape::Cuboid {
+            half_extents: Vec3::new(1.0, 2.0, 4.0),
+        })
+        .scaled(3.0)
+        {
+            CollisionShape::Cuboid { half_extents } => {
+                assert!((half_extents - Vec3::new(3.0, 6.0, 12.0)).length() < 1e-5);
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+        match (CollisionShape::Capsule {
+            half_height: 10.0,
+            radius: 2.0,
+        })
+        .scaled(2.5)
+        {
+            CollisionShape::Capsule {
+                half_height,
+                radius,
+            } => {
+                assert!((half_height - 25.0).abs() < 1e-5);
+                assert!((radius - 5.0).abs() < 1e-5, "radius must scale too");
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+        match (CollisionShape::Cylinder {
+            half_height: 10.0,
+            radius: 2.0,
+        })
+        .scaled(0.5)
+        {
+            CollisionShape::Cylinder {
+                half_height,
+                radius,
+            } => {
+                assert!((half_height - 5.0).abs() < 1e-5);
+                assert!((radius - 1.0).abs() < 1e-5);
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+    }
+
+    /// Vertex soups scale their points; the index buffer is topology and must
+    /// pass through untouched.
+    #[test]
+    fn scaled_resizes_vertices_and_preserves_topology() {
+        let mesh = CollisionShape::TriMesh {
+            vertices: vec![
+                Vec3::ZERO,
+                Vec3::new(1.0, 0.0, 0.0),
+                Vec3::new(0.0, 2.0, 0.0),
+            ],
+            indices: vec![[0, 1, 2]],
+        };
+        match mesh.scaled(4.0) {
+            CollisionShape::TriMesh { vertices, indices } => {
+                assert!((vertices[1] - Vec3::new(4.0, 0.0, 0.0)).length() < 1e-5);
+                assert!((vertices[2] - Vec3::new(0.0, 8.0, 0.0)).length() < 1e-5);
+                assert_eq!(indices, vec![[0, 1, 2]]);
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+    }
+
+    /// A compound's child OFFSETS are positions in the parent frame, so they
+    /// scale with the geometry; child rotations are orientation and do not.
+    /// Scaling only the leaves would leave the parts correctly sized but
+    /// bunched at bind-scale spacing.
+    #[test]
+    fn scaled_compound_scales_child_offsets_and_recurses() {
+        let compound = CollisionShape::Compound {
+            children: vec![(
+                Vec3::new(10.0, 0.0, 0.0),
+                Quat::from_rotation_y(0.5),
+                Box::new(CollisionShape::Ball { radius: 1.0 }),
+            )],
+        };
+        match compound.scaled(2.0) {
+            CollisionShape::Compound { children } => {
+                let (translation, rotation, child) = &children[0];
+                assert!((*translation - Vec3::new(20.0, 0.0, 0.0)).length() < 1e-5);
+                assert!(rotation.dot(Quat::from_rotation_y(0.5)).abs() > 1.0 - 1e-6);
+                match **child {
+                    CollisionShape::Ball { radius } => assert!((radius - 2.0).abs() < 1e-6),
+                    _ => panic!("child variant changed"),
+                }
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+    }
+
+    /// A degenerate factor must leave the shape alone rather than collapse it
+    /// to zero volume — parry cannot derive a usable inertia tensor from that,
+    /// and the caller would get a silently broken collider instead of a
+    /// bind-scale one.
+    #[test]
+    fn scaled_rejects_non_positive_and_non_finite_factors() {
+        for bad in [0.0, -2.0, f32::NAN, f32::INFINITY] {
+            match (CollisionShape::Ball { radius: 3.0 }).scaled(bad) {
+                CollisionShape::Ball { radius } => {
+                    assert!(
+                        (radius - 3.0).abs() < 1e-6,
+                        "factor {bad} altered the shape"
+                    );
+                }
+                other => panic!("variant changed: {other:?}"),
+            }
         }
     }
 

--- a/crates/core/src/ecs/components/global_transform.rs
+++ b/crates/core/src/ecs/components/global_transform.rs
@@ -95,6 +95,38 @@ impl GlobalTransform {
         )
     }
 
+    /// Inverse of [`Self::compose_trs`] for the translation/rotation pair:
+    /// given a child's **world** pose and its parent's world transform,
+    /// recover the **local** translation/rotation that `compose` maps back
+    /// onto that world pose.
+    ///
+    /// Lives beside `compose_trs` deliberately — the composition order has a
+    /// single home, so its inverse must too, or the two drift apart. Scale is
+    /// not returned: the only caller (physics Phase 4 writeback) never
+    /// simulates scale, and a body's world scale is by construction the one it
+    /// was registered with.
+    ///
+    /// A parent whose scale has collapsed to ~0 is not invertible; rather than
+    /// emitting infinities that would propagate into the render transform, the
+    /// scale division is skipped (treated as 1.0). Such a parent is already
+    /// degenerate — its children render at zero size either way.
+    pub fn local_from_world(
+        parent: &GlobalTransform,
+        world_translation: Vec3,
+        world_rotation: Quat,
+    ) -> (Vec3, Quat) {
+        let inverse_rotation = parent.rotation.inverse();
+        let inverse_scale = if parent.scale.abs() > 1e-6 {
+            1.0 / parent.scale
+        } else {
+            1.0
+        };
+        (
+            inverse_rotation * (world_translation - parent.translation) * inverse_scale,
+            inverse_rotation * world_rotation,
+        )
+    }
+
     /// Translation-only half of [`Self::compose_trs`]: place a child point
     /// `local_translation` into the parent's world frame. Used by placement
     /// sites (lights, particle emitters) that carry no meaningful child
@@ -166,6 +198,64 @@ mod tests {
             GlobalTransform::compose(&parent, Vec3::new(1.0, 0.0, 0.0), Quat::IDENTITY, 1.0);
         assert!(child.translation.x.abs() < 1e-4);
         assert!((child.translation.z + 1.0).abs() < 1e-4);
+    }
+
+    /// #2866 — physics Phase 4 pulls a WORLD-space Rapier pose and must store
+    /// a LOCAL `Transform`, or the next propagation pass applies the parent
+    /// chain a second time. `local_from_world` is that inverse, so it must
+    /// round-trip `compose` exactly for a parent carrying translation,
+    /// rotation AND scale simultaneously — the case where getting the order
+    /// or the scale division wrong still looks plausible.
+    #[test]
+    fn local_from_world_inverts_compose() {
+        let parent = GlobalTransform::new(
+            Vec3::new(100.0, -20.0, 7.5),
+            Quat::from_rotation_y(FRAC_PI_2) * Quat::from_rotation_x(0.3),
+            2.5,
+        );
+        let local_translation = Vec3::new(5.0, 3.0, -11.0);
+        let local_rotation = Quat::from_rotation_z(0.7);
+
+        let world = GlobalTransform::compose(&parent, local_translation, local_rotation, 1.0);
+        let (recovered_translation, recovered_rotation) =
+            GlobalTransform::local_from_world(&parent, world.translation, world.rotation);
+
+        assert!(
+            (recovered_translation - local_translation).length() < 1e-3,
+            "got {recovered_translation:?}, want {local_translation:?}"
+        );
+        assert!(
+            recovered_rotation.dot(local_rotation).abs() > 1.0 - 1e-5,
+            "got {recovered_rotation:?}, want {local_rotation:?}"
+        );
+    }
+
+    /// A root body (no parent) round-trips through an identity parent
+    /// unchanged — the fallback path Phase 4 takes for parentless entities
+    /// must stay a no-op rather than perturbing the pose.
+    #[test]
+    fn local_from_world_through_identity_parent_is_the_world_pose() {
+        let world_translation = Vec3::new(1.0, 2.0, 3.0);
+        let world_rotation = Quat::from_rotation_y(0.4);
+        let (translation, rotation) = GlobalTransform::local_from_world(
+            &GlobalTransform::IDENTITY,
+            world_translation,
+            world_rotation,
+        );
+        assert!((translation - world_translation).length() < 1e-6);
+        assert!(rotation.dot(world_rotation).abs() > 1.0 - 1e-6);
+    }
+
+    /// A parent collapsed to zero scale is not invertible. The division must
+    /// be skipped rather than emitting infinities that would propagate into
+    /// the render transform and poison the frustum/bounds math downstream.
+    #[test]
+    fn local_from_world_survives_a_degenerate_parent_scale() {
+        let parent = GlobalTransform::new(Vec3::ZERO, Quat::IDENTITY, 0.0);
+        let (translation, rotation) =
+            GlobalTransform::local_from_world(&parent, Vec3::new(4.0, 0.0, 0.0), Quat::IDENTITY);
+        assert!(translation.is_finite());
+        assert!(rotation.is_finite());
     }
 
     #[test]

--- a/crates/physics/src/ragdoll.rs
+++ b/crates/physics/src/ragdoll.rs
@@ -93,6 +93,80 @@ pub enum RagdollJointSpec {
     },
 }
 
+impl RagdollJointSpec {
+    /// Scale the body-local **pivot** vectors, leaving every axis untouched.
+    ///
+    /// #2868 — the pivots arrive from the NIF importer in authored bind-space
+    /// units, but a scaled actor's bodies are seeded a scaled distance apart.
+    /// Because a ragdoll joint is a *multibody* (reduced-coordinate) joint,
+    /// the child link's translation is not a soft constraint that the seeded
+    /// separation can win: forward kinematics *defines* it as
+    /// `parent_pose ∘ frame1 ∘ joint_rot ∘ frame2⁻¹`, so bind-scale pivots
+    /// overwrite the seeded pose on the very first step and the ragdoll
+    /// collapses to bind proportions. Scaling the pivots to match the seed is
+    /// what keeps the two consistent.
+    ///
+    /// `twist_*` / `plane_*` / `axis_*` / `perp_*` are unit **directions**
+    /// defining frame orientation — scaling them would be meaningless at best
+    /// and would corrupt the frame basis at worst. They stay as authored.
+    ///
+    /// Each side takes its own body's scale because each pivot lives in its
+    /// own body's local frame; `build_joint`'s `flip` swaps the already-scaled
+    /// pair, so orientation and scaling stay independent.
+    pub fn scaled_pivots(&self, scale_a: f32, scale_b: f32) -> Self {
+        let factor = |scale: f32| {
+            if scale.is_finite() && scale > 0.0 {
+                scale
+            } else {
+                1.0
+            }
+        };
+        let (scale_a, scale_b) = (factor(scale_a), factor(scale_b));
+        match self {
+            Self::Ragdoll {
+                twist_a,
+                plane_a,
+                pivot_a,
+                twist_b,
+                plane_b,
+                pivot_b,
+                cone_max,
+                twist_min,
+                twist_max,
+            } => Self::Ragdoll {
+                twist_a: *twist_a,
+                plane_a: *plane_a,
+                pivot_a: *pivot_a * scale_a,
+                twist_b: *twist_b,
+                plane_b: *plane_b,
+                pivot_b: *pivot_b * scale_b,
+                cone_max: *cone_max,
+                twist_min: *twist_min,
+                twist_max: *twist_max,
+            },
+            Self::LimitedHinge {
+                axis_a,
+                perp_a,
+                pivot_a,
+                axis_b,
+                perp_b,
+                pivot_b,
+                min_angle,
+                max_angle,
+            } => Self::LimitedHinge {
+                axis_a: *axis_a,
+                perp_a: *perp_a,
+                pivot_a: *pivot_a * scale_a,
+                axis_b: *axis_b,
+                perp_b: *perp_b,
+                pivot_b: *pivot_b * scale_b,
+                min_angle: *min_angle,
+                max_angle: *max_angle,
+            },
+        }
+    }
+}
+
 /// One joint linking two bodies by index into [`RagdollSpec::bodies`].
 #[derive(Debug, Clone)]
 pub struct RagdollConstraintSpec {
@@ -624,6 +698,109 @@ mod tests {
             "first step replaced the seeded child rotation: \
              {expected_rotation:?} → {actual_rotation:?}"
         );
+    }
+
+    /// #2868 — reproduces the audit's measured probe. A 2x actor seeds its
+    /// bodies 100 apart, but the authored pivots are ±25 in bind units (bind
+    /// separation 50). Because a ragdoll joint is a *multibody* joint, the
+    /// child's translation is not a soft constraint the seed can win: forward
+    /// kinematics recomputes it from the frames, so unscaled pivots discard
+    /// the seeded pose on the very first step and the ragdoll snaps to bind
+    /// proportions.
+    ///
+    /// Both directions are asserted in one test deliberately. The collapse
+    /// arm is the evidence that the scaled arm is actually load-bearing —
+    /// `first_step_preserves_seeded_child_pose` passes only because its
+    /// hand-written pivots happen to match its body separation at scale 1, so
+    /// an assertion on the scaled arm alone would look identical to a test
+    /// that never exercised the scaling at all.
+    #[test]
+    fn scaled_pivots_preserve_a_scaled_actors_seeded_separation() {
+        fn separation_after_one_step(joint: RagdollJointSpec) -> f32 {
+            let mut pw = PhysicsWorld::new();
+            pw.gravity = Vector::zeros();
+            let spec = RagdollSpec {
+                bodies: vec![ball_body(1, 0.0, 1000.0), ball_body(2, 100.0, 1000.0)],
+                constraints: vec![RagdollConstraintSpec {
+                    body_a: 0,
+                    body_b: 1,
+                    joint,
+                }],
+            };
+            let rag = build_ragdoll(&mut pw, &spec, &ContactConfig::DEFAULT);
+            pw.step(PHYSICS_DT);
+            let root = body_translation(&pw, rag.bodies[0].1).unwrap();
+            let child = body_translation(&pw, rag.bodies[1].1).unwrap();
+            (child - root).length()
+        }
+
+        let authored = loose_ragdoll(0, 1).joint;
+        let collapsed = separation_after_one_step(authored.clone());
+        assert!(
+            (collapsed - 50.0).abs() < 1.0,
+            "bind-scale pivots should pull the seeded 100 apart back to the \
+             authored 50 — got {collapsed}. If this changed, the mechanism \
+             #2868 fixes is gone and the assertion below proves nothing."
+        );
+
+        let preserved = separation_after_one_step(authored.scaled_pivots(2.0, 2.0));
+        assert!(
+            (preserved - 100.0).abs() < 1.0,
+            "scaled pivots must hold the 2x actor's seeded 100-unit separation \
+             through the first step — got {preserved}"
+        );
+    }
+
+    /// Axes are unit directions defining frame ORIENTATION; scaling them would
+    /// corrupt the frame basis. Only the pivots — body-local positions — move.
+    #[test]
+    fn scaled_pivots_leaves_axes_and_limits_untouched() {
+        let scaled = loose_ragdoll(0, 1).joint.scaled_pivots(3.0, 4.0);
+        let RagdollJointSpec::Ragdoll {
+            twist_a,
+            plane_a,
+            pivot_a,
+            pivot_b,
+            cone_max,
+            ..
+        } = scaled
+        else {
+            panic!("variant changed");
+        };
+        assert!(
+            (twist_a - Vec3::X).length() < 1e-6,
+            "twist axis must not scale"
+        );
+        assert!(
+            (plane_a - Vec3::Y).length() < 1e-6,
+            "plane axis must not scale"
+        );
+        assert!((pivot_a - Vec3::new(75.0, 0.0, 0.0)).length() < 1e-5);
+        assert!(
+            (pivot_b - Vec3::new(-100.0, 0.0, 0.0)).length() < 1e-5,
+            "each side scales by its OWN body's factor"
+        );
+        assert!(
+            (cone_max - std::f32::consts::PI).abs() < 1e-6,
+            "limits are angles"
+        );
+    }
+
+    /// A degenerate scale must leave pivots alone rather than collapsing every
+    /// joint onto its parent's origin.
+    #[test]
+    fn scaled_pivots_rejects_non_positive_factors() {
+        for bad in [0.0, -1.0, f32::NAN] {
+            let RagdollJointSpec::Ragdoll { pivot_a, .. } =
+                loose_ragdoll(0, 1).joint.scaled_pivots(bad, bad)
+            else {
+                panic!("variant changed");
+            };
+            assert!(
+                (pivot_a - Vec3::new(25.0, 0.0, 0.0)).length() < 1e-6,
+                "factor {bad} altered the pivot"
+            );
+        }
     }
 
     /// #2338 — overlapping links in one ragdoll must not generate contact

--- a/crates/physics/src/sync.rs
+++ b/crates/physics/src/sync.rs
@@ -15,7 +15,7 @@
 
 use byroredux_core::ecs::components::collision::{CollisionShape, MotionType, RigidBodyData};
 use byroredux_core::ecs::components::{
-    FormIdComponent, GlobalTransform, PhysicsSourceForm, RenderLayer, Transform,
+    FormIdComponent, GlobalTransform, Parent, PhysicsSourceForm, RenderLayer, Transform,
 };
 use byroredux_core::ecs::storage::EntityId;
 use byroredux_core::ecs::world::World;
@@ -504,7 +504,26 @@ impl Newcomer {
 fn collect_newcomers(world: &World) -> Vec<Newcomer> {
     let mut out = Vec::new();
 
-    let handles_q = world.query::<RapierHandles>();
+    // #2867 — this check used to live at the BOTTOM of `register_newcomers`,
+    // *after* every newcomer's body and colliders had already been committed
+    // to Rapier. Missing storage there meant returning with live solver
+    // objects and no ECS row pointing at them: `release_victim_rapier_bodies`
+    // walks `RapierHandles`/`Ragdoll` rows, so nothing could ever free them.
+    // Worse, the skip below is gated on the same query, so the identical
+    // newcomer set — full `TriMesh` vertex/index clones included — was
+    // re-collected and re-inserted every single frame, unbounded (the #1520
+    // leak shape on a different trigger). Refusing to collect at all keeps
+    // the miss path from reaching the solver, and stops the re-collect with
+    // the same edit.
+    let Some(handles_q) = world.query::<RapierHandles>() else {
+        log::error!(
+            "RapierHandles storage missing — call World::register::<RapierHandles>() \
+             during setup before running physics_sync_system. No colliders will be \
+             registered this frame (registering them would leak into Rapier with no \
+             ECS handle to free them by)."
+        );
+        return out;
+    };
 
     let (Some(shape_q), Some(body_q)) = (
         world.query::<CollisionShape>(),
@@ -521,10 +540,8 @@ fn collect_newcomers(world: &World) -> Vec<Newcomer> {
     };
 
     for (entity, shape) in shape_q.iter() {
-        if let Some(ref hq) = handles_q {
-            if hq.contains(entity) {
-                continue;
-            }
+        if handles_q.contains(entity) {
+            continue;
         }
         let Some(body_data) = body_q.get(entity) else {
             continue;
@@ -666,13 +683,21 @@ fn register_newcomers(world: &World, newcomers: Vec<Newcomer>) {
     // get `&World`. We work around this by pre-registering storage and
     // going through the QueryWrite::insert path, which IS available.
     if !registered.is_empty() {
-        // Ensure storage exists for QueryWrite to succeed.
+        // #2867 — a defensive net, not the gate. The gate is in
+        // `collect_newcomers`: reaching here with a non-empty batch means the
+        // storage existed when the batch was collected, and nothing between
+        // then and now can remove it. Keep the arm anyway, but note that by
+        // this point the bodies and colliders are already in the solver — if
+        // this ever fires, the batch leaks. Any future edit that wants to
+        // reject a newcomer for a storage reason must do it before the
+        // `pw.bodies.insert` above, not here.
         let mut handles_q = match world.query_mut::<RapierHandles>() {
             Some(q) => q,
             None => {
                 log::error!(
-                    "RapierHandles storage missing — call World::register::<RapierHandles>() \
-                     during setup before running physics_sync_system"
+                    "RapierHandles storage disappeared between collection and registration — \
+                     {} bodies are now orphaned in Rapier with no ECS handle to free them by",
+                    registered.len(),
                 );
                 return;
             }
@@ -753,6 +778,23 @@ fn pull_dynamic(world: &World) {
     // before taking the Transform write lock.
     let mut updates: Vec<(EntityId, glam::Vec3, glam::Quat)> = Vec::new();
     {
+        // #2866 — Rapier's pose is WORLD-space by construction (Phase 1 seeds
+        // the body from `GlobalTransform`), but the write target below is the
+        // entity's LOCAL `Transform`. For a root those coincide; for a
+        // parented body they do not, and the next propagation pass composes
+        // `parent_global ∘ local`, applying the parent chain a second time —
+        // the body renders offset from where it simulates, by exactly the
+        // parent transform. `load_nif_scene_hierarchical` produces precisely
+        // this shape (a non-root `NiNode` carrying a Dynamic `bhkCollisionObject`
+        // under a non-identity parent chain), so `cargo run -- mesh.nif` reaches
+        // it. Divide the parent back out instead of restricting the loader.
+        //
+        // Both guards are read queries acquired here and dropped with this
+        // block, before the `Transform` write below — `transform_propagation_system`
+        // holds `Transform` while acquiring `Parent`/`GlobalTransform`, so
+        // holding these across the write lock would be the reverse edge (#2135).
+        let parent_q = world.query::<Parent>();
+        let global_q = world.query::<GlobalTransform>();
         let pw = world.resource::<PhysicsWorld>();
         for (entity, handles) in handles_q.iter() {
             let Some(body_data) = body_q.get(entity) else {
@@ -767,6 +809,19 @@ fn pull_dynamic(world: &World) {
             let iso = *body.position();
             let translation = vec3_from_translation(iso.translation);
             let rotation = quat_from_na(iso.rotation);
+            // A parent that has no `GlobalTransform` cannot be divided out;
+            // propagation `continue`s on that same case, so the child's global
+            // is never recomposed either and the world pose stays correct.
+            let parent_global = parent_q
+                .as_ref()
+                .and_then(|pq| pq.get(entity))
+                .and_then(|parent| global_q.as_ref().and_then(|gq| gq.get(parent.0)));
+            let (translation, rotation) = match parent_global {
+                Some(parent_global) => {
+                    GlobalTransform::local_from_world(parent_global, translation, rotation)
+                }
+                None => (translation, rotation),
+            };
             updates.push((entity, translation, rotation));
         }
     }
@@ -791,6 +846,189 @@ fn pull_dynamic(world: &World) {
             t.translation = pos;
             t.rotation = rot;
         }
+    }
+}
+
+#[cfg(test)]
+mod phase_sync_tests {
+    use super::physics_sync_system;
+    use crate::components::RapierHandles;
+    use crate::world::PhysicsWorld;
+    use byroredux_core::ecs::components::collision::{CollisionShape, MotionType, RigidBodyData};
+    use byroredux_core::ecs::components::{GlobalTransform, Parent, Transform};
+    use byroredux_core::ecs::world::World;
+    use glam::{Quat, Vec3};
+
+    fn dynamic_body() -> RigidBodyData {
+        RigidBodyData {
+            motion_type: MotionType::Dynamic,
+            ..Default::default()
+        }
+    }
+
+    fn unit_box() -> CollisionShape {
+        CollisionShape::Cuboid {
+            half_extents: Vec3::splat(1.0),
+        }
+    }
+
+    /// Everything `physics_sync_system` touches, minus `RapierHandles` — the
+    /// storage whose absence #2867 is about.
+    fn world_without_handles_storage() -> World {
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<Parent>();
+        world.register::<CollisionShape>();
+        world.register::<RigidBodyData>();
+        world.insert_resource(PhysicsWorld::new());
+        world
+    }
+
+    fn physics_world() -> World {
+        let mut world = world_without_handles_storage();
+        world.register::<RapierHandles>();
+        world
+    }
+
+    /// #2866 — Rapier's pose is world-space, the write target is the LOCAL
+    /// `Transform`. A parented dynamic body must have its parent chain divided
+    /// back out, or `transform_propagation_system` composes it a second time
+    /// and the body renders a whole parent transform away from where it
+    /// simulates. Pre-fix this stored the raw world pose, so the child's local
+    /// came back as the world `(30, 0, 0)` rather than the local `(5, 0, 0)`.
+    ///
+    /// `dt = 0` so the solver cannot advance the body: the pose the pull reads
+    /// back is exactly the pose registration seeded, which makes the assertion
+    /// about the local/world contract alone rather than about integration.
+    #[test]
+    fn parented_dynamic_body_pulls_back_a_local_not_world_transform() {
+        let mut world = physics_world();
+
+        // Parent: translated, rotated a quarter turn about Y, scaled 2x — so a
+        // pass that drops any one of the three still fails.
+        let parent_global = GlobalTransform::new(
+            Vec3::new(20.0, 5.0, -3.0),
+            Quat::from_rotation_y(std::f32::consts::FRAC_PI_2),
+            2.0,
+        );
+        let parent = world.spawn();
+        world.insert(parent, Transform::IDENTITY);
+        world.insert(parent, parent_global);
+
+        let local_translation = Vec3::new(5.0, 0.0, 0.0);
+        let child_global =
+            GlobalTransform::compose(&parent_global, local_translation, Quat::IDENTITY, 1.0);
+        let child = world.spawn();
+        world.insert(child, Transform::IDENTITY);
+        world.insert(child, child_global);
+        world.insert(child, Parent(parent));
+        world.insert(child, unit_box());
+        world.insert(child, dynamic_body());
+
+        physics_sync_system(&world, 0.0);
+
+        let transforms = world.query::<Transform>().unwrap();
+        let local = transforms.get(child).copied().unwrap();
+        assert!(
+            (local.translation - local_translation).length() < 1e-2,
+            "child local Transform is {:?}, want the LOCAL {:?} — a world-space \
+             pose here gets the parent chain applied twice by propagation",
+            local.translation,
+            local_translation,
+        );
+
+        // The round trip is what actually matters: recomposing the stored
+        // local under the parent must land back on the simulated world pose.
+        let recomposed =
+            GlobalTransform::compose(&parent_global, local.translation, local.rotation, 1.0);
+        assert!((recomposed.translation - child_global.translation).length() < 1e-2);
+    }
+
+    /// A parentless dynamic body still receives the raw world pose — the
+    /// fallback must not perturb the far more common root case.
+    #[test]
+    fn root_dynamic_body_still_pulls_back_the_world_pose() {
+        let mut world = physics_world();
+        let seed = Vec3::new(11.0, 22.0, 33.0);
+        let entity = world.spawn();
+        world.insert(entity, Transform::IDENTITY);
+        world.insert(entity, GlobalTransform::new(seed, Quat::IDENTITY, 1.0));
+        world.insert(entity, unit_box());
+        world.insert(entity, dynamic_body());
+
+        physics_sync_system(&world, 0.0);
+
+        let transforms = world.query::<Transform>().unwrap();
+        assert!((transforms.get(entity).unwrap().translation - seed).length() < 1e-2);
+    }
+
+    /// #2867 — with `RapierHandles` storage missing there is no way to record
+    /// a handle, so nothing may reach the solver: an inserted body would be
+    /// unreachable from `release_victim_rapier_bodies` (which walks
+    /// `RapierHandles`/`Ragdoll` rows) and therefore unfreeable. Pre-fix the
+    /// bodies and colliders went in first and the check ran forty lines later.
+    ///
+    /// Ticking repeatedly is the load-bearing half: the newcomer skip is gated
+    /// on the same missing query, so the pre-fix path re-collected and
+    /// re-inserted the identical batch every frame, unbounded.
+    #[test]
+    fn missing_handles_storage_registers_nothing_and_does_not_accumulate() {
+        let mut world = world_without_handles_storage();
+        for index in 0..4 {
+            let entity = world.spawn();
+            world.insert(entity, Transform::IDENTITY);
+            world.insert(
+                entity,
+                GlobalTransform::new(
+                    Vec3::new(index as f32 * 10.0, 0.0, 0.0),
+                    Quat::IDENTITY,
+                    1.0,
+                ),
+            );
+            world.insert(entity, unit_box());
+            world.insert(entity, dynamic_body());
+        }
+
+        for tick in 1..=8 {
+            physics_sync_system(&world, 1.0 / 60.0);
+            let pw = world.resource::<PhysicsWorld>();
+            assert_eq!(
+                (pw.bodies.len(), pw.colliders.len()),
+                (0, 0),
+                "tick {tick}: bodies/colliders reached the solver with no ECS row to free them by",
+            );
+        }
+    }
+
+    /// The same scene with the storage registered must still register
+    /// normally — the #2867 guard rejects only the misconfigured case, and
+    /// registers each newcomer exactly once across repeated ticks.
+    #[test]
+    fn registered_handles_storage_admits_each_newcomer_exactly_once() {
+        let mut world = physics_world();
+        for index in 0..4 {
+            let entity = world.spawn();
+            world.insert(entity, Transform::IDENTITY);
+            world.insert(
+                entity,
+                GlobalTransform::new(
+                    Vec3::new(index as f32 * 10.0, 0.0, 0.0),
+                    Quat::IDENTITY,
+                    1.0,
+                ),
+            );
+            world.insert(entity, unit_box());
+            world.insert(entity, dynamic_body());
+        }
+
+        for _ in 0..8 {
+            physics_sync_system(&world, 1.0 / 60.0);
+        }
+
+        let pw = world.resource::<PhysicsWorld>();
+        assert_eq!(pw.bodies.len(), 4, "one body per newcomer, registered once");
+        assert_eq!(pw.colliders.len(), 4);
     }
 }
 


### PR DESCRIPTION
Closes #2866, #2867, #2868, #2869 — four independent PHYSAL defects from the 2026-08-13 physics audit.

**#2866** — `pull_dynamic` assigned Rapier's world-space pose to the entity's *local* `Transform`, so a parented dynamic body got the parent chain applied twice by the next propagation pass. `load_nif_scene_hierarchical` produces exactly that shape, so `cargo run -- mesh.nif` reaches it. Phase 4 now divides the parent back out via a new `GlobalTransform::local_from_world`, placed beside `compose_trs` so the composition order and its inverse share one home. The added read guards are dropped before the `Transform` write (#2135 lock order).

**#2867** — `register_newcomers` committed bodies + colliders to the solver and checked for `RapierHandles` storage forty lines later, leaking the batch with no ECS row to free it by — and re-collecting the identical batch every frame, since the newcomer skip is gated on the same query. The check moves to `collect_newcomers`, fixing the leak and the re-collect together.

**#2868** — `activate_ragdoll` scaled the body seed poses by the live actor scale but passed collider shapes and joint pivots through in bind units. Multibody forward kinematics then discards the seeded pose on the first step: a 2x actor's bodies seeded 100 apart collapse to 50, exactly as the audit measured. Fixed at the one boundary where live scale meets the authored template, via new `CollisionShape::scaled` and `RagdollJointSpec::scaled_pivots`. Axes stay unscaled; `build_joint` stays unit-agnostic.

**#2869** — door arrivals placed the capsule at `camera - eye_height` from a floor-level XTEL pose, burying it ~116 BU below the destination floor while cold start places it 68 BU above — a 120 BU disagreement between two engine paths for the same door, with no ground probe at all. New `ground_character_body_at` routes arrivals through the same probe and spawn-height helpers cold start uses (the probe extracted and shared, not copied), excluding the player's own capsule and falling back to the authored height on a miss.

The two `physics_sync_system` regressions were verified to fail against a temporarily reverted tree. The ragdoll test asserts the collapse and the fix in one body so the scaled arm cannot go vacuous; the door-arrival test asserts against the cold-start formula plus a tuning-independent "feet not below the floor" check.

`byroredux/src/render/fire_lights.rs`'s `derived_reach_is_currently_oversized_pending_a_unit_correct_derivation` fails on main — unrelated and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)