### PR TITLE
Fix #2606 #2607 #2608 #2609: BGSM merge-boundary flag split, roughness overwrite, and two dropped field groups

### DIFF
--- a/byroredux/src/asset_provider/material.rs
+++ b/byroredux/src/asset_provider/material.rs
@@ -52,6 +52,85 @@ pub(crate) fn forward_bgsm_phase1_flags(
     }
 }
 
+/// #2607 (FO4-D7-02) — forward BGSM's rim / backlight / subsurface shading
+/// scalars onto `ImportedMaterial`'s matching sinks.
+///
+/// The parser has decoded these since the crate existed, `ImportedMaterial`
+/// has had `rimlight_power` / `backlight_power` / `subsurface_rolloff` since
+/// #2284 wired the NIF-native path, and `translate_material` already forwards
+/// all three onto the canonical `Material` — only this hop was missing, so
+/// every BGSM-authored surface fed the Disney subsurface/rimlight lobe
+/// hardcoded zeros. #1352 (unconditional `MAT_FLAG_PBR_BSDF` for BGSM
+/// content) is what makes that visible rather than inert.
+///
+/// **Gated on the authored enable bits, deliberately.** The parser reads this
+/// whole group only on the `version < 8` branch — the v>=8 layout spends those
+/// bytes on the translucency suite instead — so on a modern BGSM `rim_power`
+/// and `subsurface_lighting_rolloff` still hold their struct defaults of
+/// 2.0 / 0.3. Those are never-parsed values, and forwarding them would be
+/// fabrication, not translation. `rim_lighting` / `subsurface_lighting` are
+/// false in exactly that case, which makes them the correct and complete gate.
+///
+/// `back_light_power` shares the rim enable bit: the format gives it none of
+/// its own, and the Bethesda Material Editor authors it in the rim-lighting
+/// group.
+///
+/// Child-first precedence via the caller's sentinels, matching every other
+/// payload-carrying field in the walk. Extracted from the merge loop for the
+/// same reason as [`forward_bgsm_phase1_flags`] (#2702): so the regression
+/// tests drive the real production logic rather than a hand-copied mirror.
+pub(crate) fn forward_bgsm_rim_subsurface(
+    material: &mut ImportedMaterial,
+    bgsm: &BgsmFile,
+    set_rim: &mut bool,
+    set_subsurface: &mut bool,
+    touched: &mut bool,
+) {
+    if !*set_rim && bgsm.rim_lighting {
+        material.rimlight_power = bgsm.rim_power;
+        material.backlight_power = bgsm.back_light_power;
+        *set_rim = true;
+        *touched = true;
+    }
+    if !*set_subsurface && bgsm.subsurface_lighting {
+        material.subsurface_rolloff = bgsm.subsurface_lighting_rolloff;
+        *set_subsurface = true;
+        *touched = true;
+    }
+}
+
+/// #2608 (FO4-D7-03) — forward BGSM's authored env-map mask scale.
+///
+/// Same drop-at-the-merge-boundary class as [`forward_bgsm_rim_subsurface`]:
+/// `merge_external_material` forwards env-map *textures* but was dropping the
+/// scale that modulates them.
+///
+/// **Gated on `base.environment_mapping`, deliberately.**
+/// `BaseMaterial::parse_after_magic` reads the `(environment_mapping,
+/// environment_mapping_mask_scale)` pair only when `version < 10`; from v10
+/// those bytes became `depth_bias` and the parser substitutes a synthetic
+/// `(false, 1.0)`. Forwarding unconditionally would stamp `env_map_scale =
+/// 1.0` onto every modern BGSM, and `Material::resolve_pbr`'s
+/// `env_map_scale > 0.3` arm reads that as authored reflection intent — a
+/// fabricated input driving real roughness on the majority of FO4 content.
+/// The enable bit is false in precisely the never-parsed case.
+///
+/// (BGSM has no v>=10 re-read of this pair, so the base bit is the whole
+/// story here. BGEM's `env_mapping_enabled()` accessor exists because BGEM
+/// *does* re-read it in its own subclass section.)
+pub(crate) fn forward_bgsm_env_map_scale(
+    material: &mut ImportedMaterial,
+    bgsm: &BgsmFile,
+    set_env_map_scale: &mut bool,
+    touched: &mut bool,
+) {
+    if !*set_env_map_scale && bgsm.base.environment_mapping {
+        material.env_map_scale = bgsm.base.environment_mapping_mask_scale;
+        *set_env_map_scale = true;
+        *touched = true;
+    }
+}
+
 /// Process-lifetime cache of extracted Starfield CDB bytes, keyed by
 /// `"<archive source>|<in-archive path>"`. #2705 (SF-D3-01) —
 /// `build_material_provider` constructs a brand-new `MaterialProvider` (and
@@ -629,6 +708,21 @@ impl MaterialProvider {
 
     /// Seed a parsed BGEM directly so merge tests exercise the production
     /// dispatch path without constructing an archive fixture.
+    /// Seed a resolved BGSM chain directly so merge tests exercise the real
+    /// `merge_external_material` BGSM arm rather than a hand-copied mirror of
+    /// its loop (#2702's failure mode). The BGEM sibling below has existed
+    /// since the BGEM arm landed; this one was missing only because
+    /// `TemplateCache` had no insert.
+    #[cfg(test)]
+    pub(crate) fn insert_bgsm_for_test(
+        &mut self,
+        path: &str,
+        resolved: byroredux_bgsm::template::ResolvedMaterial,
+    ) {
+        let key = normalize_material_path(path).to_ascii_lowercase();
+        self.bgsm_cache.insert_resolved(&key, Arc::new(resolved));
+    }
+
     #[cfg(test)]
     pub(crate) fn insert_bgem_for_test(&mut self, path: &str, bgem: BgemFile) {
         let key = normalize_material_path(path).to_ascii_lowercase();
@@ -932,6 +1026,12 @@ pub(crate) fn merge_external_material(
     let mut set_blend = false;
     let mut set_fresnel = false;
     let mut set_palette_scale = false;
+    // #2607 — the v<8 rim / backlight / subsurface group. Backlight shares
+    // `set_rim`: the format gives it no enable bit of its own.
+    let mut set_rim = false;
+    let mut set_subsurface = false;
+    // #2608 — env-map mask scale, authored only on the v<10 base layout.
+    let mut set_env_map_scale = false;
     // #2212 (NIFAL-D8-01) — chain-local, unlike `material.alpha_test`
     // itself. The NIF F4SF2 bit-25 path (`dedicated_shader.rs`) can
     // pre-set `material.alpha_test = true` before this loop ever runs, so
@@ -1048,6 +1148,13 @@ pub(crate) fn merge_external_material(
         let roughness = (1.0 - leaf.smoothness).clamp(0.04, 1.0);
         material.metalness_override = Some(metalness);
         material.roughness_override = Some(roughness);
+        // #2609 — the flag whose meaning is "authoritative PBR scalars were
+        // merged", set at the exact site that merges them. `from_bgsm` above
+        // cannot serve that role: the BGEM arm sets it too while leaving both
+        // overrides `None` (BGEM authors no smoothness/specular), so a
+        // consumer reading `from_bgsm` as "scalars present" is wrong on every
+        // effect material. Keep this write adjacent to the two it describes.
+        material.bgsm_pbr_scalars_authored = true;
         if metalness > 0.5 {
             // #1591 — blend toward the mult-free `specular_color`, NOT
             // `spec_*` (= specular_color × specular_mult); the mult-bearing
@@ -1227,6 +1334,19 @@ pub(crate) fn merge_external_material(
                 set_palette_scale = true;
                 touched = true;
             }
+            // #2607 / #2608 (FO4-D7-02 / FO4-D7-03) — two more BGSM field
+            // groups that decoded correctly and were dropped at this exact
+            // hop. Both are enable-bit gated; see the fn docs for why
+            // unconditional forwarding would be fabrication rather than
+            // translation.
+            forward_bgsm_rim_subsurface(
+                material,
+                bgsm,
+                &mut set_rim,
+                &mut set_subsurface,
+                &mut touched,
+            );
+            forward_bgsm_env_map_scale(material, bgsm, &mut set_env_map_scale, &mut touched);
             if !set_alpha {
                 material.mat_alpha = bgsm.base.alpha;
                 set_alpha = true;
@@ -1465,15 +1585,26 @@ pub(crate) fn merge_external_material(
             // #2109 (SF-D9-02) — the v21+/v22 glass-overlay suite
             // (`glass_fresnel_color`, `glass_refraction_scale_base`,
             // `glass_blur_scale_base`, `glass_blur_scale_factor`,
-            // `glass_roughness_scratch`, `glass_dirt_overlay`) and
-            // `environment_mapping_mask_scale` all decode correctly on the
-            // BGEM parser side (`bgem.rs`) but have no `ImportedMesh` sink
-            // here — same deferred-consumer class as `emittance_color`
-            // above. Mod-added FO76/Starfield-era BGEM glass renders with
-            // engine-default refraction/tint instead of these authored
-            // values; low severity, since the renderer has no binding to
-            // consume them yet even if forwarded. Deferred renderer-
-            // binding follow-up, not a parser gap.
+            // `glass_roughness_scratch`, `glass_dirt_overlay`) decodes
+            // correctly on the BGEM parser side (`bgem.rs`) but has no
+            // `ImportedMesh` sink here — same deferred-consumer class as
+            // `emittance_color` above. Mod-added FO76/Starfield-era BGEM
+            // glass renders with engine-default refraction/tint instead of
+            // these authored values; low severity, since the renderer has no
+            // binding to consume them yet even if forwarded. Deferred
+            // renderer-binding follow-up, not a parser gap.
+            //
+            // #2608 correction: `environment_mapping_mask_scale` was listed
+            // above as sink-less, and no longer is —
+            // `ImportedMaterial.env_map_scale` is now wired on the BGSM arm
+            // (`forward_bgsm_env_map_scale`), and `env_mapping_enabled()` is
+            // the exact authored gate on this side. It is left unforwarded
+            // DELIBERATELY rather than overlooked: BGEM leaves the PBR
+            // overrides `None`, so `Material::resolve_pbr` runs its keyword
+            // classifier, whose `env_map_scale > 0.3` arm would then start
+            // moving roughness on every env-mapped FO4 effect material. That
+            // is a shading change to evaluate on its own evidence, not a
+            // drop to fix in passing.
         }
         // Soft-particle depth fade + view-angle falloff cone. The NIF
         // `BSEffectShaderProperty` path fills `material.effect_shader` from the

--- a/byroredux/src/asset_provider/tests/bgsm_merge.rs
+++ b/byroredux/src/asset_provider/tests/bgsm_merge.rs
@@ -237,6 +237,178 @@ fn bgsm_merge_forwards_phase1_shader_flags() {
     assert!(touched);
 }
 
+/// Regression for #2607 (FO4-D7-02) — BGSM's v<8 rim / backlight /
+/// subsurface group reached `ImportedMaterial`'s long-existing sinks, which
+/// `translate_material` already forwards onto the canonical `Material`. Before
+/// this, every BGSM-authored surface fed the (now unconditionally live, #1352)
+/// Disney subsurface/rimlight lobe hardcoded zeros no matter what the artist
+/// wrote.
+#[test]
+fn bgsm_merge_forwards_rim_and_subsurface_when_enabled() {
+    let bgsm = BgsmFile {
+        rim_lighting: true,
+        rim_power: 4.5,
+        back_light_power: 1.25,
+        subsurface_lighting: true,
+        subsurface_lighting_rolloff: 0.75,
+        ..Default::default()
+    };
+
+    let mut material = ImportedMaterial::default();
+    let (mut set_rim, mut set_subsurface, mut touched) = (false, false, false);
+    forward_bgsm_rim_subsurface(
+        &mut material,
+        &bgsm,
+        &mut set_rim,
+        &mut set_subsurface,
+        &mut touched,
+    );
+
+    assert_eq!(material.rimlight_power, 4.5);
+    assert_eq!(
+        material.backlight_power, 1.25,
+        "backlight rides the rim enable bit — the format gives it none of its own"
+    );
+    assert_eq!(material.subsurface_rolloff, 0.75);
+    assert!(touched);
+}
+
+/// The gate half of #2607, and the load-bearing one. The parser reads this
+/// whole group ONLY on the `version < 8` branch — v>=8 spends those bytes on
+/// the translucency suite — so a modern BGSM arrives with `rim_power = 2.0`
+/// and `subsurface_lighting_rolloff = 0.3` still at their struct defaults,
+/// never having been read off disk. Forwarding those would be fabrication.
+/// The enable bools are false in exactly that case.
+#[test]
+fn bgsm_merge_does_not_forward_never_parsed_rim_defaults() {
+    // Exactly what `BgsmFile::parse` leaves behind for a v>=8 file: the
+    // enables never read (so `false`), the payloads still holding the seed
+    // values the parse initializer sets before the version branch — 2.0 and
+    // 0.3, from `crates/bgsm/src/bgsm.rs`. Written out rather than taken from
+    // `BgsmFile::default()`, which zeroes them and so would not model the
+    // never-parsed case this gate exists for.
+    let bgsm = BgsmFile {
+        base: byroredux_bgsm::BaseMaterial {
+            version: 8,
+            ..Default::default()
+        },
+        rim_lighting: false,
+        rim_power: 2.0,
+        back_light_power: 0.0,
+        subsurface_lighting: false,
+        subsurface_lighting_rolloff: 0.3,
+        ..Default::default()
+    };
+
+    let mut material = ImportedMaterial::default();
+    let (mut set_rim, mut set_subsurface, mut touched) = (false, false, false);
+    forward_bgsm_rim_subsurface(
+        &mut material,
+        &bgsm,
+        &mut set_rim,
+        &mut set_subsurface,
+        &mut touched,
+    );
+
+    assert_eq!(material.rimlight_power, 0.0);
+    assert_eq!(material.backlight_power, 0.0);
+    assert_eq!(material.subsurface_rolloff, 0.0);
+    assert!(
+        !touched,
+        "a disabled group must not count as merged authored data"
+    );
+}
+
+/// Child-first precedence, matching every other payload field in the walk:
+/// a closer BGSM that authored the group wins, and an ancestor cannot
+/// overwrite it.
+#[test]
+fn bgsm_merge_rim_subsurface_honors_child_first_chain() {
+    let child = BgsmFile {
+        rim_lighting: true,
+        rim_power: 4.0,
+        subsurface_lighting: true,
+        subsurface_lighting_rolloff: 0.9,
+        ..Default::default()
+    };
+    let parent = BgsmFile {
+        rim_lighting: true,
+        rim_power: 99.0,
+        subsurface_lighting: true,
+        subsurface_lighting_rolloff: 99.0,
+        ..Default::default()
+    };
+
+    let mut material = ImportedMaterial::default();
+    let (mut set_rim, mut set_subsurface, mut touched) = (false, false, false);
+    for bgsm in [&child, &parent] {
+        forward_bgsm_rim_subsurface(
+            &mut material,
+            bgsm,
+            &mut set_rim,
+            &mut set_subsurface,
+            &mut touched,
+        );
+    }
+
+    assert_eq!(material.rimlight_power, 4.0, "child must win");
+    assert_eq!(material.subsurface_rolloff, 0.9, "child must win");
+}
+
+/// Regression for #2608 (FO4-D7-03) — the authored env-map mask scale reaches
+/// `ImportedMaterial.env_map_scale`, which `translate_material` already
+/// forwards to the canonical `Material`.
+#[test]
+fn bgsm_merge_forwards_authored_env_map_mask_scale() {
+    let bgsm = BgsmFile {
+        base: byroredux_bgsm::BaseMaterial {
+            version: 2,
+            environment_mapping: true,
+            environment_mapping_mask_scale: 2.5,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut material = ImportedMaterial::default();
+    let (mut set_scale, mut touched) = (false, false);
+    forward_bgsm_env_map_scale(&mut material, &bgsm, &mut set_scale, &mut touched);
+
+    assert_eq!(material.env_map_scale, 2.5);
+    assert!(touched);
+}
+
+/// The gate half of #2608. From version 10 the `(environment_mapping,
+/// environment_mapping_mask_scale)` bytes became `depth_bias`, and the parser
+/// substitutes a synthetic `(false, 1.0)`. That 1.0 is not authored data:
+/// forwarding it would put every modern BGSM above `resolve_pbr`'s
+/// `env_map_scale > 0.3` arm, fabricating reflection intent that then drives
+/// real roughness on the bulk of FO4 content.
+#[test]
+fn bgsm_merge_does_not_forward_synthetic_v10_env_map_scale() {
+    let bgsm = BgsmFile {
+        base: byroredux_bgsm::BaseMaterial {
+            version: 10,
+            environment_mapping: false,
+            // Exactly what `parse_after_magic` substitutes on the v>=10 path.
+            environment_mapping_mask_scale: 1.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut material = ImportedMaterial::default();
+    let before = material.env_map_scale;
+    let (mut set_scale, mut touched) = (false, false);
+    forward_bgsm_env_map_scale(&mut material, &bgsm, &mut set_scale, &mut touched);
+
+    assert_eq!(
+        material.env_map_scale, before,
+        "a never-parsed 1.0 must not reach the canonical material"
+    );
+    assert!(!touched);
+}
+
 /// Companion: with all three flags `false` on the BGSM, the
 /// translucency / model-space-normal mesh fields must stay at their
 /// defaults (a `false` author doesn't override). `is_pbr` is the
@@ -658,6 +830,133 @@ fn bgem_merge_leaves_palette_disabled_when_neither_enable_bit_is_authored() {
         "neither grayscale_to_palette_color nor _alpha was authored — the \
          remap must stay disabled despite the filled LUT slot (#2108)"
     );
+}
+
+/// Regression for #2609 (FO4-D7-04) — `from_bgsm` and
+/// `bgsm_pbr_scalars_authored` mean different things, and the BGEM arm is
+/// where they diverge.
+///
+/// Pre-split, `from_bgsm` was set identically on both arms while only the
+/// BGSM arm populated `metalness_override`/`roughness_override`, so any
+/// consumer reading it as "PBR scalars authored" — which is precisely what
+/// #2606's fix needed — would be wrong on every effect material. The BGEM arm
+/// keeps `from_bgsm` (it is load-bearing for the FO4-vs-Skyrim glass-keyword
+/// discriminator, #2710) and must leave the scalar flag clear.
+#[test]
+fn bgem_merge_sets_provenance_but_not_the_scalar_authored_flag() {
+    let mut pool = byroredux_core::string::StringPool::new();
+    let path = "materials/tests/scalar_flag.bgem";
+    let mut provider = MaterialProvider::new();
+    provider.insert_bgem_for_test(path, BgemFile::default());
+    let mut mesh = imported_mesh_with_material_path(&mut pool, path);
+
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool).merged());
+
+    assert!(
+        mesh.material.from_bgsm,
+        "provenance stays set on the BGEM arm — #2710's glass discriminator \
+         depends on it"
+    );
+    assert!(
+        !mesh.material.bgsm_pbr_scalars_authored,
+        "BGEM authors no smoothness/specular, so it must not claim to have \
+         authored PBR scalars (#2609)"
+    );
+    assert_eq!(
+        (
+            mesh.material.metalness_override,
+            mesh.material.roughness_override
+        ),
+        (None, None),
+        "the flag's meaning must match what the arm actually populated"
+    );
+}
+
+/// The other half of #2609, and the one that keeps #2606's fix from becoming
+/// a silent no-op: the BGSM arm must SET `bgsm_pbr_scalars_authored`, right
+/// where it populates the two overrides the flag describes. If that write went
+/// missing, every FO4 BGSM would fall back through the #2606 gate again with
+/// nothing to catch it.
+///
+/// Drives the real `merge_external_material` BGSM arm via the seeded template
+/// cache — not a mirror of its loop.
+#[test]
+fn bgsm_merge_sets_the_scalar_authored_flag_alongside_the_overrides() {
+    let mut pool = byroredux_core::string::StringPool::new();
+    let path = "materials/tests/scalar_flag.bgsm";
+    let mut provider = MaterialProvider::new();
+    provider.insert_bgsm_for_test(
+        path,
+        ResolvedMaterial {
+            file: BgsmFile {
+                smoothness: 0.8,
+                specular_color: [1.0, 1.0, 1.0],
+                specular_mult: 1.0,
+                ..Default::default()
+            },
+            parent: None,
+        },
+    );
+    let mut mesh = imported_mesh_with_material_path(&mut pool, path);
+
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool).merged());
+
+    assert!(mesh.material.from_bgsm, "provenance");
+    assert!(
+        mesh.material.bgsm_pbr_scalars_authored,
+        "the BGSM arm authored metalness/roughness, so the flag gating \
+         #2606's overwrite must be set"
+    );
+    assert!(mesh.material.metalness_override.is_some());
+    assert!(
+        mesh.material.roughness_override.is_some(),
+        "roughness = 1 - smoothness is exactly what #2606 protects"
+    );
+    // 1 - 0.8, clamped to the renderer's [0.04, 1.0] band.
+    let roughness = mesh.material.roughness_override.unwrap();
+    assert!(
+        (roughness - 0.2).abs() < 1e-5,
+        "authored smoothness must drive roughness; got {roughness}"
+    );
+}
+
+/// End-to-end companion for #2607/#2608 through the real merge: an authored
+/// v<10 BGSM carrying rim, subsurface and env-mask values lands all of them on
+/// `ImportedMaterial`. The extracted-function tests above pin the gates; this
+/// pins that the merge loop actually calls them.
+#[test]
+fn bgsm_merge_forwards_rim_subsurface_and_env_scale_end_to_end() {
+    let mut pool = byroredux_core::string::StringPool::new();
+    let path = "materials/tests/rim_env.bgsm";
+    let mut provider = MaterialProvider::new();
+    provider.insert_bgsm_for_test(
+        path,
+        ResolvedMaterial {
+            file: BgsmFile {
+                rim_lighting: true,
+                rim_power: 3.5,
+                back_light_power: 0.5,
+                subsurface_lighting: true,
+                subsurface_lighting_rolloff: 0.6,
+                base: byroredux_bgsm::BaseMaterial {
+                    version: 2,
+                    environment_mapping: true,
+                    environment_mapping_mask_scale: 1.75,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            parent: None,
+        },
+    );
+    let mut mesh = imported_mesh_with_material_path(&mut pool, path);
+
+    assert!(merge_external_material(&mut mesh.material, &mut provider, &mut pool).merged());
+
+    assert_eq!(mesh.material.rimlight_power, 3.5);
+    assert_eq!(mesh.material.backlight_power, 0.5);
+    assert_eq!(mesh.material.subsurface_rolloff, 0.6);
+    assert_eq!(mesh.material.env_map_scale, 1.75);
 }
 
 /// The `grayscale_to_palette_color` enable bit alone (no alpha variant)

--- a/byroredux/src/cell_loader/spawn/mesh_instance.rs
+++ b/byroredux/src/cell_loader/spawn/mesh_instance.rs
@@ -550,7 +550,13 @@ pub(super) fn spawn_mesh_instance(
     // attached, instead of recomputing it per
     // draw in the render path. Reads the same components the renderer
     // reads, so the value is identical — only canonical + tooling-visible.
-    crate::material_translate::resolve_normal_alpha_spec_roughness(world, entity);
+    // #2606 — pass the "a real BGSM authored the PBR scalars" signal so the
+    // legacy fallback cannot clobber them.
+    crate::material_translate::resolve_normal_alpha_spec_roughness(
+        world,
+        entity,
+        mesh.material.bgsm_pbr_scalars_authored,
+    );
     // #2826 (REN-D19-02) — same "resolve once from MaterialTextureHandles"
     // pattern, for whether the model-space normal map's blue channel
     // carries authored Z.

--- a/byroredux/src/material_translate.rs
+++ b/byroredux/src/material_translate.rs
@@ -294,7 +294,31 @@ pub(crate) fn normal_alpha_spec_roughness(
     normal_map_index: u32,
     gloss_map_index: u32,
     normal_has_alpha: bool,
+    bgsm_pbr_scalars_authored: bool,
 ) -> Option<f32> {
+    // #2606 (FO4-D7-01) — never overwrite roughness a real material file
+    // authored. This is a Skyrim/Gamebryo-era fallback for content that
+    // supplies no smoothness signal at all; an FO4 BGSM supplies one
+    // directly (`roughness = 1 - smoothness`), so for BGSM content the
+    // heuristic has nothing to add and everything to lose.
+    //
+    // Live, not latent: `ImportedMaterial::default().env_map_scale` is 0.0,
+    // so the `env_map_scale <= 0.3` gate below is satisfied by DEFAULT rather
+    // than only when a low value was authored — and #2608 shows the BGSM merge
+    // has no authored value to put there for a v>=10 material. Any BGSM with a
+    // normal map, no smooth/spec texture and `specular_mult > 1.2` therefore
+    // reached the overwrite. #1352 makes it bite: `MAT_FLAG_PBR_BSDF` is now
+    // unconditional for BGSM content, so the Disney lobe consumes the
+    // clobbered roughness directly.
+    //
+    // Gated on `bgsm_pbr_scalars_authored`, NOT on `from_bgsm`/`BGSM_AUTHORED`
+    // (which the BGEM arm sets while leaving both overrides `None` — #2609)
+    // and NOT on `roughness_override.is_some()` (true for keyword-classified
+    // legacy content too, which would disable this fallback for the very
+    // population it exists to serve).
+    if bgsm_pbr_scalars_authored {
+        return None;
+    }
     if !normal_alpha_spec_applies(
         material_kind,
         metalness,
@@ -326,7 +350,11 @@ pub(crate) fn normal_alpha_spec_roughness(
 /// its timing (once at spawn, not every frame) change. Idempotent (see
 /// [`normal_alpha_spec_roughness`]). Call after all three components are
 /// attached to `entity`.
-pub(crate) fn resolve_normal_alpha_spec_roughness(world: &mut World, entity: EntityId) {
+pub(crate) fn resolve_normal_alpha_spec_roughness(
+    world: &mut World,
+    entity: EntityId,
+    bgsm_pbr_scalars_authored: bool,
+) {
     let Some((material_kind, metalness, env_map_scale, glossiness, specular_strength)) =
         world.get::<Material>(entity).map(|m| {
             (
@@ -359,6 +387,7 @@ pub(crate) fn resolve_normal_alpha_spec_roughness(world: &mut World, entity: Ent
         normal_map_index,
         gloss_map_index,
         normal_has_alpha,
+        bgsm_pbr_scalars_authored,
     ) {
         if let Some(m) = world.get_mut::<Material>(entity) {
             m.roughness = r;
@@ -494,16 +523,18 @@ mod tests {
     #[test]
     fn alpha_normal_preserves_translate_resolved_roughness() {
         // Normal alpha is specular intensity, never gloss/roughness.
-        let r =
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 80.0, 1.0, PASS.3, PASS.4, true);
+        let r = normal_alpha_spec_roughness(
+            PASS.0, PASS.1, PASS.2, 80.0, 1.0, PASS.3, PASS.4, true, false,
+        );
         assert_eq!(r, None);
     }
 
     #[test]
     fn alphaless_normal_uses_specular_strength_when_above_neutral() {
         // specular_strength 2.0 → 0.85 - (1.0)*0.1 = 0.75.
-        let r =
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 80.0, 2.0, PASS.3, PASS.4, false);
+        let r = normal_alpha_spec_roughness(
+            PASS.0, PASS.1, PASS.2, 80.0, 2.0, PASS.3, PASS.4, false, false,
+        );
         assert!((r.unwrap() - 0.75).abs() < 1e-5, "{r:?}");
     }
 
@@ -511,9 +542,79 @@ mod tests {
     fn alphaless_normal_with_neutral_specular_keeps_resolved_roughness() {
         // specular_strength 1.0 (<= 1.2) and no normal alpha → None (caller
         // keeps the translate-resolved roughness, no override).
-        let r =
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 80.0, 1.0, PASS.3, PASS.4, false);
+        let r = normal_alpha_spec_roughness(
+            PASS.0, PASS.1, PASS.2, 80.0, 1.0, PASS.3, PASS.4, false, false,
+        );
         assert_eq!(r, None);
+    }
+
+    /// Regression for #2606 (FO4-D7-01) — a BGSM that authored its own PBR
+    /// scalars must keep the roughness `merge_external_material` derived from
+    /// its `smoothness`, never have it replaced by this Skyrim-era fallback.
+    ///
+    /// The inputs are the real trigger shape, not a contrived one:
+    /// `env_map_scale = 0.0` is `ImportedMaterial`'s DEFAULT (so the
+    /// `<= 0.3` gate was satisfied without anything authoring a low value —
+    /// which is what made this live rather than latent), plus a normal map,
+    /// no smooth/spec texture, and `specular_mult > 1.2`. Both arms are
+    /// asserted in one body: the `false` arm proves the overwrite still
+    /// happens for the legacy population this fallback exists to serve, so
+    /// the `true` arm cannot pass vacuously.
+    #[test]
+    fn authored_bgsm_scalars_survive_the_normal_alpha_spec_fallback() {
+        const DEFAULT_ENV_MAP_SCALE: f32 = 0.0;
+        let call = |authored: bool| {
+            normal_alpha_spec_roughness(
+                0,   // lit material kind
+                0.0, // metalness < 0.3
+                DEFAULT_ENV_MAP_SCALE,
+                80.0,
+                2.0, // specular_mult > 1.2
+                7,   // normal map bound
+                0,   // no dedicated gloss/spec map
+                false,
+                authored,
+            )
+        };
+
+        assert_eq!(
+            call(true),
+            None,
+            "BGSM-authored roughness must not be overwritten by the heuristic"
+        );
+        assert!(
+            call(false).is_some(),
+            "the same inputs without authored scalars must still take the \
+             legacy fallback — otherwise the assertion above proves nothing"
+        );
+    }
+
+    /// #2609 — the gate is specifically NOT `from_bgsm`/`BGSM_AUTHORED`.
+    /// A BGEM sets those while leaving both overrides `None`, so an effect
+    /// material has no authored roughness to protect and must keep taking the
+    /// fallback like any other non-BGSM content.
+    #[test]
+    fn bgem_provenance_alone_does_not_suppress_the_fallback() {
+        let material = ImportedMaterial {
+            from_bgsm: true,
+            bgsm_pbr_scalars_authored: false,
+            ..Default::default()
+        };
+        assert!(
+            normal_alpha_spec_roughness(
+                0,
+                0.0,
+                0.0,
+                80.0,
+                2.0,
+                7,
+                0,
+                false,
+                material.bgsm_pbr_scalars_authored,
+            )
+            .is_some(),
+            "`from_bgsm` is provenance, not a scalar-authored signal"
+        );
     }
 
     #[test]
@@ -536,7 +637,9 @@ mod tests {
     fn roughness_clamps_to_renderer_ranges() {
         // huge specular_strength → 0.85 - big, clamped to 0.4 floor.
         assert_eq!(
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 80.0, 99.0, PASS.3, PASS.4, false),
+            normal_alpha_spec_roughness(
+                PASS.0, PASS.1, PASS.2, 80.0, 99.0, PASS.3, PASS.4, false, false
+            ),
             Some(0.4)
         );
     }
@@ -544,8 +647,9 @@ mod tests {
     #[test]
     fn alpha_normal_ignores_even_non_finite_glossiness() {
         for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
-            let r =
-                normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, bad, 1.0, PASS.3, PASS.4, true);
+            let r = normal_alpha_spec_roughness(
+                PASS.0, PASS.1, PASS.2, bad, 1.0, PASS.3, PASS.4, true, false,
+            );
             assert_eq!(
                 r, None,
                 "normal-alpha spec intensity must not derive roughness from {bad}"
@@ -559,10 +663,12 @@ mod tests {
         // prior write is a no-op —
         // the property that makes the resolve-at-spawn relocation safe to run
         // more than once (#1480).
-        let first =
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 65.0, 2.0, PASS.3, PASS.4, false);
-        let second =
-            normal_alpha_spec_roughness(PASS.0, PASS.1, PASS.2, 65.0, 2.0, PASS.3, PASS.4, false);
+        let first = normal_alpha_spec_roughness(
+            PASS.0, PASS.1, PASS.2, 65.0, 2.0, PASS.3, PASS.4, false, false,
+        );
+        let second = normal_alpha_spec_roughness(
+            PASS.0, PASS.1, PASS.2, 65.0, 2.0, PASS.3, PASS.4, false, false,
+        );
         assert_eq!(first, second);
         assert!((first.unwrap() - 0.75).abs() < 1e-5, "{first:?}");
     }

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -989,7 +989,13 @@ pub(crate) fn load_nif_bytes_with_skeleton(
         // ONCE into the canonical Material now that MaterialTextureHandles is
         // attached (mirrors the cell-loader spawn
         // path), instead of recomputing it per draw in the render path.
-        crate::material_translate::resolve_normal_alpha_spec_roughness(world, entity);
+        // #2606 — pass the "a real BGSM authored the PBR scalars" signal so
+        // the legacy fallback cannot clobber them.
+        crate::material_translate::resolve_normal_alpha_spec_roughness(
+            world,
+            entity,
+            mesh.material.bgsm_pbr_scalars_authored,
+        );
         // #2826 (REN-D19-02) — same pattern, for whether the model-space
         // normal map's blue channel carries authored Z.
         crate::material_translate::resolve_msn_z_source(world, entity);

--- a/crates/bgsm/src/template.rs
+++ b/crates/bgsm/src/template.rs
@@ -137,6 +137,23 @@ impl TemplateCache {
         self.entries.is_empty()
     }
 
+    /// Seed an already-resolved chain under `path`, bypassing the resolver.
+    ///
+    /// Exists so callers can drive their BGSM code paths against synthetic
+    /// materials without standing up archive IO. Before this, the engine's
+    /// BGSM merge tests had no way to reach the real `merge_external_material`
+    /// BGSM arm at all (the BGEM arm had `insert_bgem_for_test`, backed by a
+    /// plain `HashMap`, but this cache had no insert), so they tested
+    /// hand-copied mirrors of the merge loop instead — the failure mode #2702
+    /// documents, where a mirror silently diverged from production and the
+    /// suite stayed green.
+    ///
+    /// Keys are lowercased like [`Self::resolve`]'s, and the entry
+    /// participates in normal LRU bookkeeping.
+    pub fn insert_resolved(&mut self, path: &str, resolved: Arc<ResolvedMaterial>) {
+        self.insert(path.to_ascii_lowercase(), resolved);
+    }
+
     /// Resolve a BGSM + its template chain. The same path is guaranteed
     /// to return `Arc::ptr_eq`-identical results between calls as long
     /// as the entry stays in the cache.

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -1329,6 +1329,11 @@ impl MaterialInfo {
             from_bgsm: false,
             bgem_glass: false,
             thin_glass: false,
+            // #2609 — the NIF importer never reads an external material file,
+            // so the overrides below are the keyword classifier's guess, not
+            // authored scalars. Consumers gating on "authoritative" must see
+            // false here even when `metalness_override` is `Some`.
+            bgsm_pbr_scalars_authored: false,
             // #2707 (SF-D8-01) — `None` when `classify_legacy_pbr` had
             // literally no signal to classify from (the Starfield
             // material-reference stub case), so `translate_material` seeds

--- a/crates/nif/src/import/types.rs
+++ b/crates/nif/src/import/types.rs
@@ -458,9 +458,28 @@ pub struct ImportedMaterial {
     pub is_pbr: bool,
     pub has_translucency: bool,
     pub model_space_normals: bool,
+    /// **Provenance only**: an external `.bgsm` *or* `.bgem` file resolved for
+    /// this material. Says nothing about which fields it supplied — the BGEM
+    /// arm sets this too, and BGEM authors no smoothness/specular at all.
+    /// Load-bearing for the FO4-vs-Skyrim glass-keyword discriminator
+    /// (`classify_glass_into_material`, #2710), which is why it stays set on
+    /// both arms. For "authoritative PBR scalars were merged" use
+    /// [`Self::bgsm_pbr_scalars_authored`] instead (#2609).
     pub from_bgsm: bool,
     pub bgem_glass: bool,
     pub thin_glass: bool,
+    /// #2609 — the BGSM arm of `merge_external_material` resolved authoritative
+    /// spec-glossiness scalars and wrote them into
+    /// [`Self::metalness_override`] / [`Self::roughness_override`].
+    ///
+    /// Distinct from [`Self::from_bgsm`], which is set on the BGEM arm as well
+    /// even though BGEM leaves both overrides `None`. It is also distinct from
+    /// `roughness_override.is_some()`: legacy inline-NIF content arrives with
+    /// `Some(...)` from the keyword classifier, which is a *guess*, not
+    /// authored data. Only this flag means "a real material file said so", so
+    /// it is the correct gate for any heuristic that would otherwise overwrite
+    /// resolved roughness.
+    pub bgsm_pbr_scalars_authored: bool,
     pub metalness_override: Option<f32>,
     pub roughness_override: Option<f32>,
     pub translucency_subsurface_color: [f32; 3],
@@ -549,6 +568,7 @@ impl Default for ImportedMaterial {
             from_bgsm: false,
             bgem_glass: false,
             thin_glass: false,
+            bgsm_pbr_scalars_authored: false,
             metalness_override: None,
             roughness_override: None,
             translucency_subsurface_color: [0.0; 3],


### PR DESCRIPTION
Closes #2609, #2606, #2607, #2608 — four interlocking findings at the FO4 BGSM merge boundary, landed in dependency order.

**#2609** — `from_bgsm` was set on both the BGSM and BGEM arms while only BGSM populates `metalness_override`/`roughness_override`, so it could not serve as the "PBR scalars authored" gate #2606 needed. It can't simply move, either: it's load-bearing as *provenance* for the glass-keyword discriminator (#2710). Split instead — `from_bgsm` keeps provenance, and a new `ImportedMaterial::bgsm_pbr_scalars_authored` is written beside the two overrides it describes. Also deliberately not `roughness_override.is_some()`, which is `Some(..)` for keyword-classified legacy content too.

**#2606** — `resolve_normal_alpha_spec_roughness` is a Skyrim-era fallback for content with no smoothness signal; an FO4 BGSM has one (`1 - smoothness`), and #1352 made the Disney lobe consume it unconditionally. Live because `ImportedMaterial::default().env_map_scale` is 0.0, satisfying the `<= 0.3` gate by default. Now gated on the new flag, threaded from both spawn sites. The shared `normal_alpha_spec_applies` predicate is untouched, so the render path's per-draw `NORMAL_ALPHA_SPEC_BIT` is unchanged — only the roughness write is gated.

**#2607 / #2608** — BGSM's rim/backlight/subsurface group and env-map mask scale both parse fine and have had `ImportedMaterial` sinks since #2284; only this hop was missing. Both forwards are **enable-bit gated**, which is the load-bearing half: the parser reads these groups only on `version < 8` / `version < 10` and otherwise leaves seed values (`2.0`, `0.3`, a synthetic `1.0`) that would be fabrication if forwarded — the env-map one especially, since `resolve_pbr`'s `env_map_scale > 0.3` arm would read a never-parsed 1.0 as authored intent. `back_light_power` is included; the issue lists four fields but the parse branch has five.

The forwards are extracted into named functions (the #2702 precedent) so tests drive production logic. That mattered here: this file had no way to reach the real BGSM arm at all — `TemplateCache` had no insert while the BGEM cache did — which is why its BGSM coverage was mirror-based. `TemplateCache::insert_resolved` closes that, and two tests now drive the real arm end to end, including #2609's positive half (without it, a lost flag write would silently revert #2606 to a no-op).

**Deliberately not fixed**: BGEM's own `environment_mapping_mask_scale`. The sink now exists, but BGEM leaves the PBR overrides `None`, so forwarding it would start moving roughness on every env-mapped FO4 effect material via `resolve_pbr`'s classifier. The stale #2109 "no sink" comment is corrected in place so it reads as a decision.

`byroredux/src/render/fire_lights.rs`'s `derived_reach_is_currently_oversized_pending_a_unit_correct_derivation` fails on main — unrelated and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)