### PR TITLE
Fix #2751 #2752 #2734: indirect-draw clamp, readback allocation + invalidate, lazy navigator fetch

### DIFF
--- a/crates/renderer/src/vulkan/buffer.rs
+++ b/crates/renderer/src/vulkan/buffer.rs
@@ -503,7 +503,7 @@ pub(crate) const NON_COHERENT_ATOM_SIZE: vk::DeviceSize = 256;
 ///
 /// Used instead of `VK_WHOLE_SIZE` so flushes don't extend past the
 /// gpu-allocator sub-allocation into unrelated memory.
-fn aligned_flush_range(
+pub(crate) fn aligned_flush_range(
     offset: vk::DeviceSize,
     size: vk::DeviceSize,
 ) -> (vk::DeviceSize, vk::DeviceSize) {
@@ -743,6 +743,91 @@ impl GpuBuffer {
         })
     }
 
+    /// Create a host-visible buffer for device→host **readback**.
+    ///
+    /// #2752 / REN-D4-05 — the readback sibling of [`Self::create_host_visible`],
+    /// which pins `MemoryLocation::CpuToGpu`. The two locations are not
+    /// interchangeable: `CpuToGpu` exists for staging *uploads*, and
+    /// gpu-allocator resolves it toward `HOST_VISIBLE | HOST_COHERENT` —
+    /// frequently device-local BAR memory on a discrete card, i.e. uncached
+    /// write-combined from the CPU's point of view. `GpuToCpu` is the
+    /// readback preset and additionally prefers `HOST_CACHED`, which is what
+    /// a buffer the host drains every frame on the hot path actually wants.
+    ///
+    /// Kept as a separate constructor rather than a `location` parameter on
+    /// `create_host_visible` so that function's #423 audit guard ("every call
+    /// site MUST be per-frame mutable upload") keeps its meaning — a reader
+    /// checking either constructor's call sites is checking one intent, not
+    /// two.
+    ///
+    /// **`HOST_CACHED` is exactly the case where a missing invalidate becomes
+    /// observable**, so every caller must run [`Self::invalidate_if_needed`]
+    /// after the fence wait and before reading through
+    /// [`Self::mapped_slice_mut`]. That ordering is the whole point of this
+    /// pair — see #2740 (REN-D4-04) for why a fence alone does not make
+    /// device writes visible to the host.
+    pub fn create_host_readback(
+        device: &ash::Device,
+        allocator: &SharedAllocator,
+        size: vk::DeviceSize,
+        usage: vk::BufferUsageFlags,
+    ) -> Result<Self> {
+        let buffer_info = vk::BufferCreateInfo::default()
+            .size(size)
+            .usage(usage)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE);
+
+        // SAFETY: `device` is the caller's live logical device, valid for the
+        // call; `buffer_info` is a fully-populated valid VkBufferCreateInfo.
+        let buffer = unsafe {
+            device
+                .create_buffer(&buffer_info, None)
+                .context("Failed to create host-readback buffer")?
+        };
+
+        // SAFETY: `buffer` was just created by this device above and is live;
+        // the device outlives the call.
+        let requirements = unsafe { device.get_buffer_memory_requirements(buffer) };
+
+        let allocation = allocator
+            .lock()
+            .expect("allocator lock poisoned")
+            .allocate(&vulkan::AllocationCreateDesc {
+                name: "host_readback_buffer",
+                requirements,
+                location: MemoryLocation::GpuToCpu,
+                linear: true,
+                allocation_scheme: vulkan::AllocationScheme::GpuAllocatorManaged,
+            })
+            .context("Failed to allocate host-readback memory")?;
+        // Same mapping-policy tripwire as the upload path: every reader
+        // reaches `mapped_slice_mut` on its hot path, so catch a regression
+        // at construction rather than on the first drain.
+        debug_assert_cpu_to_gpu_mapped(&allocation, "create_host_readback");
+
+        // SAFETY: `buffer` and `allocation` were both created here from this
+        // device; the memory/offset come from the allocation that satisfied
+        // `buffer`'s memory requirements, and the buffer is not yet bound.
+        unsafe {
+            device
+                .bind_buffer_memory(buffer, allocation.memory(), allocation.offset())
+                .context("Failed to bind host-readback buffer")?;
+        }
+
+        let is_coherent = allocation
+            .memory_properties()
+            .contains(vk::MemoryPropertyFlags::HOST_COHERENT);
+
+        Ok(Self {
+            buffer,
+            size,
+            allocation: Some(allocation),
+            is_coherent,
+            device: device.clone(),
+            allocator: Some(allocator.clone()),
+        })
+    }
+
     /// Create a DEVICE_LOCAL buffer without initial data.
     ///
     /// Used for GPU-only buffers that are populated by device commands
@@ -807,18 +892,17 @@ impl GpuBuffer {
     /// Get the mapped memory slice for direct writes (no intermediate Vec).
     /// Call `flush_if_needed()` after writing to ensure GPU visibility.
     ///
-    /// #2793 (REN-D5-05) — this type has no `vkInvalidateMappedMemoryRanges`
-    /// counterpart to `flush_if_needed()`. That's fine for the write-then-
-    /// flush usage this doc comment describes, but a caller that instead
-    /// READS GPU-written bytes back through this same slice (e.g. an
+    /// #2793 (REN-D5-05) described the gap that #2752 then closed: a caller
+    /// that READS GPU-written bytes back through this slice (an
     /// atomic-counter buffer the shader writes and the host later drains)
-    /// gets no equivalent visibility guarantee from this type — it's
-    /// correct today only because every current `mapped_slice_mut` caller's
-    /// buffer is `create_host_visible` (`CpuToGpu`), and gpu-allocator
-    /// 0.27's `CpuToGpu` preset requires (not merely prefers)
-    /// `HOST_COHERENT`, so `is_coherent` is always `true` in practice. Add
-    /// an `invalidate_if_needed()` sibling to `flush_if_needed()` before
-    /// this type is ever used with a non-coherent-eligible allocation.
+    /// needs the device→host counterpart, not `flush_if_needed()`. That
+    /// counterpart now exists — [`Self::invalidate_if_needed`] — and every
+    /// reader must call it after the fence wait and before reading here.
+    /// The image-health buffers were the case in point: they are allocated
+    /// via [`Self::create_host_readback`] (`GpuToCpu`, which prefers
+    /// `HOST_CACHED`) precisely because they are drained every frame, and
+    /// `HOST_CACHED` is the memory type where skipping the invalidate stops
+    /// being theoretical.
     pub fn mapped_slice_mut(&mut self) -> Result<&mut [u8]> {
         let alloc = self
             .allocation
@@ -861,6 +945,56 @@ impl GpuBuffer {
                 device
                     .flush_mapped_memory_ranges(&[range])
                     .context("Failed to flush mapped memory")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Invalidate mapped memory if not HOST_COHERENT. Call BEFORE reading
+    /// device-written bytes back through [`Self::mapped_slice_mut`].
+    ///
+    /// #2752 / REN-D4-05 — the device→host counterpart to
+    /// [`Self::flush_if_needed`], and the prerequisite that let the
+    /// image-health buffers move to `MemoryLocation::GpuToCpu`. Waiting on a
+    /// fence proves the submission *completed*; it does not make the device's
+    /// writes *visible to the host*, because a fence's memory-dependency
+    /// access scope covers device access only (#2740 / REN-D4-04). On a
+    /// `HOST_CACHED` allocation — exactly what `GpuToCpu` prefers — the host
+    /// can otherwise read stale cache lines.
+    ///
+    /// A no-op on coherent memory, which is what the dev card resolves to, so
+    /// this is insurance against a memory-type change rather than something
+    /// observable here. That is also why it cannot be falsified by
+    /// `cargo test`: it needs a device that hands back a non-coherent
+    /// readback type, or a validation-layer run.
+    pub fn invalidate_if_needed(&mut self, device: &ash::Device) -> Result<()> {
+        let alloc = self
+            .allocation
+            .as_ref()
+            .context("Buffer has no allocation")?;
+
+        if !self.is_coherent {
+            let (aligned_offset, aligned_size) = aligned_flush_range(alloc.offset(), alloc.size());
+            debug_assert_flush_range_bounded(alloc, aligned_offset, aligned_size);
+            // SAFETY: identical range-widening argument to `flush_if_needed`
+            // above — `aligned_flush_range` rounds the offset DOWN and the
+            // size UP to `NON_COHERENT_ATOM_SIZE`, producing a strict
+            // SUPERSET of this allocation that stays inside the parent
+            // `GpuAllocatorManaged` block. Invalidating a superset is safe in
+            // a way flushing one is not: it discards possibly-stale host
+            // cache lines for a neighbouring suballocation, forcing a re-read
+            // from memory, rather than publishing this allocation's bytes
+            // over anything. `IMAGE_HEALTH_BUFFER_BYTES` is 8, far below a
+            // typical 64-byte `nonCoherentAtomSize`, so the widening is the
+            // normal case here, not the edge case.
+            unsafe {
+                let range = vk::MappedMemoryRange::default()
+                    .memory(alloc.memory())
+                    .offset(aligned_offset)
+                    .size(aligned_size);
+                device
+                    .invalidate_mapped_memory_ranges(&[range])
+                    .context("Failed to invalidate mapped memory")?;
             }
         }
         Ok(())
@@ -1375,6 +1509,75 @@ mod tests {
                 "aligned end must round UP, never down past the real end"
             );
         }
+    }
+
+    /// #2752 (REN-D4-05) — `IMAGE_HEALTH_BUFFER_BYTES` is 8, far below the
+    /// 256-byte `NON_COHERENT_ATOM_SIZE`, so for the readback buffer this fix
+    /// is about, the widening is the *normal* case rather than an edge case:
+    /// an 8-byte invalidate always covers a whole atom. That is sound for an
+    /// invalidate (it only discards possibly-stale host cache lines, forcing
+    /// a re-read) in a way it would not be for a flush, and it is why the
+    /// invalidate path can share `aligned_flush_range` unchanged.
+    #[test]
+    fn eight_byte_readback_range_widens_to_a_whole_atom() {
+        let (aligned_offset, aligned_size) = aligned_flush_range(0, 8);
+        assert_eq!(aligned_offset, 0);
+        assert_eq!(
+            aligned_size, NON_COHERENT_ATOM_SIZE,
+            "an 8-byte counter buffer invalidates a full atom, not 8 bytes"
+        );
+
+        // Mid-block placement: gpu-allocator suballocates on
+        // `VkMemoryRequirements.alignment`, so the image-health buffer will
+        // not generally start atom-aligned.
+        let (aligned_offset, aligned_size) = aligned_flush_range(NON_COHERENT_ATOM_SIZE + 8, 8);
+        assert_eq!(aligned_offset, NON_COHERENT_ATOM_SIZE);
+        assert!(
+            aligned_offset + aligned_size >= NON_COHERENT_ATOM_SIZE + 16,
+            "the widened range must still cover the real 8 bytes"
+        );
+    }
+
+    /// #2752 — the readback pair has to stay wired the way the fix left it,
+    /// and none of it is reachable from a unit test: the allocation location
+    /// needs a device, and on the dev card gpu-allocator resolves both
+    /// presets to coherent memory, so a missing invalidate is invisible
+    /// anyway (that's what #2740 means by "needs a device to falsify").
+    /// Source-scan is the honest pin — it catches the realistic regression,
+    /// which is someone copying `create_host_visible` into a new readback
+    /// site or dropping the invalidate as redundant.
+    #[test]
+    fn readback_constructor_uses_the_readback_memory_location() {
+        let src = include_str!("buffer.rs");
+        let start = src
+            .find("pub fn create_host_readback(")
+            .expect("create_host_readback must still exist (#2752)");
+        let body = &src[start..];
+        let end = body
+            .find("pub fn create_device_local_uninit(")
+            .expect("create_host_readback must still be followed by its sibling");
+        let body = &body[..end];
+        assert!(
+            body.contains("MemoryLocation::GpuToCpu"),
+            "the readback constructor must allocate GpuToCpu — CpuToGpu is \
+             the upload preset and steers toward uncached write-combined BAR"
+        );
+        assert!(
+            !body.contains("MemoryLocation::CpuToGpu"),
+            "no CpuToGpu allocation may survive inside the readback constructor"
+        );
+
+        // The invalidate primitive is the prerequisite that made the location
+        // switch safe; it must not be deleted as an apparent no-op.
+        assert!(
+            src.contains("pub fn invalidate_if_needed("),
+            "GpuBuffer::invalidate_if_needed is what makes a non-coherent \
+             readback allocation sound (#2740 / REN-D4-04)"
+        );
+        assert!(
+            src.contains("invalidate_mapped_memory_ranges"),
+            "invalidate_if_needed must actually issue vkInvalidateMappedMemoryRanges"
+        );
     }
 
     /// Regression for #2683 (SAFE-D4-01) — `flush_range_within` (the pure

--- a/crates/renderer/src/vulkan/context/draw.rs
+++ b/crates/renderer/src/vulkan/context/draw.rs
@@ -10,6 +10,7 @@ use super::super::scene_buffer::{
     INSTANCE_FLAG_DIFFUSE_ALPHA, INSTANCE_FLAG_FLAT_SHADING, INSTANCE_FLAG_NON_UNIFORM_SCALE,
     INSTANCE_FLAG_TERRAIN_SPLAT, INSTANCE_RENDER_LAYER_MASK, INSTANCE_RENDER_LAYER_SHIFT,
     INSTANCE_TERRAIN_TILE_MASK, INSTANCE_TERRAIN_TILE_SHIFT, MATERIAL_KIND_GLASS,
+    MAX_INDIRECT_DRAWS,
 };
 use super::super::sync::MAX_FRAMES_IN_FLIGHT;
 use super::super::upscaling::fsr_camera_parameters;
@@ -1196,12 +1197,38 @@ pub(super) fn needs_two_sided_blend_split(b: &DrawBatch) -> bool {
 /// (on a slot's first use) uninitialized command list — the GPU fetches
 /// and executes `index_count`/`vertex_offset` from it, so that's a
 /// page-fault/TDR risk, not a misrender.
+///
+/// #2751 / REN-D12-2026-08-12-01 adds the fourth: the batch count must fit
+/// the indirect buffer. `upload_indirect_draws` clamps its write to
+/// [`MAX_INDIRECT_DRAWS`] and warns — the RP-1 "log and continue" policy —
+/// but the draw loop walked the *unclamped* `batches` slice and derived
+/// `byte_offset = i * stride` from it, so an overflowing frame recorded a
+/// call whose `offset + drawCount × stride` ran past the allocation
+/// (`indirect_buffers[frame]` is sized exactly `MAX_INDIRECT_DRAWS`
+/// commands). That violates VUID-vkCmdDrawIndexedIndirect-offset-00556 and
+/// has the GPU fetch `indexCount`/`vertexOffset`/`firstInstance` from
+/// unallocated memory — device-lost class, the same failure #2504 closed on
+/// the upload-failure axis and left open on the overflow axis.
+///
+/// Rejecting the whole frame rather than clamping the loop is the safer of
+/// the two fixes the finding offers: the direct-draw fallback reads no
+/// indirect buffer at all, so every batch still renders. Clamping the loop
+/// would instead silently drop the tail beyond the ceiling, compounding the
+/// producer's own silent drop. Reachability is a deep tail — it needs
+/// >262 144 post-merge rasterized batches in one frame, ~20× the densest
+/// cell this codebase's own comments cite — which is why this is
+/// defence-in-depth at an already-declared lossy ceiling rather than a live
+/// spec violation.
 pub(super) fn should_use_indirect_draws(
     global_bound: bool,
     multi_draw_indirect_supported: bool,
     indirect_upload_ok: bool,
+    batch_count: usize,
 ) -> bool {
-    global_bound && multi_draw_indirect_supported && indirect_upload_ok
+    global_bound
+        && multi_draw_indirect_supported
+        && indirect_upload_ok
+        && batch_count <= MAX_INDIRECT_DRAWS
 }
 
 /// All per-frame inputs consumed by [`VulkanContext::draw_frame`].
@@ -4278,27 +4305,69 @@ mod should_use_indirect_draws_tests {
     //! `cmd_draw_indexed_indirect` reading a stale/uninitialized buffer.
     use super::*;
 
-    /// All three prerequisites hold — the happy path that actually reaches
+    /// All prerequisites hold — the happy path that actually reaches
     /// `cmd_draw_indexed_indirect`.
     #[test]
     fn true_when_bound_supported_and_upload_succeeded() {
-        assert!(should_use_indirect_draws(true, true, true));
+        assert!(should_use_indirect_draws(true, true, true, 1));
     }
 
     /// The regression case: everything else says "go indirect" but this
     /// frame's upload failed. Must fall back to direct draws.
     #[test]
     fn false_when_upload_failed_even_if_otherwise_eligible() {
-        assert!(!should_use_indirect_draws(true, true, false));
+        assert!(!should_use_indirect_draws(true, true, false, 1));
     }
 
     #[test]
     fn false_when_global_buffer_not_bound() {
-        assert!(!should_use_indirect_draws(false, true, true));
+        assert!(!should_use_indirect_draws(false, true, true, 1));
     }
 
     #[test]
     fn false_when_device_lacks_multi_draw_indirect() {
-        assert!(!should_use_indirect_draws(true, false, true));
+        assert!(!should_use_indirect_draws(true, false, true, 1));
+    }
+
+    /// #2751 / REN-D12-2026-08-12-01 — the batch count is the limb this
+    /// predicate was missing. `indirect_buffers[frame]` holds exactly
+    /// `MAX_INDIRECT_DRAWS` commands, and the draw loop derives its
+    /// `byte_offset` from the *unclamped* batch index, so one batch past the
+    /// ceiling is already a read past the allocation
+    /// (VUID-vkCmdDrawIndexedIndirect-offset-00556) — not a misrender but a
+    /// device-lost-class fetch of `indexCount`/`vertexOffset` from
+    /// unallocated memory.
+    #[test]
+    fn false_when_batch_count_exceeds_the_indirect_buffer() {
+        assert!(
+            !should_use_indirect_draws(true, true, true, MAX_INDIRECT_DRAWS + 1),
+            "one batch past the ceiling must reject the indirect path"
+        );
+        assert!(
+            !should_use_indirect_draws(true, true, true, MAX_INDIRECT_DRAWS * 4),
+            "a wildly overflowing frame must reject it too"
+        );
+    }
+
+    /// Exactly `MAX_INDIRECT_DRAWS` batches is the last legal count, not the
+    /// first illegal one: the loop's final `byte_offset + stride` lands
+    /// exactly on the buffer end. An off-by-one here would silently drop the
+    /// indirect path for a frame that fits.
+    #[test]
+    fn true_at_exactly_the_indirect_buffer_capacity() {
+        assert!(should_use_indirect_draws(
+            true,
+            true,
+            true,
+            MAX_INDIRECT_DRAWS
+        ));
+    }
+
+    /// An empty frame stays eligible — the draw loop simply records nothing.
+    /// Rejecting here would be harmless but would misattribute the fallback
+    /// in any future telemetry on this predicate.
+    #[test]
+    fn true_for_an_empty_batch_list() {
+        assert!(should_use_indirect_draws(true, true, true, 0));
     }
 }

--- a/crates/renderer/src/vulkan/context/geometry_pass.rs
+++ b/crates/renderer/src/vulkan/context/geometry_pass.rs
@@ -204,10 +204,15 @@ impl VulkanContext {
             // `false` means this frame's upload failed, so fall back to
             // direct draws rather than issue `cmd_draw_indexed_indirect`
             // over a stale/uninitialized buffer.
+            // #2751 — `batches.len()` is the fourth limb: the loop below
+            // derives `byte_offset` from `i` over this exact slice, so a
+            // count the indirect buffer can't hold must reject the path
+            // outright rather than record a read past the allocation.
             let use_indirect = should_use_indirect_draws(
                 global_bound,
                 self.device_caps.multi_draw_indirect_supported,
                 self.indirect_upload_ok,
+                batches.len(),
             );
             let indirect_buffer = self.scene_buffers.indirect_buffer(frame);
             let indirect_stride = std::mem::size_of::<vk::DrawIndexedIndirectCommand>() as u32;

--- a/crates/renderer/src/vulkan/context/mod.rs
+++ b/crates/renderer/src/vulkan/context/mod.rs
@@ -2802,10 +2802,19 @@ impl VulkanContext {
         )
         .context("create frame upscaler")?;
         // EX-05 / #2736 — one small host-visible counter buffer per frame slot.
+        //
+        // #2752 / REN-D4-05 — `create_host_readback` (`GpuToCpu`), not
+        // `create_host_visible` (`CpuToGpu`). The shader `atomicAdd`s into
+        // these and the HOST drains them every frame right after the fence
+        // wait, so they are readback buffers; allocating them from the upload
+        // preset put a per-frame host-read on memory gpu-allocator steers
+        // toward uncached write-combined BAR on a discrete card. `GpuToCpu`
+        // additionally prefers `HOST_CACHED` — which is exactly why
+        // `collect_image_health` must now invalidate before reading.
         let mut image_health_buffers = Vec::with_capacity(sync::MAX_FRAMES_IN_FLIGHT);
         for _ in 0..sync::MAX_FRAMES_IN_FLIGHT {
             image_health_buffers.push(
-                super::buffer::GpuBuffer::create_host_visible(
+                super::buffer::GpuBuffer::create_host_readback(
                     &device,
                     &gpu_allocator,
                     IMAGE_HEALTH_BUFFER_BYTES,
@@ -2817,9 +2826,16 @@ impl VulkanContext {
         // gpu-allocator makes no zero-init guarantee, so the very first frame
         // would otherwise read whatever was in the suballocation and report a
         // phantom NaN count before the shader had written anything.
+        //
+        // This is a host WRITE, so it needs the flush half of the pair — on a
+        // non-coherent readback type the zeroing would otherwise sit in a
+        // dirty cache line the shader's first `atomicAdd` never sees.
         for buffer in image_health_buffers.iter_mut() {
             if let Ok(bytes) = buffer.mapped_slice_mut() {
                 bytes.fill(0);
+            }
+            if let Err(e) = buffer.flush_if_needed(&device) {
+                log::warn!("image-health buffer zero-init flush failed: {e}");
             }
         }
         let health_handles: Vec<vk::Buffer> =

--- a/crates/renderer/src/vulkan/context/resources.rs
+++ b/crates/renderer/src/vulkan/context/resources.rs
@@ -96,25 +96,40 @@ impl VulkanContext {
     /// screen and then goes. A gate that only sampled the current frame would
     /// miss it; the total is what makes the smoke check reliable.
     ///
-    /// #2793 (REN-D5-05) — this reads GPU-written data through
-    /// `mapped_slice_mut()` with no `vkInvalidateMappedMemoryRanges` call
-    /// (`GpuBuffer` has no invalidate primitive at all), then writes the
-    /// reset-to-zero bytes back through the same mapping with no
-    /// `flush_if_needed()` — despite `mapped_slice_mut`'s own doc mandating
-    /// one after writes. Both omissions are visibility gaps on paper. They
-    /// are benign in practice ONLY because `image_health_buffers` is a
-    /// `create_host_visible` (`MemoryLocation::CpuToGpu`) allocation, and
-    /// gpu-allocator 0.27's `CpuToGpu` preset puts `HOST_COHERENT` in the
-    /// *required* (not just preferred) memory-property flags — so
-    /// `is_coherent` is always `true` here and both the GPU write and this
-    /// host read/write stay automatically visible to each other with no
-    /// explicit barrier. That's a property of this specific allocator
-    /// version, not a Vulkan-spec guarantee; it doesn't hold if this buffer
-    /// is ever changed to a non-coherent-eligible allocation.
+    /// #2793 (REN-D5-05) described the visibility gaps here; #2752
+    /// (REN-D4-05) closes them, and the two halves had to move together.
+    ///
+    /// This reads GPU-written data through `mapped_slice_mut()` and then
+    /// writes the reset-to-zero bytes back through the same mapping. Both
+    /// directions need an explicit step on non-coherent memory: an
+    /// **invalidate** before the read (a fence proves the submission
+    /// completed, but its memory-dependency access scope covers device
+    /// access only — #2740 / REN-D4-04), and a **flush** after the zeroing so
+    /// the next frame's shader `atomicAdd` doesn't accumulate onto a stale
+    /// line.
+    ///
+    /// Both were previously absent, benign only because the buffer was a
+    /// `CpuToGpu` allocation whose gpu-allocator preset *requires*
+    /// `HOST_COHERENT`. That is a property of one allocator version, not a
+    /// spec guarantee — and #2752 deliberately moved this buffer to
+    /// `GpuToCpu` (which merely *prefers* `HOST_CACHED`), so the coincidence
+    /// no longer covers it. Both calls are no-ops on a coherent allocation.
     pub(super) fn collect_image_health(&mut self, frame: usize) {
+        // Split-borrow: `invalidate_if_needed`/`flush_if_needed` take the
+        // device, which lives on `self` alongside the buffer vec.
+        let device = self.device.clone();
         let Some(buffer) = self.image_health_buffers.get_mut(frame) else {
             return;
         };
+        // Before the read. A failure here means the counters may be stale, so
+        // the honest move is to skip this frame's sample rather than fold a
+        // possibly-stale value into the running total the smoke gate asserts on.
+        if let Err(e) = buffer.invalidate_if_needed(&device) {
+            log::warn!(
+                "image-health readback invalidate failed: {e} — skipping this frame's sample"
+            );
+            return;
+        }
         let Ok(bytes) = buffer.mapped_slice_mut() else {
             return;
         };
@@ -124,6 +139,11 @@ impl VulkanContext {
         let rgb = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
         let alpha = u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
         bytes[..8].fill(0);
+        // After the zeroing write, so the shader's next `atomicAdd` starts
+        // from zero rather than a dirty host cache line.
+        if let Err(e) = buffer.flush_if_needed(&device) {
+            log::warn!("image-health counter reset flush failed: {e}");
+        }
 
         self.image_health_last = (rgb, alpha);
         self.image_health_total.0 = self.image_health_total.0.saturating_add(u64::from(rgb));
@@ -635,6 +655,86 @@ mod tests {
             mod_src.contains("HOST_COHERENT") || mod_src.contains("collect_image_health"),
             "image_health_buffers field doc must point to the corrected \
              explanation (#2740)"
+        );
+    }
+
+    /// #2752 (REN-D4-05) — the readback path's two halves must stay together.
+    /// #2740 said not to blind-fix the location, because switching to
+    /// `GpuToCpu` (which prefers `HOST_CACHED`) is exactly what turns a
+    /// missing invalidate from theoretical into observable. So the allocation
+    /// change and the invalidate call are one change, and this pins that
+    /// neither can be removed without the other.
+    ///
+    /// Source-scan for the same reason as the sibling test above: on the dev
+    /// card gpu-allocator resolves both presets to coherent memory, so
+    /// `is_coherent` is true and the invalidate is a no-op — there is no
+    /// device-free way to observe the difference. What this *can* catch is
+    /// the realistic regression: the invalidate being deleted as dead code,
+    /// or the buffer drifting back to the upload constructor.
+    #[test]
+    fn image_health_readback_allocates_gputocpu_and_invalidates_before_reading() {
+        let resources_src_full = include_str!("resources.rs");
+        let production = &resources_src_full[..resources_src_full
+            .find("mod tests {")
+            .expect("resources.rs must have a `mod tests` block")];
+        let mod_src = include_str!("mod.rs");
+
+        assert!(
+            mod_src.contains("GpuBuffer::create_host_readback("),
+            "image_health_buffers must be allocated through the readback \
+             constructor — `create_host_visible` is CpuToGpu, an upload \
+             preset, on a buffer the host drains every frame (#2752)"
+        );
+
+        // Scope to the function BODY — the doc comment above it necessarily
+        // names both `mapped_slice_mut` and the invalidate while explaining
+        // the ordering, which would make a whole-file scan self-satisfying.
+        let body_start = production
+            .find("pub(super) fn collect_image_health(")
+            .expect("collect_image_health must still exist");
+        let body = &production[body_start..];
+        let body = &body[..body
+            .find("\n    /// ")
+            .expect("collect_image_health must be followed by another doc-commented item")];
+
+        let invalidate = body
+            .find("invalidate_if_needed")
+            .expect("collect_image_health must invalidate before reading (#2752)");
+        let read = body
+            .find("mapped_slice_mut")
+            .expect("collect_image_health must still read through mapped_slice_mut");
+        assert!(
+            invalidate < read,
+            "the invalidate must precede the read — after it, the host may \
+             already have consumed a stale cache line"
+        );
+
+        // The zeroing write that follows the read needs the other half of the
+        // pair, or the next frame's atomicAdd accumulates onto a dirty line.
+        assert!(
+            body[read..].contains("flush_if_needed"),
+            "the counter reset written through the same mapping must be \
+             flushed (#2793's write-side half)"
+        );
+    }
+
+    /// The screenshot staging buffer has always been `GpuToCpu`, so it was
+    /// the site most exposed to the missing-invalidate gap even before #2752
+    /// moved the image-health buffers there. A stale read hands a torn or
+    /// previous-frame image to the golden-frame comparison — the one consumer
+    /// that cannot tell the difference.
+    #[test]
+    fn screenshot_readback_invalidates_before_mapping() {
+        let src = include_str!("screenshot.rs");
+        let invalidate = src
+            .find("invalidate_mapped_memory_ranges")
+            .expect("screenshot readback must invalidate (#2752 sibling)");
+        let read = src
+            .find("allocation.mapped_slice()")
+            .expect("screenshot readback must still read the staging mapping");
+        assert!(
+            invalidate < read,
+            "the invalidate must precede the staging-buffer read"
         );
     }
 }

--- a/crates/renderer/src/vulkan/context/screenshot.rs
+++ b/crates/renderer/src/vulkan/context/screenshot.rs
@@ -31,6 +31,51 @@ impl VulkanContext {
         let width = extent.width;
         let height = extent.height;
 
+        // #2752 sibling — this staging buffer has ALWAYS been `GpuToCpu`
+        // (unlike the image-health buffers, which #2752 moved there), so it
+        // has always been the site most exposed to the missing-invalidate gap
+        // #2740 / REN-D4-04 describes: `GpuToCpu` prefers `HOST_CACHED`, and
+        // the fence wait that precedes this read makes the copy *complete*
+        // without making it *visible to the host* — a fence's memory
+        // dependency has device-only access scope. A stale read here hands a
+        // torn or previous-frame image to the golden-frame comparison, which
+        // is the one consumer that cannot tell the difference.
+        //
+        // Not routed through `GpuBuffer::invalidate_if_needed` because the
+        // screenshot staging is a raw `vk_alloc::Allocation`, not a
+        // `GpuBuffer`; the range arithmetic is the shared helper, so the two
+        // paths cannot drift on alignment. No-op on coherent memory.
+        if !allocation
+            .memory_properties()
+            .contains(vk::MemoryPropertyFlags::HOST_COHERENT)
+        {
+            let (aligned_offset, aligned_size) =
+                super::super::buffer::aligned_flush_range(allocation.offset(), allocation.size());
+            // SAFETY: `allocation` is live and mapped (checked below), and
+            // `aligned_flush_range` widens outward to `NON_COHERENT_ATOM_SIZE`,
+            // producing a superset of this suballocation that stays inside the
+            // parent `GpuAllocatorManaged` block. Invalidating a superset only
+            // discards possibly-stale host cache lines, forcing a re-read from
+            // memory — it publishes nothing, so widening is safe here in a way
+            // it is not for a flush.
+            // SAFETY (`Allocation::memory`): returns the underlying
+            // `VkDeviceMemory` this suballocation lives in. Sound here
+            // because the handle is only used to name the memory object in a
+            // `VkMappedMemoryRange` — it is neither freed, mapped, nor bound
+            // through this call, and `allocation` is owned by
+            // `self.screenshot_staging` for the duration.
+            let result = unsafe {
+                let range = vk::MappedMemoryRange::default()
+                    .memory(allocation.memory())
+                    .offset(aligned_offset)
+                    .size(aligned_size);
+                self.device.invalidate_mapped_memory_ranges(&[range])
+            };
+            if let Err(e) = result {
+                log::warn!("Screenshot readback invalidate failed: {e} — image may be stale");
+            }
+        }
+
         // Read the staging buffer.
         let data = match allocation.mapped_slice() {
             Some(slice) => &slice[..size as usize],

--- a/crates/ui/src/host/tests.rs
+++ b/crates/ui/src/host/tests.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use byroredux_bsa::{Ba2Archive, BsaArchive};
@@ -464,7 +463,7 @@ fn installed_fallout4_representative_menus_obey_host_object_lifecycle() {
         "/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data",
     )
     .join("Fallout4 - Interface.ba2");
-    let archive = Rc::new(Ba2Archive::open(&archive_path).expect("open Fallout 4 interface BA2"));
+    let archive = Arc::new(Ba2Archive::open(&archive_path).expect("open Fallout 4 interface BA2"));
     let cases = [
         (
             "HUD",

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -14,7 +14,7 @@ mod navigator;
 mod player;
 mod profile;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use avm2_host::ScaleformHostObjectState;
 pub use catalog::{
@@ -84,7 +84,7 @@ impl UiManager {
     /// Gamebryo archive resource provider.
     pub fn load_swf_from_resource_provider(
         &mut self,
-        provider: Rc<dyn ScaleformResourceProvider>,
+        provider: Arc<dyn ScaleformResourceProvider>,
         movie_path: &str,
         name: &str,
         profile: ScaleformProfile,

--- a/crates/ui/src/navigator.rs
+++ b/crates/ui/src/navigator.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_channel::{Receiver, Sender};
@@ -32,7 +33,14 @@ use url::{ParseError, Url};
 /// Paths use backslashes and are relative to the game data root, such as
 /// `interface\fonts_en.swf`. Returning `Ok(None)` means the source does not
 /// contain the requested resource.
-pub trait ScaleformResourceProvider {
+///
+/// `Send + Sync` (#2734): the provider is held behind an `Arc` so the archive
+/// extract can move off the main loop to a worker. `BsaArchive`/`Ba2Archive`
+/// already satisfy this — each serialises its `File` cursor behind a `Mutex`
+/// so `extract` can take `&self` (#360) — so the bound costs nothing today
+/// and is what makes sharing the streaming worker's provider possible rather
+/// than a fresh archive handle per menu.
+pub trait ScaleformResourceProvider: Send + Sync {
     fn load(&self, path: &str) -> io::Result<Option<Vec<u8>>>;
 }
 
@@ -84,7 +92,7 @@ impl ScaleformNavigatorRuntime {
     pub(crate) fn create(
         movie_path: &str,
         movie_data: &[u8],
-        provider: Rc<dyn ScaleformResourceProvider>,
+        provider: Arc<dyn ScaleformResourceProvider>,
     ) -> Result<(ScaleformNavigator, Self, String), String> {
         let movie_url = archive_movie_url(movie_path)?;
         let executor = NullExecutor::new();
@@ -117,19 +125,108 @@ impl ScaleformNavigatorRuntime {
 
 pub(crate) struct ScaleformNavigator {
     movie_url: Url,
-    provider: Rc<dyn ScaleformResourceProvider>,
+    provider: Arc<dyn ScaleformResourceProvider>,
     spawner: NullSpawner,
     state: Rc<RefCell<NavigatorState>>,
 }
 
+/// Record a fetch failure and build the matching `ErrorResponse`.
+///
+/// Free function rather than a method so the deferred half of [`fetch`] —
+/// which owns a cloned `state` handle and cannot name `self` — reports errors
+/// through the exact same path as the eager half. See
+/// [`ScaleformNavigator::fetch`].
+///
+/// [`fetch`]: ScaleformNavigator::fetch
+fn record_failure(
+    state: &Rc<RefCell<NavigatorState>>,
+    url: &str,
+    message: impl Into<String>,
+) -> ErrorResponse {
+    let message = message.into();
+    state.borrow_mut().errors.push(message.clone());
+    ErrorResponse {
+        url: url.to_string(),
+        error: Error::FetchError(message),
+    }
+}
+
+/// The deferred half of [`ScaleformNavigator::fetch`]: everything that costs
+/// real time.
+///
+/// #2734 (CONC-D7-UI-06) — `fetch` returns an `OwnedFuture`, but every path
+/// used to do its work *eagerly* and hand back an already-computed value
+/// wrapped in `Box::pin(async move { Ok(..) })`. That work is not cheap: a
+/// full `provider.load` archive extract (zlib/LZ4 inflate for BSA/BA2), and
+/// for import assets a `decompress_swf` + `parse_swf` + tag-record rewrite.
+/// Ruffle calls `fetch` from inside `player.preload()` / `player.tick()`, so
+/// all of it landed as one main-loop stall with no opportunity for the local
+/// executor to interleave — `MAX_ARCHIVE_PRELOAD_PASSES` bounds the pass
+/// count but not the per-pass cost.
+///
+/// Moving it here makes the future actually lazy: `drive_archive_preload`
+/// alternates `preload()` with `run_until_stalled()`, so the cost is now
+/// amortised across pump passes instead of blocking one of them. Combined
+/// with the `Arc` provider, this is also the shape a real worker handoff
+/// needs — the body no longer closes over the navigator.
+fn load_archive_resource(
+    provider: &dyn ScaleformResourceProvider,
+    state: &Rc<RefCell<NavigatorState>>,
+    request_url: String,
+    resolved: Url,
+    archive_path: String,
+) -> Result<Box<dyn SuccessResponse>, ErrorResponse> {
+    let body = match provider.load(&archive_path) {
+        Ok(Some(body)) => body,
+        Ok(None) => {
+            return Err(record_failure(
+                state,
+                &request_url,
+                format!(
+                    "Scaleform resource {archive_path:?} was not found in the configured archive"
+                ),
+            ));
+        }
+        Err(source) => {
+            return Err(record_failure(
+                state,
+                &request_url,
+                format!("failed to extract Scaleform resource {archive_path:?}: {source}"),
+            ));
+        }
+    };
+    let is_import_asset = state.borrow().import_asset_paths.contains(&archive_path);
+    let (body, import_preload_rewritten) = if is_import_asset {
+        match prepare_import_asset_swf(&body) {
+            Ok(body) => body,
+            Err(message) => return Err(record_failure(state, &request_url, message)),
+        }
+    } else {
+        (body, false)
+    };
+    if is_import_asset {
+        match import_asset_paths(&resolved, &body) {
+            Ok(paths) => state.borrow_mut().import_asset_paths.extend(paths),
+            Err(message) => return Err(record_failure(state, &request_url, message)),
+        }
+    }
+
+    state.borrow_mut().loads.push(ScaleformResourceLoad {
+        request_url,
+        archive_path,
+        byte_len: body.len(),
+        import_preload_rewritten,
+    });
+    Ok(Box::new(MemoryResponse {
+        url: resolved.to_string(),
+        body,
+        chunk_sent: false,
+    }))
+}
+
 impl ScaleformNavigator {
     fn fail(&self, url: &str, message: impl Into<String>) -> ErrorResponse {
-        let message = message.into();
-        self.state.borrow_mut().errors.push(message.clone());
-        ErrorResponse {
-            url: url.to_string(),
-            error: Error::FetchError(message),
-        }
+        record_failure(&self.state, url, message)
     }
 }
 
@@ -170,63 +267,21 @@ impl NavigatorBackend for ScaleformNavigator {
                 return Box::pin(async move { Err(error) });
             }
         };
-        let body = match self.provider.load(&archive_path) {
-            Ok(Some(body)) => body,
-            Ok(None) => {
-                let error = self.fail(
-                    &request_url,
-                    format!(
-                        "Scaleform resource {archive_path:?} was not found in the configured archive"
-                    ),
-                );
-                return Box::pin(async move { Err(error) });
-            }
-            Err(source) => {
-                let error = self.fail(
-                    &request_url,
-                    format!("failed to extract Scaleform resource {archive_path:?}: {source}"),
-                );
-                return Box::pin(async move { Err(error) });
-            }
-        };
-        let is_import_asset = self
-            .state
-            .borrow()
-            .import_asset_paths
-            .contains(&archive_path);
-        let (body, import_preload_rewritten) = if is_import_asset {
-            match prepare_import_asset_swf(&body) {
-                Ok(body) => body,
-                Err(message) => {
-                    let error = self.fail(&request_url, message);
-                    return Box::pin(async move { Err(error) });
-                }
-            }
-        } else {
-            (body, false)
-        };
-        if is_import_asset {
-            match import_asset_paths(&resolved, &body) {
-                Ok(paths) => self.state.borrow_mut().import_asset_paths.extend(paths),
-                Err(message) => {
-                    let error = self.fail(&request_url, message);
-                    return Box::pin(async move { Err(error) });
-                }
-            }
-        }
-
-        self.state.borrow_mut().loads.push(ScaleformResourceLoad {
-            request_url,
-            archive_path,
-            byte_len: body.len(),
-            import_preload_rewritten,
-        });
-        let response: Box<dyn SuccessResponse> = Box::new(MemoryResponse {
-            url: resolved.to_string(),
-            body,
-            chunk_sent: false,
-        });
-        Box::pin(async move { Ok(response) })
+        // #2734 — everything above is pure string/URL validation: cheap, and
+        // worth keeping eager so a malformed request still fails fast and
+        // lands in `errors` without waiting for a pump pass. Everything below
+        // touches the archive, so it moves into the future body.
+        let provider = Arc::clone(&self.provider);
+        let state = Rc::clone(&self.state);
+        Box::pin(async move {
+            load_archive_resource(
+                provider.as_ref(),
+                &state,
+                request_url,
+                resolved,
+                archive_path,
+            )
+        })
     }
 
     fn resolve_url(&self, url: &str) -> Result<Url, ParseError> {
@@ -468,7 +523,7 @@ fn raw_tag_records(data: &[u8]) -> Result<Vec<(u16, usize)>, String> {
 mod tests {
     use std::collections::HashMap;
     use std::io;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     use futures::executor::block_on;
     use ruffle_core::backend::navigator::{NavigatorBackend, Request};
@@ -488,9 +543,108 @@ mod tests {
         }
     }
 
+    /// Counts `load` calls so a test can tell "the future was constructed"
+    /// from "the archive was actually read".
+    struct CountingProvider {
+        inner: MemoryProvider,
+        loads: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingProvider {
+        fn count(&self) -> usize {
+            self.loads.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl ScaleformResourceProvider for CountingProvider {
+        fn load(&self, path: &str) -> io::Result<Option<Vec<u8>>> {
+            self.loads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.load(path)
+        }
+    }
+
+    /// Regression for #2734 (CONC-D7-UI-06) — `fetch` returns an
+    /// `OwnedFuture`, so it must not have done the work by the time it
+    /// returns. Pre-fix every path ran `provider.load` (a full zlib/LZ4
+    /// archive inflate on real data) plus, for import assets, a
+    /// `decompress_swf` + `parse_swf` + tag rewrite, then wrapped the
+    /// finished value in `Box::pin(async move { Ok(..) })`. Ruffle calls
+    /// `fetch` from inside `preload()`/`tick()`, so that landed as a
+    /// main-loop stall the local executor had no chance to interleave.
+    ///
+    /// Holding the future unpolled is the whole test: a provider whose
+    /// `load` has not been called yet proves the work is deferred, and
+    /// driving it afterwards proves nothing was lost by deferring.
+    #[test]
+    fn fetch_defers_archive_io_until_the_future_is_polled() {
+        let provider = Arc::new(CountingProvider {
+            inner: MemoryProvider(HashMap::from([(
+                "interface\\fonts_en.swf".to_string(),
+                b"font movie".to_vec(),
+            )])),
+            loads: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let (navigator, runtime, _) = ScaleformNavigatorRuntime::create(
+            "interface\\hudmenu.swf",
+            b"",
+            provider.clone() as Arc<dyn ScaleformResourceProvider>,
+        )
+        .unwrap();
+
+        let pending = navigator.fetch(Request::get("fonts_en.swf".to_string()));
+        assert_eq!(
+            provider.count(),
+            0,
+            "constructing the fetch future must not touch the archive — that \
+             is the entire point of returning a future"
+        );
+        assert!(
+            runtime.loads().is_empty(),
+            "no load may be recorded before the future runs"
+        );
+
+        let response = match block_on(pending) {
+            Ok(response) => response,
+            Err(error) => panic!("deferred fetch should succeed: {}", error.error),
+        };
+        assert_eq!(provider.count(), 1, "polling must perform exactly one load");
+        assert_eq!(block_on(response.body()).unwrap(), b"font movie");
+        assert_eq!(runtime.loads()[0].archive_path, "interface\\fonts_en.swf");
+    }
+
+    /// The cheap half stays eager on purpose: a malformed URL is pure string
+    /// validation, so it fails fast and lands in `errors` without waiting for
+    /// a pump pass — and it must never reach the archive.
+    #[test]
+    fn malformed_request_fails_without_touching_the_archive() {
+        let provider = Arc::new(CountingProvider {
+            inner: MemoryProvider(HashMap::new()),
+            loads: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let (navigator, runtime, _) = ScaleformNavigatorRuntime::create(
+            "interface\\hudmenu.swf",
+            b"",
+            provider.clone() as Arc<dyn ScaleformResourceProvider>,
+        )
+        .unwrap();
+
+        // Non-local scheme — rejected by `archive_path_from_url`.
+        let pending = navigator.fetch(Request::get("http://example.com/x.swf".to_string()));
+        assert!(
+            runtime.first_error().is_some(),
+            "URL validation stays eager, so the error is visible immediately"
+        );
+        assert!(block_on(pending).is_err());
+        assert_eq!(
+            provider.count(),
+            0,
+            "a rejected URL must not hit the archive"
+        );
+    }
+
     #[test]
     fn relative_urls_resolve_to_the_movie_archive_directory() {
-        let provider = Rc::new(MemoryProvider(HashMap::from([(
+        let provider = Arc::new(MemoryProvider(HashMap::from([(
             "interface\\fonts_en.swf".to_string(),
             b"font movie".to_vec(),
         )])));
@@ -529,7 +683,7 @@ mod tests {
                 imports: Vec::new(),
             },
         ]);
-        let provider = Rc::new(MemoryProvider(HashMap::from([
+        let provider = Arc::new(MemoryProvider(HashMap::from([
             ("interface\\hudmenu.swf".to_string(), root),
             ("interface\\fonts_en.swf".to_string(), imported),
         ])));

--- a/crates/ui/src/player.rs
+++ b/crates/ui/src/player.rs
@@ -6,7 +6,6 @@
 
 use anyhow::{anyhow, Result};
 use std::any::Any;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use ruffle_core::external::Value as ExternalValue;
@@ -144,7 +143,7 @@ impl SwfPlayer {
 
     /// Load a menu and all of its relative imports through one archive source.
     pub fn from_resource_provider(
-        provider: Rc<dyn ScaleformResourceProvider>,
+        provider: Arc<dyn ScaleformResourceProvider>,
         movie_path: &str,
         width: u32,
         height: u32,


### PR DESCRIPTION
Closes #2751, #2752, #2734. (#2738 is already implemented — see the note at the end.)

**#2751** — `upload_indirect_draws` clamps to `MAX_INDIRECT_DRAWS`; the draw loop didn't, and derived `byte_offset` from the unclamped batch index, so an overflowing frame recorded a call running past `indirect_buffers[frame]` (VUID-vkCmdDrawIndexedIndirect-offset-00556, device-lost class). Folded a `batch_count` limb into `should_use_indirect_draws` so an overflowing frame falls back to direct draws — which read no indirect buffer at all, so every batch still renders. The finding's other option (clamp the loop) would silently drop the tail, compounding the producer's own silent drop.

**#2752** — the image-health buffers are drained by the host every frame but were allocated from `CpuToGpu`, the staging *upload* preset. Its own text said "observation only" because #2740 required an invalidate step to exist first; #2740 closed with only its documentation half, so that prerequisite was still genuinely open. Both halves land together: new `GpuBuffer::invalidate_if_needed` (device→host mirror of `flush_if_needed`, sharing `aligned_flush_range`), new `create_host_readback` (`GpuToCpu`, kept a separate constructor so `create_host_visible`'s #423 audit guard keeps one meaning), and `collect_image_health` now invalidates before the read and flushes after the zeroing write. Sibling fixed too: `screenshot_finish_readback` has always been `GpuToCpu`, so it was the more exposed site all along.

> ⚠️ **This needs a device run before merge.** #2740's instruction was an explicit `BYRO_VALIDATION=1` pass with synchronization validation, and I can't do that here. On the 4070 Ti gpu-allocator resolves both presets to coherent memory, so the invalidate is a no-op and `cargo test` cannot falsify any of it. The tests included are source-scans plus range arithmetic — they catch the realistic regression, not the spec question.

**#2734** — `fetch` returned an `OwnedFuture` but did all its work eagerly (archive extract + SWF reparse) inside Ruffle's `preload()`/`tick()`. The expensive half moves into the future body, so `drive_archive_preload`'s alternating `preload()`/`run_until_stalled()` amortises it across pump passes; URL/method validation stays eager so malformed requests still fail fast. `ScaleformResourceProvider` gains `Send + Sync` and moves `Rc`→`Arc` — the design change the finding named as the prerequisite for a worker handoff. The archives already satisfy the bound (`Mutex<File>`, #360). Actually moving the extract onto the streaming worker is still out: `OwnedFuture` isn't `Send` and `NullSpawner` is a local executor, so that needs a channel round-trip, and the path remains test-only.

**#2738 needs no work** — commit `f8e59b4e` already decoded NVNM geometry, triangles with per-edge neighbours, and the external connection table, for both the Gamebryo typed form and the Creation packed blob, with 15 unit tests and an `examples/dump_navmesh` sweep. It referenced the issue without a closing keyword, so it stayed open.

`byroredux/src/render/fire_lights.rs`'s `derived_reach_is_currently_oversized_pending_a_unit_correct_derivation` fails on main — unrelated and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)