### PR TITLE
Fix #2718 Fix #2719 Fix #2720 Fix #2721: forward uncataloged BGSCodeO…

### DIFF
--- a/.claude/issues/2718-2721/ISSUE.md
+++ b/.claude/issues/2718-2721/ISSUE.md
@@ -1,0 +1,52 @@
+# #2718 #2719 #2720 #2721 — Scaleform UI bundle (audit closeout, 2026-08-14)
+
+Four issues from the 2026-08-12 `ui-deep` audit suite, fixed together because
+three of them land in `crates/ui`.
+
+## #2718 — FO4 host-method catalog validated against 3 of 311 menus
+`SAFEUI-04`. The injected AVM2 adapter installed exactly one forwarder per
+catalog entry (138) onto `BGSCodeObj`. Any `BGSCodeObj.Foo(...)` outside the
+catalog is a call on `undefined` (AVM2 Error #1006), which aborts the executing
+frame handler — a menu that renders but stops responding. The only guard was an
+`#[ignore]`d 3-movie test.
+
+**Fix**: install the union of the catalog and the methods the movie's own
+bytecode calls (the existing `referenced_host_methods` scan, promoted out of
+`#[cfg(test)]`). Corpus sweep widened to all 311 menus and un-ignored.
+
+**Measured**: 131 distinct uncataloged methods across the corpus — including
+the entire main menu (`StartNewGame`, `ContinueGame`, `PopulateLoadList`,
+`DeleteSave`, …). All 311 movies scan cleanly and still round-trip injection.
+
+## #2719 — UI overlay allocates a fresh VkImage every frame
+`CONC-D7-UI-03`. `SwfPlayer::tick` ended with unconditional `self.dirty = true`,
+so `render`'s `if !self.dirty` early exit was dead code.
+
+**Fix**: `dirty |= player.needs_render()` (the gate Ruffle's own desktop/web
+hosts use), plus a content comparison of the readback so an unchanged picture
+returns `None`. NOT done: recording the copy into `draw_frame`'s own command
+buffer (suggested fix (b)) — that is a Vulkan sync change with failure modes
+invisible to `cargo test`.
+
+## #2720 — Navigator pump has two silent permanent-freeze paths
+`CONC-D7-UI-04` / `SAFEUI-06`. (1) `NavigatorState::errors` was never cleared,
+`first_error()` peeked at it, and `tick` returned early forever once it was
+`Some`. (2) An unsettled preload returned from `tick` with no log, no error and
+no state change.
+
+**Fix**: `take_errors()` drains; failures are recorded (deduped, bounded) and
+reported through `resource_errors()`; the stall wait is bounded, logged and
+surfaced via `preload_stalled()`.
+
+**Found while fixing**: the two paths are the same event. Ruffle sets
+`awaiting_import` before an `ImportAssets` fetch and clears it *only* on
+`load_asset_movie`'s success path, so a failed dependency wedges the preload
+inside Ruffle — non-fatal error handling alone would have moved the freeze, not
+removed it. The navigator now answers a failed fetch with a valid empty SWF so
+the import completes with no symbols.
+
+## #2721 — Three live "100-byte Vertex" doc sites
+`TD3-2026-08-12-01`. Two were still live (`docs/engine/ui.md`,
+`docs/engine/testing.md`); the third (`vulkan/pipeline.rs`) was already fixed by
+`f6eb7fde`. Repo-wide sweep confirms the remaining `100 byte` hits are unrelated
+record/block sizes.

--- a/crates/ui/src/avm2_host.rs
+++ b/crates/ui/src/avm2_host.rs
@@ -8,7 +8,6 @@
 //! `BGSCodeObj`; that bootstrap fills the object and forwards each call through
 //! ExternalInterface without relying on Ruffle's private AVM2 object model.
 
-#[cfg(test)]
 use std::collections::BTreeSet;
 
 use swf::avm2::read::Reader;
@@ -99,7 +98,46 @@ pub(crate) fn inject_host_object_adapter(
         .ok_or_else(|| "Fallout 4 root ABC index does not reference an ABC tag".to_string())?;
     let patched_root_abc = patch_root_constructor(root_abc, &root_class)?;
 
-    let adapter = build_adapter_abc(catalog)
+    // #2718 (SAFEUI-04) — the catalog is a hand-transcribed inventory of a
+    // third-party reconstruction of the vanilla sources, and it is the ONLY
+    // thing that used to decide which properties exist on `BGSCodeObj`. A
+    // method the catalog missed resolves to an absent property on a dynamic
+    // object, which AVM2 reports as a call on `undefined` (Error #1006) — it
+    // aborts the executing frame handler, so the menu renders and then stops
+    // responding, with the true cause (a missing string in a Rust table)
+    // invisible from the failure. Take the union with what this movie
+    // actually calls, so an uncataloged method still gets a forwarder and
+    // degrades into a recorded `ScaleformHostDispatch::Unknown` returning
+    // null instead of throwing — which is also what makes the bridge's
+    // `unknown_methods()` diagnostic reachable at all.
+    //
+    // A scan failure is deliberately non-fatal: the inventory is a bonus on
+    // top of the catalog, and refusing to load a menu because its bytecode
+    // has a shape the scanner cannot walk would be strictly worse than the
+    // pre-fix behaviour.
+    let referenced = match referenced_host_methods_in_tags(&movie.tags) {
+        Ok(referenced) => referenced,
+        Err(error) => {
+            log::warn!(
+                "Fallout 4 host-call inventory scan failed ({error}); installing the \
+                 catalog's {} forwarders only",
+                catalog.len()
+            );
+            BTreeSet::new()
+        }
+    };
+    let uncataloged = uncataloged_host_methods(catalog, &referenced);
+    if !uncataloged.is_empty() {
+        log::info!(
+            "Fallout 4 menu calls {} BGSCodeObj method(s) outside the {}-entry catalog; \
+             forwarding them too (#2718): {:?}",
+            uncataloged.len(),
+            catalog.len(),
+            uncataloged,
+        );
+    }
+
+    let adapter = build_adapter_abc(catalog, &uncataloged)
         .map_err(|error| format!("building Fallout 4 AVM2 adapter: {error}"))?;
     let replacement = match &movie.tags[root_abc_index] {
         Tag::DoAbc(_) => Tag::DoAbc(&patched_root_abc),
@@ -185,14 +223,24 @@ fn multiname_local_name(abc: &AbcFile, index: Index<Multiname>) -> Option<Vec<u8
         .cloned()
 }
 
+/// Every `BGSCodeObj.<method>(…)` call site a movie's bytecode contains, from
+/// its raw (still compressed) bytes — the corpus sweeps' entry point.
+/// Injection itself scans the movie it has already parsed, through
+/// [`referenced_host_methods_in_tags`].
 #[cfg(test)]
 pub(crate) fn referenced_host_methods(swf_data: &[u8]) -> Result<BTreeSet<String>, String> {
     let decompressed =
         decompress_swf(swf_data).map_err(|error| format!("decompressing SWF: {error}"))?;
     let movie = parse_swf(&decompressed).map_err(|error| format!("parsing SWF: {error}"))?;
+    referenced_host_methods_in_tags(&movie.tags)
+}
+
+/// [`referenced_host_methods`] over already-parsed tags, so the injection path
+/// scans the movie it has in hand instead of decompressing it a second time.
+fn referenced_host_methods_in_tags(tags: &[Tag<'_>]) -> Result<BTreeSet<String>, String> {
     let mut methods = BTreeSet::new();
 
-    for tag in &movie.tags {
+    for tag in tags {
         let Some(data) = abc_payload(tag) else {
             continue;
         };
@@ -238,7 +286,36 @@ pub(crate) fn referenced_host_methods(swf_data: &[u8]) -> Result<BTreeSet<String
     Ok(methods)
 }
 
-#[cfg(test)]
+/// Members every AVM2 `Object` already answers. A forwarder installed over one
+/// of these would shadow the real thing for any menu that legitimately calls
+/// it on `BGSCodeObj`, so a call site naming one is never taken as evidence of
+/// a host method — unlike a genuinely uncataloged name, whose only possible
+/// meaning is "the game filled this in natively".
+const OBJECT_PROTOTYPE_MEMBERS: &[&str] = &[
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "setPropertyIsEnumerable",
+    "toLocaleString",
+    "toString",
+    "valueOf",
+];
+
+/// Referenced host methods the catalog does not already cover, in the order
+/// their forwarders get installed. Split out (pure, `&str`-only) so the union
+/// rule can be pinned without building an ABC.
+fn uncataloged_host_methods(
+    catalog: ScaleformHostCatalog,
+    referenced: &BTreeSet<String>,
+) -> Vec<String> {
+    referenced
+        .iter()
+        .filter(|method| !catalog.contains(method))
+        .filter(|method| !OBJECT_PROTOTYPE_MEMBERS.contains(&method.as_str()))
+        .cloned()
+        .collect()
+}
+
 #[derive(Clone)]
 enum InventoryStackValue {
     BgsCodeObj,
@@ -246,7 +323,6 @@ enum InventoryStackValue {
     Other,
 }
 
-#[cfg(test)]
 fn method_called_with_bgs_receiver(abc: &AbcFile, ops: &[Op]) -> Option<Vec<u8>> {
     for mut stack in [
         vec![InventoryStackValue::BgsCodeObj],
@@ -525,7 +601,28 @@ fn helper_name(index: usize) -> String {
     format!("{HELPER_PREFIX}{index}")
 }
 
-fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> {
+/// Names the adapter installs on the host object: the catalog, plus whatever
+/// #2718's per-movie scan found that the catalog missed. One flat list because
+/// each installed method's trait carries a sequential `disp_id`.
+fn installed_method_names<'a>(
+    catalog: ScaleformHostCatalog,
+    uncataloged: &'a [String],
+) -> Vec<&'a str>
+where
+    'static: 'a,
+{
+    catalog
+        .methods()
+        .iter()
+        .map(|method| method.name)
+        .chain(uncataloged.iter().map(String::as_str))
+        .collect()
+}
+
+fn build_adapter_abc(
+    catalog: ScaleformHostCatalog,
+    uncataloged: &[String],
+) -> std::io::Result<Vec<u8>> {
     let object = catalog
         .host_object()
         .expect("AVM2 adapter requires a host-object profile");
@@ -595,11 +692,12 @@ fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> 
     );
     let root_slot = add_multiname(&mut multinames, qname(public_namespace, root_slot_string));
 
-    let mut methods = Vec::with_capacity(catalog.len() + 4);
-    let mut method_bodies = Vec::with_capacity(catalog.len() + 4);
-    let mut traits = Vec::with_capacity(catalog.len() + 4);
-    let mut helper_multinames = Vec::with_capacity(catalog.len());
-    let mut method_property_multinames = Vec::with_capacity(catalog.len());
+    let installed = installed_method_names(catalog, uncataloged);
+    let mut methods = Vec::with_capacity(installed.len() + 4);
+    let mut method_bodies = Vec::with_capacity(installed.len() + 4);
+    let mut traits = Vec::with_capacity(installed.len() + 4);
+    let mut helper_multinames = Vec::with_capacity(installed.len());
+    let mut method_property_multinames = Vec::with_capacity(installed.len());
     traits.push(Trait {
         name: root_slot,
         kind: TraitKind::Slot {
@@ -612,11 +710,10 @@ fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> 
         is_override: false,
     });
 
-    for (index, method) in catalog.methods().iter().enumerate() {
+    for (index, method) in installed.iter().enumerate() {
         let helper_string = add_string(&mut strings, helper_name(index));
-        let transport_string =
-            add_string(&mut strings, format!("{}.{}", object.property, method.name));
-        let method_property_string = add_string(&mut strings, method.name);
+        let transport_string = add_string(&mut strings, format!("{}.{}", object.property, method));
+        let method_property_string = add_string(&mut strings, *method);
 
         let helper_multiname =
             add_multiname(&mut multinames, qname(public_namespace, helper_string));
@@ -702,7 +799,7 @@ fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> 
     traits.push(method_trait(
         ready_helper,
         ready_method,
-        catalog.len() as u32 + 1,
+        installed.len() as u32 + 1,
     ));
 
     let destroy_method = Index::new(methods.len() as u32);
@@ -746,7 +843,7 @@ fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> 
     traits.push(method_trait(
         destroy_helper,
         destroy_method,
-        catalog.len() as u32 + 2,
+        installed.len() as u32 + 2,
     ));
 
     let installer_method = Index::new(methods.len() as u32);
@@ -826,7 +923,7 @@ fn build_adapter_abc(catalog: ScaleformHostCatalog) -> std::io::Result<Vec<u8>> 
     traits.push(method_trait(
         install_helper,
         installer_method,
-        catalog.len() as u32 + 3,
+        installed.len() as u32 + 3,
     ));
 
     let init_method = Index::new(methods.len() as u32);
@@ -943,14 +1040,51 @@ mod tests {
 
     use super::{
         build_adapter_abc, inject_host_object_adapter, max_stack_with_injected_bootstrap_headroom,
-        referenced_host_methods, write_ops, DESTROYED_EVENT, LOADED_CALLBACK,
+        referenced_host_methods, uncataloged_host_methods, write_ops, DESTROYED_EVENT,
+        LOADED_CALLBACK,
     };
     use crate::{ScaleformHostCatalog, ScaleformProfile};
+
+    /// FO4 interface archive used by the corpus sweeps, or `None` when the
+    /// game isn't installed on this machine (the corpus is multi-gigabyte
+    /// game data that can't ship with the repo, so the sweeps self-skip
+    /// rather than failing — see #2717).
+    fn fallout4_interface_archive(test_name: &str) -> Option<Ba2Archive> {
+        let path = std::env::var("BYROREDUX_FO4_DATA").unwrap_or_else(|_| {
+            "/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data".to_string()
+        });
+        let archive_path = std::path::Path::new(&path).join("Fallout4 - Interface.ba2");
+        match Ba2Archive::open(&archive_path) {
+            Ok(archive) => Some(archive),
+            Err(_) => {
+                eprintln!(
+                    "skipping {test_name}: {archive_path:?} not available \
+                     (set BYROREDUX_FO4_DATA to override)"
+                );
+                None
+            }
+        }
+    }
+
+    fn fallout4_swf_paths(archive: &Ba2Archive) -> Vec<String> {
+        let mut swf_paths: Vec<String> = archive
+            .list_files()
+            .into_iter()
+            .filter(|path| path.ends_with(".swf"))
+            .map(str::to_string)
+            .collect();
+        swf_paths.sort();
+        assert!(
+            !swf_paths.is_empty(),
+            "expected .swf files in the FO4 interface archive"
+        );
+        swf_paths
+    }
 
     #[test]
     fn generated_adapter_is_valid_abc_with_one_helper_per_method() {
         let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
-        let bytes = build_adapter_abc(catalog).unwrap();
+        let bytes = build_adapter_abc(catalog, &[]).unwrap();
         let abc = Reader::new(&bytes).read().unwrap();
 
         assert_eq!(abc.scripts.len(), 1);
@@ -1018,7 +1152,7 @@ mod tests {
     #[test]
     fn generated_adapter_pool_carries_no_abandoned_loader_strategy() {
         let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
-        let bytes = build_adapter_abc(catalog).unwrap();
+        let bytes = build_adapter_abc(catalog, &[]).unwrap();
         let abc = Reader::new(&bytes).read().unwrap();
 
         for abandoned in [
@@ -1049,42 +1183,81 @@ mod tests {
         assert_eq!(abc.constant_pool.namespaces.len(), 2);
     }
 
+    /// #2718 (SAFEUI-04) — the corpus sweep the pre-fix version of this test
+    /// could not be: it inspected **three** movies out of 311 and was
+    /// `#[ignore]`d, so 308 shipped menus were unverified against the catalog
+    /// and nothing ran in a normal `cargo test`. It now walks every `.swf` in
+    /// the interface archive, and self-skips (like its `all_installed_…`
+    /// sibling) instead of being permanently opted out.
+    ///
+    /// The assertion also changed shape with the fix. `referenced ⊆ catalog`
+    /// is no longer the safety property — an uncataloged method is no longer
+    /// fatal, because injection installs a forwarder for the *union* of the
+    /// catalog and this movie's own call sites. What must hold now is that
+    /// the scan those forwarders come from actually succeeds on every real
+    /// menu: a scan failure silently degrades injection back to catalog-only
+    /// and re-arms the Error #1006 the fix removes. The catalog gap itself is
+    /// reported rather than asserted — it is a to-do list for the catalog's
+    /// `kind`/response metadata, not a load-blocker.
     #[test]
-    #[ignore = "requires an installed Fallout 4 corpus"]
-    fn installed_fallout4_host_calls_are_cataloged() {
-        let path = std::env::var("BYROREDUX_FO4_DATA").unwrap_or_else(|_| {
-            "/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data".to_string()
-        });
-        let archive =
-            Ba2Archive::open(std::path::Path::new(&path).join("Fallout4 - Interface.ba2")).unwrap();
+    fn installed_fallout4_host_calls_are_all_forwarded() {
+        let Some(archive) =
+            fallout4_interface_archive("installed_fallout4_host_calls_are_all_forwarded")
+        else {
+            return;
+        };
         let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
-        let mut referenced = std::collections::BTreeSet::new();
+        let swf_paths = fallout4_swf_paths(&archive);
 
-        for movie in [
-            "interface\\hudmenu.swf",
-            "interface\\pipboymenu.swf",
-            "programs\\atomiccommand.swf",
-        ] {
-            let swf = archive.extract(movie).unwrap();
-            let methods = referenced_host_methods(&swf).unwrap();
-            let unknown = methods
-                .iter()
-                .filter(|method| !catalog.contains(method))
-                .cloned()
-                .collect::<Vec<_>>();
-            assert!(
-                unknown.is_empty(),
-                "{movie} references uncataloged BGSCodeObj methods: {unknown:?}; all={methods:?}"
-            );
-            referenced.extend(methods);
+        let mut referenced = std::collections::BTreeSet::new();
+        let mut uncataloged = std::collections::BTreeSet::new();
+        let mut failures = Vec::new();
+        let mut scanned = 0usize;
+        for movie in &swf_paths {
+            let swf = match archive.extract(movie) {
+                Ok(swf) => swf,
+                Err(error) => {
+                    failures.push(format!("{movie}: extract failed: {error}"));
+                    continue;
+                }
+            };
+            match referenced_host_methods(&swf) {
+                Ok(methods) => {
+                    scanned += 1;
+                    uncataloged.extend(uncataloged_host_methods(catalog, &methods));
+                    referenced.extend(methods);
+                }
+                Err(error) => failures.push(format!("{movie}: host-call scan failed: {error}")),
+            }
         }
 
-        // #2727 — the reverse direction. `methods ⊆ catalog` alone can never
+        assert!(
+            failures.is_empty(),
+            "{} of {} FO4 SWFs could not be scanned for BGSCodeObj call sites — injection \
+             falls back to catalog-only forwarders for these, which is exactly the \
+             Error #1006 exposure #2718 removes:\n{}",
+            failures.len(),
+            swf_paths.len(),
+            failures.join("\n"),
+        );
+
+        if !uncataloged.is_empty() {
+            eprintln!(
+                "note: {} BGSCodeObj method(s) called by the {scanned}-movie corpus are \
+                 outside the {}-entry catalog. These are forwarded (and land as \
+                 `ScaleformHostDispatch::Unknown`) since #2718, but carry no catalog \
+                 `kind`: {uncataloged:?}",
+                uncataloged.len(),
+                catalog.len(),
+            );
+        }
+
+        // #2727 — the reverse direction. `referenced ⊆ catalog` alone can never
         // fail on a *bogus* catalog entry, which is how the mangled
         // `functiononGPSModeButtonClicked` (#2726) survived into a checked-in
-        // 138-method catalog. This is a warning list rather than an assertion:
-        // the three-movie sample is not the whole menu set, so legitimate
-        // entries for other menus are expected to appear here.
+        // 138-method catalog. Still a warning list rather than an assertion:
+        // menus outside this archive (and dynamically-dispatched call sites the
+        // scanner cannot see) legitimately leave entries unreferenced.
         let unreferenced = catalog
             .methods()
             .iter()
@@ -1093,10 +1266,71 @@ mod tests {
             .collect::<Vec<_>>();
         if !unreferenced.is_empty() {
             eprintln!(
-                "note: {} of {} catalog entries are unreferenced by the 3-movie sample \
-                 (expected for menus outside it — scan for malformed names): {unreferenced:?}",
+                "note: {} of {} catalog entries are unreferenced by the whole {scanned}-movie \
+                 corpus (scan for malformed names): {unreferenced:?}",
                 unreferenced.len(),
                 catalog.len()
+            );
+        }
+    }
+
+    /// #2718 — the union rule itself. A method the movie calls but the catalog
+    /// lacks must be installed; one the catalog already has must not be
+    /// installed twice (each forwarder's trait carries a sequential `disp_id`);
+    /// and a plain `Object` member must never be shadowed by a forwarder that
+    /// would send `toString()` to the engine.
+    #[test]
+    fn uncataloged_methods_are_the_union_minus_catalog_and_object_members() {
+        let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
+        let referenced = ["PlaySound", "SomeUnknownFO4Method", "toString", "valueOf"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(catalog.contains("PlaySound"), "test premise");
+
+        assert_eq!(
+            uncataloged_host_methods(catalog, &referenced),
+            vec!["SomeUnknownFO4Method".to_string()]
+        );
+    }
+
+    /// #2718 — and the union really reaches the emitted bytecode: an extra
+    /// method adds one more forwarder, one more installed property, and its
+    /// name to the transport strings, without disturbing the fixed tail
+    /// (ready / destroy / installer / script init).
+    #[test]
+    fn an_uncataloged_method_gets_its_own_installed_forwarder() {
+        let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
+        let extra = vec!["SomeUnknownFO4Method".to_string()];
+        let bytes = build_adapter_abc(catalog, &extra).unwrap();
+        let abc = Reader::new(&bytes).read().unwrap();
+        let installed = catalog.len() + extra.len();
+
+        assert_eq!(abc.methods.len(), installed + 4);
+        assert_eq!(abc.method_bodies.len(), installed + 4);
+        assert_eq!(abc.scripts[0].traits.len(), installed + 4);
+
+        let installer = &abc.method_bodies[installed + 2];
+        let mut reader = Reader::new(&installer.code);
+        let mut installed_properties = 0;
+        while !reader.as_slice().is_empty() {
+            if matches!(
+                reader.read_op().unwrap(),
+                swf::avm2::types::Op::SetProperty { .. }
+            ) {
+                installed_properties += 1;
+            }
+        }
+        // One per installed method, plus the root-slot store.
+        assert_eq!(installed_properties, installed + 1);
+
+        for expected in ["SomeUnknownFO4Method", "BGSCodeObj.SomeUnknownFO4Method"] {
+            assert!(
+                abc.constant_pool
+                    .strings
+                    .iter()
+                    .any(|string| string.as_slice() == expected.as_bytes()),
+                "adapter pool is missing {expected:?}"
             );
         }
     }
@@ -1144,30 +1378,13 @@ mod tests {
             "interface\\terminalmenu.swf",
         ];
 
-        let path = std::env::var("BYROREDUX_FO4_DATA").unwrap_or_else(|_| {
-            "/mnt/data/SteamLibrary/steamapps/common/Fallout 4/Data".to_string()
-        });
-        let archive_path = std::path::Path::new(&path).join("Fallout4 - Interface.ba2");
-        let Ok(archive) = Ba2Archive::open(&archive_path) else {
-            eprintln!(
-                "skipping all_installed_fallout4_swfs_round_trip_through_injection: \
-                 {archive_path:?} not available (set BYROREDUX_FO4_DATA to override)"
-            );
+        let Some(archive) =
+            fallout4_interface_archive("all_installed_fallout4_swfs_round_trip_through_injection")
+        else {
             return;
         };
         let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::Fallout4Avm2);
-
-        let mut swf_paths: Vec<String> = archive
-            .list_files()
-            .into_iter()
-            .filter(|path| path.ends_with(".swf"))
-            .map(str::to_string)
-            .collect();
-        swf_paths.sort();
-        assert!(
-            !swf_paths.is_empty(),
-            "expected .swf files in the FO4 interface archive at {archive_path:?}"
-        );
+        let swf_paths = fallout4_swf_paths(&archive);
 
         let mut injected_count = 0usize;
         let mut failures = Vec::new();

--- a/crates/ui/src/navigator.rs
+++ b/crates/ui/src/navigator.rs
@@ -110,8 +110,17 @@ impl ScaleformNavigatorRuntime {
         self.state.borrow().loads.clone()
     }
 
-    pub(crate) fn first_error(&self) -> Option<String> {
-        self.state.borrow().errors.first().cloned()
+    /// Remove and return the fetch failures recorded since the previous call.
+    ///
+    /// #2720 — this used to be `first_error()`, a *peek* at a list nothing
+    /// ever cleared. One failed dependency therefore answered `Some` forever,
+    /// and the player's `tick` copied that into a latch whose first statement
+    /// was an early return: a single missing file — including the entirely
+    /// routine "not in this archive" case — froze the whole menu for the rest
+    /// of the session. Draining makes each failure a one-time event the owner
+    /// records and moves past.
+    pub(crate) fn take_errors(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.state.borrow_mut().errors)
     }
 }
 
@@ -123,14 +132,49 @@ pub(crate) struct ScaleformNavigator {
 }
 
 impl ScaleformNavigator {
-    fn fail(&self, url: &str, message: impl Into<String>) -> ErrorResponse {
+    /// Record a fetch failure and answer with an empty placeholder movie.
+    ///
+    /// #2720 — returning `Err` here is what froze the menu, and not only
+    /// through the engine-side latch this fix removes. Ruffle sets
+    /// `MovieClip::preload_progress.awaiting_import` before spawning an
+    /// `ImportAssets` fetch and clears it **only** on
+    /// `LoadManager::load_asset_movie`'s success path; `MovieClip::preload`
+    /// returns `false` for as long as that flag is set, and the root timeline
+    /// will not advance past a frame it has not preloaded. So a failed
+    /// dependency fetch wedges the movie inside Ruffle, no matter how the
+    /// caller handles the error.
+    ///
+    /// Handing back a valid, empty SWF lets the import *complete* with no
+    /// symbols: whatever the menu imported is missing (Ruffle logs the
+    /// unresolved character), but the movie preloads, runs, and draws. The
+    /// failure is not swallowed — it is recorded for
+    /// `SwfPlayer::resource_errors` and logged by the owning player, which is
+    /// what makes "this menu is missing an asset" a diagnosis rather than a
+    /// silent hang.
+    fn degraded(&self, url: &str, message: impl Into<String>) -> Box<dyn SuccessResponse> {
         let message = message.into();
-        self.state.borrow_mut().errors.push(message.clone());
-        ErrorResponse {
+        log::debug!("Scaleform archive fetch failed, substituting an empty movie: {message}");
+        self.state.borrow_mut().errors.push(message);
+        Box::new(MemoryResponse {
             url: url.to_string(),
-            error: Error::FetchError(message),
-        }
+            body: placeholder_movie(),
+            chunk_sent: false,
+        })
     }
+}
+
+/// A valid, empty, single-frame SWF — see [`ScaleformNavigator::degraded`].
+///
+/// Deliberately carries no `FileAttributes` tag: an imported movie with no
+/// exports has nothing for either VM to run, and the AVM1 form is the one
+/// Ruffle accepts from every importer.
+fn placeholder_movie() -> Vec<u8> {
+    let mut header = swf::Header::default_with_swf_version(9);
+    header.num_frames = 1;
+    let mut bytes = Vec::new();
+    swf::write_swf(&header, &[Tag::ShowFrame], &mut bytes)
+        .expect("writing a fixed, empty in-memory SWF cannot fail");
+    bytes
 }
 
 impl NavigatorBackend for ScaleformNavigator {
@@ -146,47 +190,47 @@ impl NavigatorBackend for ScaleformNavigator {
     fn fetch(&self, request: Request) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
         let request_url = request.url().to_string();
         if request.method() != NavigationMethod::Get {
-            let error = self.fail(
+            let response = self.degraded(
                 &request_url,
                 format!("Scaleform archive fetch only supports GET: {request_url}"),
             );
-            return Box::pin(async move { Err(error) });
+            return Box::pin(async move { Ok(response) });
         }
 
         let resolved = match self.resolve_url(&request_url) {
             Ok(url) => url,
             Err(error) => {
-                let error = self.fail(
+                let response = self.degraded(
                     &request_url,
                     format!("invalid Scaleform resource URL {request_url:?}: {error}"),
                 );
-                return Box::pin(async move { Err(error) });
+                return Box::pin(async move { Ok(response) });
             }
         };
         let archive_path = match archive_path_from_url(&resolved) {
             Ok(path) => path,
             Err(message) => {
-                let error = self.fail(&request_url, message);
-                return Box::pin(async move { Err(error) });
+                let response = self.degraded(&request_url, message);
+                return Box::pin(async move { Ok(response) });
             }
         };
         let body = match self.provider.load(&archive_path) {
             Ok(Some(body)) => body,
             Ok(None) => {
-                let error = self.fail(
+                let response = self.degraded(
                     &request_url,
                     format!(
                         "Scaleform resource {archive_path:?} was not found in the configured archive"
                     ),
                 );
-                return Box::pin(async move { Err(error) });
+                return Box::pin(async move { Ok(response) });
             }
             Err(source) => {
-                let error = self.fail(
+                let response = self.degraded(
                     &request_url,
                     format!("failed to extract Scaleform resource {archive_path:?}: {source}"),
                 );
-                return Box::pin(async move { Err(error) });
+                return Box::pin(async move { Ok(response) });
             }
         };
         let is_import_asset = self
@@ -198,8 +242,8 @@ impl NavigatorBackend for ScaleformNavigator {
             match prepare_import_asset_swf(&body) {
                 Ok(body) => body,
                 Err(message) => {
-                    let error = self.fail(&request_url, message);
-                    return Box::pin(async move { Err(error) });
+                    let response = self.degraded(&request_url, message);
+                    return Box::pin(async move { Ok(response) });
                 }
             }
         } else {
@@ -209,8 +253,8 @@ impl NavigatorBackend for ScaleformNavigator {
             match import_asset_paths(&resolved, &body) {
                 Ok(paths) => self.state.borrow_mut().import_asset_paths.extend(paths),
                 Err(message) => {
-                    let error = self.fail(&request_url, message);
-                    return Box::pin(async move { Err(error) });
+                    let response = self.degraded(&request_url, message);
+                    return Box::pin(async move { Ok(response) });
                 }
             }
         }
@@ -550,6 +594,115 @@ mod tests {
         player.tick(1.0 / 30.0);
         assert_eq!(player.current_frame(), Some(1));
         assert_eq!(player.resource_error(), None);
+    }
+
+    /// Regression for #2720 / CONC-D7-UI-04: a dependency that isn't in the
+    /// configured archive must not stop the menu.
+    ///
+    /// `ScaleformNavigator::fail` pushed onto a `NavigatorState::errors` list
+    /// nothing ever cleared, `first_error()` peeked at it, and `tick`'s first
+    /// statement returned early whenever that peek was `Some`. So **one**
+    /// missing file — including the entirely routine `Ok(None)` "not in this
+    /// archive" case, on a navigator that holds exactly one archive — froze
+    /// the whole movie for the rest of the session, leaving the last uploaded
+    /// frame on screen. The failure has to be recorded and reported, not
+    /// latched.
+    #[test]
+    fn a_missing_dependency_is_recorded_without_freezing_the_movie() {
+        let root = movie(vec![
+            Tag::FileAttributes(FileAttributes::IS_ACTION_SCRIPT_3),
+            Tag::ImportAssets {
+                url: SwfStr::from_utf8_str("fonts_en.swf"),
+                imports: Vec::new(),
+            },
+        ]);
+        // Deliberately NOT supplying interface\fonts_en.swf.
+        let provider = Rc::new(MemoryProvider(HashMap::from([(
+            "interface\\hudmenu.swf".to_string(),
+            root,
+        )])));
+
+        let mut player = SwfPlayer::from_resource_provider(
+            provider,
+            "interface\\hudmenu.swf",
+            64,
+            64,
+            ScaleformProfile::Fallout4Avm2,
+        )
+        .expect("a missing dependency must not fail the load of a root movie that parsed");
+
+        let error = player
+            .resource_error()
+            .expect("the failed fetch must still be reported");
+        assert!(
+            error.contains("fonts_en.swf"),
+            "the report must name the missing file: {error}"
+        );
+        assert_eq!(
+            player.resource_errors().len(),
+            1,
+            "one missing file, one recorded failure: {:?}",
+            player.resource_errors()
+        );
+        // The placeholder answer is what lets Ruffle's own `awaiting_import`
+        // flag clear (`LoadManager::load_asset_movie` only calls
+        // `finish_importing()` on its success path), so the preload settles
+        // rather than wedging the root timeline behind an unpreloaded frame.
+        assert!(
+            !player.preload_stalled(),
+            "the placeholder import must let the preload settle"
+        );
+
+        // And the movie runs: the latch is what's gone, not the player.
+        for _ in 0..3 {
+            player.tick(1.0 / 30.0);
+        }
+        assert_eq!(player.current_frame(), Some(1));
+        assert_eq!(
+            player.resource_errors().len(),
+            1,
+            "a repeated failure must dedup rather than accumulate: {:?}",
+            player.resource_errors()
+        );
+    }
+
+    /// Regression for #2719 / CONC-D7-UI-03: `tick` ended with an
+    /// unconditional `self.dirty = true`, so `render`'s `if !self.dirty`
+    /// early exit was dead code and a *static* menu re-rendered, re-read back
+    /// and re-uploaded a full-viewport RGBA image every single frame. Each of
+    /// those uploads builds a fresh `VkImage` and blocks on a one-time
+    /// submit's fence ahead of `draw_frame`. A movie whose picture is not
+    /// changing must hand the caller pixels once and then stop.
+    #[test]
+    fn a_static_movie_stops_handing_back_pixels_after_the_first_frame() {
+        let provider = Rc::new(MemoryProvider(HashMap::from([(
+            "interface\\hudmenu.swf".to_string(),
+            movie(vec![Tag::FileAttributes(
+                FileAttributes::IS_ACTION_SCRIPT_3,
+            )]),
+        )])));
+        let mut player = SwfPlayer::from_resource_provider(
+            provider,
+            "interface\\hudmenu.swf",
+            64,
+            64,
+            ScaleformProfile::Fallout4Avm2,
+        )
+        .unwrap();
+
+        player.tick(1.0 / 30.0);
+        assert!(
+            player.render().is_some(),
+            "the first frame must always be uploaded — the caller has no texture yet"
+        );
+
+        for frame in 0..8 {
+            player.tick(1.0 / 30.0);
+            assert!(
+                player.render().is_none(),
+                "frame {frame} of a static movie re-uploaded an unchanged image"
+            );
+        }
     }
 
     fn movie(mut tags: Vec<Tag<'_>>) -> Vec<u8> {

--- a/crates/ui/src/player.rs
+++ b/crates/ui/src/player.rs
@@ -28,6 +28,36 @@ use crate::{
 
 const MAX_ARCHIVE_PRELOAD_PASSES: usize = 64;
 
+/// Consecutive frames an unsettled archive preload may suppress the movie's
+/// own `tick` before the player advances it anyway (#2720).
+///
+/// The pre-fix code returned from `tick` on every unsettled frame, forever,
+/// with no log line, no recorded error and no state change — a preload that
+/// never settles was indistinguishable from a hang, and the identical
+/// condition is a hard `Err` at construction. One second of grace at 60 Hz is
+/// far more than the handful of frames a real cross-archive import needs, and
+/// after it a degraded menu (some imported symbols missing) beats a frozen
+/// one: the stall is logged once and surfaced through
+/// [`SwfPlayer::preload_stalled`].
+const MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES: u32 = 60;
+
+/// Whether an unsettled preload has held the movie back long enough that
+/// `tick` should advance it anyway (#2720).
+///
+/// Split out (pure) so the default suite can pin the property that actually
+/// matters — that the wait *terminates* — without having to synthesize a
+/// preload that never settles.
+fn preload_stall_grace_expired(consecutive_stall_frames: u32) -> bool {
+    consecutive_stall_frames >= MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES
+}
+
+/// Distinct archive-fetch failures a player retains (#2720).
+///
+/// Failures are deduplicated, so this only binds a movie that keeps asking
+/// for *different* missing files every frame. It is a leak stop, not a
+/// capacity estimate — a real menu records zero or one.
+const MAX_RECORDED_RESOURCE_ERRORS: usize = 64;
+
 /// Process-wide Ruffle GPU bundle, created on first menu load (#2733).
 ///
 /// Pre-fix every [`SwfPlayer`] built its own wgpu instance, adapter, device
@@ -100,10 +130,23 @@ pub struct SwfPlayer {
     height: u32,
     pixel_buffer: Vec<u8>,
     dirty: bool,
+    /// Whether [`Self::render`] has handed its buffer to the caller at least
+    /// once, so the content comparison in #2719 can't suppress the very first
+    /// upload (see there).
+    uploaded_once: bool,
     host_bridge: ScaleformHostBridge,
     host_object_state: ScaleformHostObjectState,
     navigator_runtime: Option<ScaleformNavigatorRuntime>,
-    resource_error: Option<String>,
+    /// Distinct archive-fetch failures seen so far, oldest first (#2720).
+    /// Recorded and reported, never latched — see [`Self::tick`].
+    resource_errors: Vec<String>,
+    /// One-shot latch for the [`MAX_RECORDED_RESOURCE_ERRORS`] cap warning.
+    resource_errors_capped: bool,
+    /// Consecutive frames the archive preload has failed to settle (#2720).
+    preload_stall_frames: u32,
+    /// Whether the stall grace period has been exhausted and the movie is
+    /// being advanced without a settled preload (#2720).
+    preload_stalled: bool,
 }
 
 impl SwfPlayer {
@@ -177,10 +220,34 @@ impl SwfPlayer {
             host_object_state,
             Some((navigator, runtime)),
         )?;
-        if !player.drive_archive_preload()? {
-            return Err(anyhow!(
-                "Scaleform archive preload did not settle after {MAX_ARCHIVE_PRELOAD_PASSES} passes"
-            ));
+        // #2720 — a dependency that fails to fetch is recorded, not fatal: the
+        // root movie loaded, and a menu missing an imported font is worth more
+        // than no menu.
+        //
+        // The two failure modes are the same event in Ruffle, which is why
+        // this is one check rather than two. `MovieClip::preload` returns
+        // `false` forever while `awaiting_import` is set, and
+        // `LoadManager::load_asset_movie` only calls `finish_importing()` on
+        // its success path — so a failed `ImportAssets` fetch *is* a preload
+        // that never settles. Refusing to load in that case would just move
+        // the pre-fix freeze from tick time to load time.
+        //
+        // A stall we cannot explain is still a hard error: nothing was
+        // reported, so there is no diagnosis to degrade gracefully under.
+        if !player.drive_archive_preload() {
+            if player.resource_errors.is_empty() {
+                return Err(anyhow!(
+                    "Scaleform archive preload did not settle after \
+                     {MAX_ARCHIVE_PRELOAD_PASSES} passes"
+                ));
+            }
+            log::warn!(
+                "Scaleform archive preload for {movie_path:?} did not settle after \
+                 {MAX_ARCHIVE_PRELOAD_PASSES} passes; loading the menu anyway with \
+                 {} failed dependency fetch(es) (#2720)",
+                player.resource_errors.len(),
+            );
+            player.preload_stalled = true;
         }
         Ok(player)
     }
@@ -240,43 +307,71 @@ impl SwfPlayer {
             height,
             pixel_buffer,
             dirty: true,
+            uploaded_once: false,
             host_bridge,
             host_object_state,
             navigator_runtime,
-            resource_error: None,
+            resource_errors: Vec::new(),
+            resource_errors_capped: false,
+            preload_stall_frames: 0,
+            preload_stalled: false,
         })
     }
 
     /// Advance the player by `dt` seconds. Ruffle handles frame accumulation
     /// internally — just call tick() each frame with the real delta time.
+    ///
+    /// #2720 — neither an archive failure nor an unsettled preload latches the
+    /// movie off any more. A failed *dependency* fetch is recorded and playback
+    /// continues (see [`Self::resource_errors`]); only a failure of the root
+    /// movie, which happens at construction, is fatal. An unsettled preload
+    /// still suppresses the tick, but for a bounded number of frames and with a
+    /// log line and an observable state, instead of silently forever.
     pub fn tick(&mut self, dt: f64) {
-        if self.resource_error.is_some() {
-            return;
-        }
-        if self.navigator_runtime.is_some() {
-            match self.drive_archive_preload() {
-                Ok(true) => {}
-                Ok(false) => return,
-                Err(error) => {
-                    let error = error.to_string();
-                    log::error!("{error}");
-                    self.resource_error = Some(error);
+        if self.navigator_runtime.is_some() && !self.drive_archive_preload() {
+            self.preload_stall_frames = self.preload_stall_frames.saturating_add(1);
+            if !self.preload_stalled {
+                if self.preload_stall_frames == 1 {
+                    log::warn!(
+                        "Scaleform archive preload did not settle after \
+                         {MAX_ARCHIVE_PRELOAD_PASSES} passes; retrying next frame"
+                    );
+                }
+                if !preload_stall_grace_expired(self.preload_stall_frames) {
                     return;
                 }
+                self.preload_stalled = true;
+                self.record_resource_errors(vec![format!(
+                    "Scaleform archive preload stalled for \
+                     {MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES} consecutive frames; advancing the \
+                     movie without a settled preload"
+                )]);
             }
+            // Fall through: a menu missing some imported symbols is worth more
+            // than a menu frozen on its last uploaded frame.
+        } else {
+            self.preload_stall_frames = 0;
+            self.preload_stalled = false;
         }
-        {
+        let needs_render = {
             let mut player = self.player.lock().unwrap();
             player.tick(FloatDuration::from_secs(dt));
-        }
+            player.needs_render()
+        };
         if let Some(runtime) = &mut self.navigator_runtime {
             runtime.run_until_stalled();
-            if let Some(error) = runtime.first_error() {
-                log::error!("{error}");
-                self.resource_error = Some(error);
-            }
+            let errors = runtime.take_errors();
+            self.record_resource_errors(errors);
         }
-        self.dirty = true;
+        // #2719 — only mark dirty when Ruffle says the stage actually changed.
+        // An unconditional `self.dirty = true` here made `render`'s early exit
+        // dead code, so a *static* menu re-rendered, re-read back and
+        // re-uploaded a full-viewport RGBA image every frame — at 1920×1080
+        // that is an 8.3 MB readback plus a fresh `VkImage` and a blocking
+        // one-time submit, ahead of `draw_frame`, for a picture that did not
+        // move. Ruffle raises this flag whenever a frame ran or the mouse
+        // state changed, and clears it in `Player::render`.
+        self.dirty |= needs_render;
     }
 
     /// Forward a platform-neutral input event to Ruffle.
@@ -296,7 +391,17 @@ impl SwfPlayer {
     }
 
     /// Render the current frame to the internal pixel buffer.
-    /// Returns the RGBA pixel data if the frame is dirty, None otherwise.
+    ///
+    /// Returns the RGBA pixel data only when it differs from what the caller
+    /// was last handed, and `None` otherwise — a `None` means "keep showing
+    /// the texture you already have", not "nothing was drawn".
+    ///
+    /// #2719 — the caller's response to `Some` is a full-viewport
+    /// `update_rgba`, which builds a **new** `VkImage` and blocks on a
+    /// one-time submit's fence ahead of `draw_frame`. Ruffle re-rendering is
+    /// not the same thing as the picture changing (a timeline frame can
+    /// advance with nothing visibly moving), so the returned-pixels decision
+    /// is made on content, not on the render having happened.
     pub fn render(&mut self) -> Option<&[u8]> {
         if !self.dirty {
             return None;
@@ -310,6 +415,7 @@ impl SwfPlayer {
 
         // Capture the rendered frame by downcasting to the concrete backend type.
         // This follows the same pattern as Ruffle's exporter crate.
+        let mut changed = false;
         {
             let mut player = self.player.lock().unwrap();
             let renderer = player.renderer_mut();
@@ -319,7 +425,10 @@ impl SwfPlayer {
                 if let Some(image) = wgpu_backend.capture_frame() {
                     let rgba = image.into_raw();
                     if rgba.len() == self.pixel_buffer.len() {
-                        self.pixel_buffer.copy_from_slice(&rgba);
+                        changed = rgba != self.pixel_buffer;
+                        if changed {
+                            self.pixel_buffer.copy_from_slice(&rgba);
+                        }
                     } else {
                         log::warn!(
                             "Ruffle frame size mismatch: got {} bytes, expected {}",
@@ -332,6 +441,13 @@ impl SwfPlayer {
         }
 
         self.dirty = false;
+        // The very first render must always be handed over: the caller has no
+        // texture yet, and an all-zero movie would otherwise compare equal to
+        // the freshly zeroed buffer and never upload.
+        if !changed && self.uploaded_once {
+            return None;
+        }
+        self.uploaded_once = true;
         Some(&self.pixel_buffer)
     }
 
@@ -367,7 +483,47 @@ impl SwfPlayer {
 
     /// First archive loading failure encountered after construction.
     pub fn resource_error(&self) -> Option<&str> {
-        self.resource_error.as_deref()
+        self.resource_errors.first().map(String::as_str)
+    }
+
+    /// Every distinct archive loading failure seen so far, oldest first.
+    ///
+    /// #2720 — these are diagnostics, not a kill switch: the movie keeps
+    /// playing after each one. A non-empty list on a menu that looks wrong is
+    /// the first thing to read.
+    pub fn resource_errors(&self) -> &[String] {
+        &self.resource_errors
+    }
+
+    /// Whether the archive preload exhausted its stall grace period and the
+    /// movie is being advanced without having settled (#2720).
+    pub fn preload_stalled(&self) -> bool {
+        self.preload_stalled
+    }
+
+    /// Record fetch failures, deduplicated and bounded.
+    ///
+    /// Deduplication is what keeps a per-frame retry of the same missing file
+    /// from both flooding the log and growing the list without limit; the hard
+    /// cap covers the pathological case of endlessly *distinct* failures.
+    fn record_resource_errors(&mut self, errors: Vec<String>) {
+        for error in errors {
+            if self.resource_errors.contains(&error) {
+                continue;
+            }
+            if self.resource_errors.len() >= MAX_RECORDED_RESOURCE_ERRORS {
+                if !self.resource_errors_capped {
+                    self.resource_errors_capped = true;
+                    log::error!(
+                        "Scaleform resource failures hit the {MAX_RECORDED_RESOURCE_ERRORS}-entry \
+                         cap; further distinct failures are neither recorded nor logged"
+                    );
+                }
+                continue;
+            }
+            log::error!("{error}");
+            self.resource_errors.push(error);
+        }
     }
 
     /// Invoke a callback registered through `ExternalInterface.addCallback`.
@@ -393,25 +549,35 @@ impl SwfPlayer {
         Some(ScaleformValue::from(&result))
     }
 
-    fn drive_archive_preload(&mut self) -> Result<bool> {
+    /// Pump Ruffle's preload and the navigator's local executor until the
+    /// preload settles, returning whether it did.
+    ///
+    /// #2720 — a dependency fetch that fails is drained into
+    /// [`Self::resource_errors`] and the pump continues. It used to abort the
+    /// whole preload with an `Err`, which the caller turned into the permanent
+    /// latch; but `ScaleformNavigator::fail` fires for the entirely routine
+    /// "this file is not in the configured archive" case, and the navigator
+    /// holds exactly one archive.
+    fn drive_archive_preload(&mut self) -> bool {
         for _ in 0..MAX_ARCHIVE_PRELOAD_PASSES {
             let finished = {
                 let mut execution_limit = ExecutionLimit::none();
                 self.player.lock().unwrap().preload(&mut execution_limit)
             };
-            let runtime = self
+            let errors = self
                 .navigator_runtime
                 .as_mut()
+                .map(|runtime| {
+                    runtime.run_until_stalled();
+                    runtime.take_errors()
+                })
                 .expect("archive preload requires a navigator runtime");
-            runtime.run_until_stalled();
-            if let Some(error) = runtime.first_error() {
-                return Err(anyhow!("Scaleform archive preload failed: {error}"));
-            }
+            self.record_resource_errors(errors);
             if finished {
-                return Ok(true);
+                return true;
             }
         }
-        Ok(false)
+        false
     }
 }
 
@@ -422,6 +588,33 @@ impl Drop for SwfPlayer {
                 let _ = player.call_internal_interface(DESTROY_CALLBACK, []);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod preload_stall_tests {
+    use super::{preload_stall_grace_expired, MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES};
+
+    /// #2720 — the pre-fix `tick` mapped an unsettled preload to a bare
+    /// `return` with no log, no recorded error and no state change, re-checked
+    /// the same condition next frame, and so suppressed the movie *forever* if
+    /// the preload never settled: a hang and a stall were indistinguishable.
+    /// The property that fixes it is simply that the wait ends — pin the
+    /// boundary in both directions so a future edit can't quietly restore an
+    /// unbounded one (e.g. by making the comparison strict on a counter that
+    /// saturates).
+    #[test]
+    fn the_preload_stall_wait_terminates() {
+        assert!(!preload_stall_grace_expired(0));
+        assert!(!preload_stall_grace_expired(
+            MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES - 1
+        ));
+        assert!(preload_stall_grace_expired(
+            MAX_CONSECUTIVE_PRELOAD_STALL_FRAMES
+        ));
+        // `preload_stall_frames` saturates rather than wrapping, so the
+        // saturated value must still count as expired.
+        assert!(preload_stall_grace_expired(u32::MAX));
     }
 }
 

--- a/docs/engine/testing.md
+++ b/docs/engine/testing.md
@@ -85,7 +85,7 @@ each crate's `tests/` directory and the binary crate's own
 
 ### Renderer — `byroredux-renderer`
 The renderer crate carries real unit tests now, not just doc-tests. Coverage that runs without a GPU lives in pure-data modules:
-- **Vertex + mesh** — `vertex.rs` pins the 100-byte stride / 9 attribute descriptions; `mesh.rs` exercises the cube/triangle/quad helpers and SSBO bookkeeping
+- **Vertex + mesh** — `vertex.rs` pins the 104-byte stride / 9 attribute descriptions; `mesh.rs` exercises the cube/triangle/quad helpers and SSBO bookkeeping
 - **Scene-buffer GPU contract** — [`crates/renderer/src/vulkan/scene_buffer/`](../../crates/renderer/src/vulkan/scene_buffer/) tests pin the `#[repr(C)]` std430 layout (`gpu_instance_layout_tests`, `instance_hash_tests`, `material_hash_tests`, `scene_descriptor_reflection_tests`), guarding the Shader Struct Sync contract
 - **DDS / texture registry** — `vulkan/dds.rs` header parsing, `texture_registry_tests` + `texture_registry_bindless_tests`
 - **Shader reflection** — `vulkan/reflect.rs` and `shader_constants.rs` keep the GLSL-side constants in lockstep

--- a/docs/engine/ui.md
+++ b/docs/engine/ui.md
@@ -269,7 +269,7 @@ with:
   normal / motion-vector / mesh-id G-buffer.
 - **Lightweight vertex format.** The UI quad uses `UiVertex` (position +
   UV only, **20 bytes** — `[f32; 3]` + `[f32; 2]`, 2 attribute
-  descriptions) rather than the full 100-byte scene `Vertex`. The split
+  descriptions) rather than the full 104-byte scene `Vertex`. The split
   landed alongside the M-NORMALS vertex work (#783); the 20-byte size and
   field offsets are pinned by tests in `crates/renderer/src/vertex.rs`.
 - **Bindless texture sampling.** `ui.frag` samples


### PR DESCRIPTION
…bj calls, stop the per-frame UI image churn, and unfreeze the navigator pump

Four findings from the 2026-08-12 ui-deep audit suite; three land in crates/ui.

#2718 (SAFEUI-04) — the injected AVM2 adapter installed exactly one forwarder per catalog entry, so any BGSCodeObj method the hand-transcribed 138-entry catalog missed resolved to an absent property on a dynamic object: AVM2 Error #1006, which aborts the executing frame handler. The symptom is a menu that renders and then stops responding, with the cause (a missing string in a Rust table) invisible from the failure. Injection now installs the union of the catalog and the methods the movie's own bytecode calls, reusing the referenced_host_methods scan that until now only existed for tests. An uncataloged method reaches the bridge and lands as ScaleformHostDispatch:: Unknown returning null — which is also the only way unknown_methods() could ever become a live diagnostic. Object.prototype members are excluded so a forwarder can never shadow toString(); a scan failure degrades to catalog-only rather than refusing to load the menu.

The corpus test that was supposed to guard this inspected 3 of 311 menus and was #[ignore]d. It now sweeps the whole interface archive, self-skips when the game isn't installed, and asserts what actually matters post-fix: that the scan those forwarders come from succeeds on every real menu. Against the installed corpus it reports 131 distinct uncataloged methods — including the entire main menu (StartNewGame, ContinueGame, PopulateLoadList, DeleteSave). Every movie scans cleanly and still round-trips injection.

#2719 (CONC-D7-UI-03) — SwfPlayer::tick ended with an unconditional self.dirty = true, making render's early exit dead code: a static menu re-rendered, re-read back and re-uploaded a full-viewport RGBA image every frame. At 1920x1080 that is an 8.3 MB readback plus a fresh VkImage and a blocking one-time submit sitting ahead of draw_frame. Dirty now follows Player::needs_render() (the gate Ruffle's own desktop and web hosts use), and render compares the readback so an unchanged picture returns None. The first frame is always handed over, since the caller has no texture yet. Suggested fix (b) — recording the copy into draw_frame's command buffer — is deliberately not taken here: that is a Vulkan sync change whose failure modes are invisible to cargo test.

#2720 (CONC-D7-UI-04 / SAFEUI-06) — two latches, both permanent and silent. NavigatorState::errors was never cleared and first_error() only peeked, so one failed fetch made tick's early return fire forever; and an unsettled preload returned from tick with no log, no recorded error and no state change. Errors are now drained, recorded deduplicated and bounded, and reported through resource_errors(); the stall wait is bounded, logged once, and observable via preload_stalled().

That alone would have moved the freeze rather than removed it. Ruffle sets MovieClip::preload_progress.awaiting_import before an ImportAssets fetch and clears it only on LoadManager::load_asset_movie's success path, so a failed dependency wedges the preload inside Ruffle and the root timeline never advances past its unpreloaded frame — the "sticky error" and "silent non-settle" paths are one event, not two. The navigator therefore answers a failed fetch with a valid empty SWF: the import completes with no symbols, the menu loads without whatever it imported, and the failure is recorded rather than swallowed.

#2721 (TD3-2026-08-12-01) — two of the three "100-byte Vertex" doc sites were still live; pipeline.rs was already corrected by f6eb7fde. The remaining "100 byte" hits repo-wide are unrelated record and block sizes.