### PR TITLE
Fix #2664 Fix #2665 Fix #2666 Fix #2667: give exterior logical-actor …

### DIFF
--- a/.claude/issues/2664-2667/ISSUE.md
+++ b/.claude/issues/2664-2667/ISSUE.md
@@ -1,0 +1,65 @@
+# #2664 #2665 #2666 #2667 — scripting-domain audit closeout (2026-08-14)
+
+Four findings from `docs/audits/AUDIT_SCRIPTING_2026-08-12.md` (eleventh
+scripting pass). One live correctness bug, three maintenance-shaped.
+
+## #2664 (SCR-D7-NEW11-03) — MEDIUM, live
+The worldspace persistent-cell loader open-coded `stamp_quest_reference`'s body
+for its logical-actor stubs and inserted **no transform**. `resolve_alias_
+bindings` ranks distance-anchored aliases with
+`world.get::<GlobalTransform>(entity)?` *inside a `filter_map`*, so those
+candidates were dropped from the `min_by` entirely — a Find-Matching /
+Unique-Actor alias authored "Closest" whose only candidates are persistent
+worldspace `ACHR`s silently never filled.
+
+**Fix**: call the shared `spawn_logical_quest_reference` (now `pub(crate)`),
+passing the REFR's own placement through the same conversion the reference
+loader uses.
+
+**Tests**: behavioural pin in `byroredux-scripting`
+(`quest_alias_closest_fill_needs_a_transform_on_its_only_candidate`, asserting
+both directions), plus a source pin on the call site — driving
+`PersistentCellApplyJob::apply` needs Vulkan + game data.
+
+**Sibling sweep**: `stamp_quest_reference` is now the only production
+constructor of `SceneAliasCandidate` (the other two hits are `#[cfg(test)]`
+fixtures in `commands/quest.rs` and `scripting/dialogue.rs`).
+
+## #2665 (SCR-D1-NEW11-01) — LOW, docs
+`FunctionInfo::line_numbers` claimed the boolean pass consults it to reject
+cross-line merges. It has zero readers workspace-wide, and declining that check
+is `decompile::boolean`'s deliberate departure 1 — the docstring advertised a
+safety guard that does not exist, on the pass where #2655 showed its absence
+silently erased a `While`. `function_type` claimed a `Method` fallback; the
+reader maps unknown bytes to `None`.
+
+## #2666 (SCR-D2-NEW11-01) — LOW, latent
+`rebuild_expression`'s "verified single match must be consumed" postcondition
+was a `debug_assert!` — nothing in release. It spans two independently
+maintained traversals (`child_nodes` counts, `child_nodes_mut` substitutes); a
+divergence would take the success path with the producer unconsumed, dropping
+the statement while its consumer keeps a dangling `::tempN`.
+
+**Fix**: return `ExpressionRebuildFailed`, matching the `>1` arm. Added
+`node.rs`'s first tests — a parity check over all 16 `NodeKind` variants, with
+an exhaustive `match` so a new variant fails to compile until covered.
+Verified the test bites by temporarily dropping `else_if` from the mutable
+traversal.
+
+## #2667 (SCR-D3-NEW11-02) — LOW, latent
+`collapse`'s two `.expect`s held only because the depth cap fires first: a
+nested collapse whose rejoin is an on-stack ancestor removes that block, and
+the ancestor's own `collapse` then looks it up. Both are now local declines.
+Added a guard for a self-referential operand/rejoin edge (sibling of the #2028
+degenerate-shape decline) — which is also what makes the two remaining
+`get_mut(&current).expect(…)` uses locally sound. Narrowed the module doc's
+termination claim to the iterative loop, and gave `RecursionLimit` a `pass`
+discriminant so a boolean-pass overflow stops reporting itself as a
+control-flow failure.
+
+## Corpus validation
+`pex_corpus_smoke` over `Skyrim - Misc.bsa` + `Fallout4 - Misc.ba2`:
+**21900/21901 decompiled (100.0%), 0 panics — byte-identical to the
+pre-change baseline**, so the new declines and the fail-closed rebuild cost
+nothing on real content. The `#[ignore]`d R5 fidelity gate also passes against
+on-disk Skyrim SE data.

--- a/byroredux/src/cell_loader/exterior.rs
+++ b/byroredux/src/cell_loader/exterior.rs
@@ -253,32 +253,23 @@ impl PersistentCellApplyJob {
                 return PersistentCellApplyProgress::Pending(self);
             }
             let placed = &self.logical_stub_refs[self.next_logical_stub];
-            let entity = world.spawn();
-            let plugin_name =
-                super::load_order::plugin_for_form_id(placed.form_id, &wctx.load_order)
-                    .unwrap_or("Engine.esm");
-            let form_id = world
-                .resource_mut::<byroredux_core::form_id::FormIdPool>()
-                .intern(byroredux_core::form_id::FormIdPair {
-                    plugin: byroredux_core::form_id::PluginId::from_filename(plugin_name),
-                    local: byroredux_core::form_id::LocalFormId(placed.form_id),
-                });
-            world.insert(
-                entity,
-                byroredux_core::ecs::components::FormIdComponent(form_id),
-            );
-            world.insert(
-                entity,
-                byroredux_scripting::SceneAliasCandidate {
-                    reference_form_id: placed.form_id,
-                    base_form_id: placed.base_form_id,
-                    linked_refs: placed
-                        .linked_refs
-                        .iter()
-                        .map(|link| (link.keyword, link.target))
-                        .collect(),
-                    location_ref_types: placed.location_ref_types.clone(),
-                },
+            // #2664 (SCR-D7-NEW11-03) — this used to open-code
+            // `stamp_quest_reference`'s body and insert nothing else. Two
+            // problems, one of them live: the copy would drift from the
+            // canonical stamper as `SceneAliasCandidate` grows (the
+            // divergence #2541 guards against), and it left the entity with
+            // no transform at all, which excludes it from every
+            // distance-ranked alias fill (see
+            // `spawn_logical_quest_reference`'s docs). `placed.position` was
+            // available the whole time. Same conversion as the REFR
+            // placement path in `references::load_references_budgeted`.
+            super::references::spawn_logical_quest_reference(
+                world,
+                placed,
+                &wctx.load_order,
+                super::transition::position_zup_to_yup(placed.position),
+                super::transition::rotation_zup_to_yup_quat(placed.rotation),
+                placed.scale,
             );
             self.next_logical_stub += 1;
             budget.complete_unit();
@@ -409,6 +400,50 @@ fn persistent_position_is_local(
     let gx = (position_zup[0] / EXTERIOR_CELL_UNITS).floor() as i32;
     let gy = (position_zup[1] / EXTERIOR_CELL_UNITS).floor() as i32;
     (gx - center_grid.0).abs().max((gy - center_grid.1).abs()) <= radius.max(0)
+}
+
+/// Regression for #2664 (SCR-D7-NEW11-03): the persistent-cell logical-actor
+/// stub must route through the one shared spawner.
+///
+/// Driving `PersistentCellApplyJob::apply` needs a `VulkanContext` and on-disk
+/// game data, out of `cargo test` scope — so this pins the wiring the way the
+/// reference loader's own untestable paths are pinned (see
+/// `references/source_pin_tests.rs`). What it guards is the *duplication*: the
+/// loop used to carry a verbatim copy of `stamp_quest_reference`'s body, which
+/// both drifts as `SceneAliasCandidate` grows (#2541's invariant) and — the
+/// live consequence — inserted no transform, excluding the entity from every
+/// distance-ranked alias fill. The behavioural half is pinned in
+/// `byroredux-scripting`'s
+/// `quest_alias_closest_fill_needs_a_transform_on_its_only_candidate`.
+#[cfg(test)]
+mod logical_stub_source_pin_tests {
+    /// This file's own source. Self-matching is not a risk here: the literals
+    /// below appear in the assertions themselves, so each is checked for a
+    /// count rather than mere presence where that matters.
+    const SRC: &str = include_str!("exterior.rs");
+
+    #[test]
+    fn logical_actor_stubs_spawn_through_the_shared_transform_bearing_helper() {
+        assert!(
+            SRC.contains("references::spawn_logical_quest_reference("),
+            "the persistent-cell logical stub must call the shared spawner, not \
+             open-code the identity components"
+        );
+        assert!(
+            SRC.contains("transition::position_zup_to_yup(placed.position)"),
+            "the stub must be given the REFR's own placement, converted the same \
+             way the reference loader converts it"
+        );
+        // The hand-rolled block this replaced constructed the candidate inline.
+        // One occurrence is this assertion's own literal.
+        assert_eq!(
+            SRC.matches("SceneAliasCandidate {").count(),
+            1,
+            "the alias-candidate component must be built only by \
+             `stamp_quest_reference`; a second construction site here is the \
+             duplication #2664 removed"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/byroredux/src/cell_loader/references/mod.rs
+++ b/byroredux/src/cell_loader/references/mod.rs
@@ -813,6 +813,10 @@ use synth_child::{
     attach_quest_reference_script, refr_script_instance_for_synth_child, spawn_synth_child,
     stamp_quest_reference,
 };
+// #2664 — the exterior persistent-cell loader spawns the same logical
+// identity entity for a 3D-less persistent ACHR, so the one spawner is
+// shared rather than copied.
+pub(crate) use synth_child::spawn_logical_quest_reference;
 
 // Tests live in sibling files by topic (#2409 / TD1-006).
 #[cfg(test)]

--- a/byroredux/src/cell_loader/references/synth_child.rs
+++ b/byroredux/src/cell_loader/references/synth_child.rs
@@ -38,7 +38,22 @@ pub(super) fn stamp_quest_reference(
     byroredux_scripting::mark_scene_actor_bindings_dirty(world);
 }
 
-fn spawn_logical_quest_reference(
+/// Spawn the identity-only entity for a REFR that produced no 3D, carrying a
+/// transform so it stays a *rankable* alias candidate.
+///
+/// The transform is the load-bearing part, not decoration: `resolve_alias_
+/// bindings` ranks distance-anchored aliases (`closest_to_alias`, or
+/// `ALIAS_FLAG_CLOSEST` anchored on the player) with
+/// `world.get::<GlobalTransform>(entity)?` *inside a `filter_map`*, so a
+/// candidate without one is dropped from the `min_by` entirely rather than
+/// merely ranked last. An alias whose only candidates are transform-less
+/// stubs silently stays unfilled — no log line, no error.
+///
+/// `pub(crate)` since #2664: the worldspace persistent-cell loader
+/// (`cell_loader::exterior`) has the same "logical actor identity, no 3D"
+/// case for remote / spawn-less persistent `ACHR`s, and used to open-code a
+/// copy of [`stamp_quest_reference`] that omitted the transform.
+pub(crate) fn spawn_logical_quest_reference(
     world: &mut World,
     placed_ref: &esm::cell::PlacedRef,
     load_order: &[String],

--- a/crates/pex/src/decompile/boolean.rs
+++ b/crates/pex/src/decompile/boolean.rs
@@ -30,7 +30,14 @@
 //! 2. **Termination guard.** The C++ unconditionally re-processes the
 //!    source block after a potential `||`; we re-process only when a
 //!    collapse actually merged a non-exit block (which strictly shrinks
-//!    the graph), so the loop always terminates.
+//!    the graph), so the `while` loop in [`BoolPass::rebuild`] terminates.
+//!
+//!    #2667 — that argument covers the *iterative* loop only. The same
+//!    edge adoption can drive `rebuild`'s **recursion** back into the block
+//!    range it is already walking (the adopted `next` points at the range
+//!    start for `&&`, `on_false` for `||`), and nothing about a shrinking
+//!    graph bounds that. [`MAX_REBUILD_DEPTH`] is what bounds it, and the
+//!    resulting `RecursionLimit` is a clean decline.
 
 use std::collections::BTreeMap;
 
@@ -133,6 +140,10 @@ impl BoolPass<'_> {
     fn rebuild(&mut self, start: usize, end: usize, depth: usize) -> Result<(), DecompileError> {
         if depth > MAX_REBUILD_DEPTH {
             return Err(DecompileError::RecursionLimit {
+                // #2667 — not "control-flow": this pass runs one step before
+                // that one, and a chain that overflows here used to be
+                // reported under the other pass's name.
+                pass: "short-circuit boolean",
                 function: self.func_name.to_string(),
                 limit: MAX_REBUILD_DEPTH,
             });
@@ -177,17 +188,36 @@ impl BoolPass<'_> {
     /// `op`. Returns `true` when a collapse merged a non-exit rejoin block
     /// (so `current` should be re-processed for a further chain).
     fn collapse(&mut self, current: usize, cond: &str, op: BoolOp) -> Result<bool, DecompileError> {
-        let src = self
-            .cfg
-            .block(current)
-            .cloned()
-            .expect("source block exists");
+        // #2667 (SCR-D3-NEW11-02) — this was `.expect("source block exists")`,
+        // an invariant *inherited* rather than local. `rebuild` verifies the
+        // block exists, but then recurses into the operand range before
+        // calling here, and a nested `collapse` whose rejoin is an enclosing
+        // (on-stack) block removes that ancestor from the CFG. The panic
+        // survived only because the adopted edge necessarily points back into
+        // the range being walked, so `rebuild` re-enters and `MAX_REBUILD_DEPTH`
+        // fires first — a crafted `.pex` reaches `RecursionLimit`, not this
+        // line. That is a real guarantee today and no guarantee at all if the
+        // cap is ever raised or bypassed, so decline locally instead.
+        let Some(src) = self.cfg.block(current).cloned() else {
+            return Ok(false);
+        };
         // For `&&` the operand is the true block and the rejoin is the
         // false block; for `||` they swap.
         let (operand_key, rejoin_key) = match op {
             BoolOp::And => (src.on_true(), src.on_false),
             BoolOp::Or => (src.on_false, src.on_true()),
         };
+        if operand_key == current || rejoin_key == current {
+            // #2667 — a self-referential edge. Sibling of the degenerate shape
+            // below: folding `current` into itself would have the rejoin merge
+            // remove the very block being rewritten (`blocks.remove(&rejoin_key)`
+            // after `blocks.get_mut(&current)`), leaving every predecessor
+            // pointing at a hole. Declining here is also what keeps the two
+            // remaining `get_mut(&current).expect(…)` uses below *locally*
+            // sound: after this guard, nothing between the lookup above and
+            // those calls can remove `current`.
+            return Ok(false);
+        }
         if operand_key == rejoin_key {
             // Degenerate/adversarial shape (SCR-D3-NEW-01 / #2028): a
             // conditional block whose true and false edges are the same
@@ -226,9 +256,14 @@ impl BoolPass<'_> {
 
         // Build the combined expression onto the source scope.
         let mut src_scope = self.scopes.remove(&current).unwrap_or_default();
-        let left = src_scope
-            .pop()
-            .expect("conditional source has a last statement");
+        // #2667 — likewise inherited, not local: `rebuild` checked
+        // `!scope.is_empty()` on a *clone* taken before the recursive
+        // `rebuild` call, which can have merged this scope away in the
+        // meantime. Put it back and decline rather than panic.
+        let Some(left) = src_scope.pop() else {
+            self.scopes.insert(current, src_scope);
+            return Ok(false);
+        };
         src_scope.push(combine(left, op.as_str(), right, cond));
 
         // The operand block is now folded into the expression — drop it.
@@ -549,6 +584,172 @@ mod tests {
         );
     }
 
+    /// #2667 (SCR-D3-NEW11-02) — `collapse` must not assume the block it was
+    /// asked about still exists.
+    ///
+    /// `rebuild` verifies it before recursing into the operand range, but a
+    /// nested collapse whose rejoin is an *enclosing* (on-stack) block removes
+    /// that ancestor from the CFG; the ancestor's own `collapse` then ran
+    /// `self.cfg.block(current).expect("source block exists")` on a hole. The
+    /// panic was unreachable only because the adopted edge forces `rebuild`
+    /// back into the range it is walking, so `MAX_REBUILD_DEPTH` fires first —
+    /// a property of a *cap*, not a local invariant. Calling `collapse`
+    /// directly is what separates the two: no recursion is involved here, so
+    /// nothing but the guard itself is under test.
+    #[test]
+    fn collapse_declines_when_its_source_block_is_gone() {
+        let mut cfg = Cfg {
+            blocks: BTreeMap::new(),
+            entry: 0,
+            exit: 2,
+        };
+        // Deliberately empty: `current` was removed by an inner collapse.
+        let mut scopes: BTreeMap<usize, Vec<Node>> = BTreeMap::new();
+        let mut pass = BoolPass {
+            cfg: &mut cfg,
+            scopes: &mut scopes,
+            func_name: "VanishedSource",
+        };
+
+        let collapsed = pass
+            .collapse(0, "t", BoolOp::And)
+            .expect("a missing source block must decline, not error");
+        assert!(!collapsed, "nothing was merged, so nothing to re-process");
+    }
+
+    /// #2667 — the same locality point for the source *scope*. `rebuild`
+    /// checks `!scope.is_empty()` on a clone taken before its recursive call,
+    /// so by the time `collapse` pops the last statement the scope may have
+    /// been merged away. Declining must also leave the scope where it was:
+    /// `collapse` removes it from the map before popping.
+    #[test]
+    fn collapse_declines_and_restores_when_the_source_scope_is_empty() {
+        let mut cfg = Cfg {
+            blocks: BTreeMap::new(),
+            entry: 0,
+            exit: 3,
+        };
+        cfg.blocks.insert(
+            0,
+            CodeBlock {
+                begin: 0,
+                end: 0,
+                next: 1,
+                on_false: 2,
+                condition: Some("t".to_string()),
+            },
+        );
+        // Operand falls through to the rejoin, so the collapse gets as far as
+        // popping the source scope's last statement.
+        cfg.blocks.insert(
+            1,
+            CodeBlock {
+                begin: 1,
+                end: 1,
+                next: 2,
+                on_false: END,
+                condition: None,
+            },
+        );
+        cfg.blocks.insert(
+            2,
+            CodeBlock {
+                begin: 2,
+                end: 2,
+                next: 3,
+                on_false: END,
+                condition: None,
+            },
+        );
+        let mut scopes: BTreeMap<usize, Vec<Node>> = BTreeMap::new();
+        scopes.insert(0, Vec::new());
+        scopes.insert(
+            1,
+            vec![Node::assign(
+                SYNTH_IP,
+                Node::constant(SYNTH_IP, id("t")),
+                Node::constant(SYNTH_IP, id("b")),
+            )],
+        );
+        let mut pass = BoolPass {
+            cfg: &mut cfg,
+            scopes: &mut scopes,
+            func_name: "EmptySource",
+        };
+
+        let collapsed = pass
+            .collapse(0, "t", BoolOp::And)
+            .expect("an empty source scope must decline, not error");
+        assert!(!collapsed);
+        assert!(
+            pass.scopes.contains_key(&0),
+            "the declined source scope must be put back, not left removed"
+        );
+        assert!(
+            pass.cfg.blocks.contains_key(&1) && pass.scopes.contains_key(&1),
+            "declining must not consume the operand block"
+        );
+    }
+
+    /// #2667 — a self-referential rejoin edge. Merging it would run
+    /// `blocks.remove(&rejoin_key)` on the very block just rewritten through
+    /// `blocks.get_mut(&current)`, leaving every predecessor pointing at a
+    /// hole. Sibling of `collapse_declines_when_operand_and_rejoin_keys_are_equal`.
+    #[test]
+    fn collapse_declines_when_the_rejoin_is_the_source_itself() {
+        let mut cfg = Cfg {
+            blocks: BTreeMap::new(),
+            entry: 0,
+            exit: 2,
+        };
+        cfg.blocks.insert(
+            0,
+            CodeBlock {
+                begin: 0,
+                end: 0,
+                next: 1,
+                // `&&` takes the false edge as the rejoin — point it at self.
+                on_false: 0,
+                condition: Some("t".to_string()),
+            },
+        );
+        cfg.blocks.insert(
+            1,
+            CodeBlock {
+                begin: 1,
+                end: 1,
+                next: 0,
+                on_false: END,
+                condition: None,
+            },
+        );
+        let mut scopes: BTreeMap<usize, Vec<Node>> = BTreeMap::new();
+        for key in [0usize, 1] {
+            scopes.insert(
+                key,
+                vec![Node::assign(
+                    SYNTH_IP,
+                    Node::constant(SYNTH_IP, id("t")),
+                    Node::constant(SYNTH_IP, id("a")),
+                )],
+            );
+        }
+        let mut pass = BoolPass {
+            cfg: &mut cfg,
+            scopes: &mut scopes,
+            func_name: "SelfRejoin",
+        };
+
+        let collapsed = pass
+            .collapse(0, "t", BoolOp::And)
+            .expect("a self-referential rejoin must decline, not error");
+        assert!(!collapsed);
+        assert!(
+            pass.cfg.blocks.contains_key(&0),
+            "the source block must survive its own declined collapse"
+        );
+    }
+
     /// SCR-D2-01 (#1815) — an adversarial / malformed `.pex` that would nest
     /// short-circuit operands deeper than the cap is rejected with a
     /// `RecursionLimit` error rather than overflowing the stack. Mirrors
@@ -573,6 +774,18 @@ mod tests {
         assert!(
             matches!(err, DecompileError::RecursionLimit { limit, .. } if limit == MAX_REBUILD_DEPTH),
             "got {err:?}"
+        );
+        // #2667 — and it must name *this* pass. The message used to hardcode
+        // "control-flow reconstruction", so a short-circuit-chain overflow
+        // sent triage to the other file.
+        let text = err.to_string();
+        assert!(
+            text.contains("short-circuit boolean"),
+            "a boolean-pass overflow must say so: {text}"
+        );
+        assert!(
+            !text.contains("control-flow"),
+            "and must not attribute itself to the control-flow pass: {text}"
         );
     }
 }

--- a/crates/pex/src/decompile/control_flow.rs
+++ b/crates/pex/src/decompile/control_flow.rs
@@ -107,6 +107,7 @@ impl Reconstructor {
     ) -> Result<Vec<Node>, DecompileError> {
         if depth > MAX_REBUILD_DEPTH {
             return Err(DecompileError::RecursionLimit {
+                pass: "control-flow",
                 function: self.func_name.clone(),
                 limit: MAX_REBUILD_DEPTH,
             });
@@ -277,6 +278,9 @@ mod tests {
             matches!(err, DecompileError::RecursionLimit { limit, .. } if limit == MAX_REBUILD_DEPTH),
             "got {err:?}"
         );
+        // #2667 — the message is per-pass now; this is the pass whose name it
+        // used to hardcode for both.
+        assert!(err.to_string().contains("control-flow"), "got {err}");
     }
 
     /// SCR-D3-01 (#1732) — when the block before the false exit is itself

--- a/crates/pex/src/decompile/lift.rs
+++ b/crates/pex/src/decompile/lift.rs
@@ -400,7 +400,26 @@ pub(super) fn rebuild_expression(
                 let producer = std::mem::replace(&mut scope[i], placeholder);
                 let mut slot = Some(producer);
                 replace_constant_id(&mut scope[j], &temp, &mut slot);
-                debug_assert!(slot.is_none(), "verified single match must be consumed");
+                if slot.is_some() {
+                    // #2666 / SCR-D2-NEW11-01 — this was a `debug_assert!`,
+                    // i.e. nothing at all in release. The postcondition it
+                    // states ("the match `count_constant_id` verified was
+                    // consumed") spans two independently maintained
+                    // traversals: the count walks `Node::child_nodes()`, the
+                    // replace walks `Node::child_nodes_mut()`. They agree
+                    // today — pinned by `node.rs`'s parity test as of this
+                    // fix — but if one ever gains an arm the other lacks, the
+                    // release build would take the *success* path with the
+                    // producer still in hand: the statement is unlinked below
+                    // and dropped, while its consumer keeps a dangling
+                    // `::tempN` reference. That is a wrong AST emitted
+                    // without an error, the one degradation this pass's `>1`
+                    // arm already refuses to make. Fail closed the same way.
+                    return Err(DecompileError::ExpressionRebuildFailed {
+                        function: func_name.to_string(),
+                        ip: scope[j].begin,
+                    });
+                }
 
                 // Unlink `i` from the live chain.
                 removed[i] = true;

--- a/crates/pex/src/decompile/mod.rs
+++ b/crates/pex/src/decompile/mod.rs
@@ -63,12 +63,21 @@ pub enum DecompileError {
     #[error("failed to rebuild control flow in '{function}'")]
     ControlFlowFailed { function: String },
 
-    /// Control-flow reconstruction nested deeper than the recursion cap —
-    /// a malformed / adversarial `.pex` (SAFE-2026-06-23-02). Bounded so an
+    /// A reconstruction pass nested deeper than its recursion cap — a
+    /// malformed / adversarial `.pex` (SAFE-2026-06-23-02). Bounded so an
     /// untrusted plugin can't blow the stack; the cap sits far above any
     /// real Papyrus nesting depth.
-    #[error("control-flow reconstruction in '{function}' exceeded the recursion limit ({limit})")]
-    RecursionLimit { function: String, limit: usize },
+    ///
+    /// #2667 — `pass` exists because two passes raise this (`boolean`, one
+    /// step before `control_flow`) and the message used to hardcode
+    /// "control-flow reconstruction", so a short-circuit-chain overflow was
+    /// reported as a control-flow failure and sent triage to the wrong file.
+    #[error("{pass} reconstruction in '{function}' exceeded the recursion limit ({limit})")]
+    RecursionLimit {
+        pass: &'static str,
+        function: String,
+        limit: usize,
+    },
 
     /// The `.pex` carried no object to decompile into a script.
     #[error(".pex has no object to decompile")]

--- a/crates/pex/src/decompile/node.rs
+++ b/crates/pex/src/decompile/node.rs
@@ -433,3 +433,170 @@ pub(crate) fn is_temp_var(name: &str) -> bool {
     (name.len() > 6 && name.starts_with("::temp") && !name.ends_with("_var"))
         || name.eq_ignore_ascii_case("::nonevar")
 }
+
+/// #2666 (SCR-D2-NEW11-01) — [`Node::child_nodes`] and
+/// [`Node::child_nodes_mut`] are two independently maintained traversals over
+/// the same shape, and copy-propagation splits its work across them: the
+/// count runs on the immutable one, the substitution on the mutable one.
+///
+/// They agreed by inspection but nothing pinned it, and this file had no
+/// tests at all. A variant enumerated by one and not the other is a silent
+/// wrong AST — `lift::rebuild_expression` now fails closed on the mismatch
+/// instead of a `debug_assert!`, but the mismatch itself should never get
+/// that far.
+#[cfg(test)]
+mod child_traversal_parity_tests {
+    use super::*;
+
+    /// Bump together with [`variant_name`]'s match — the count is what turns
+    /// "added a `NodeKind` variant and an arm, but no sample" into a failure
+    /// rather than a silent coverage hole.
+    const NODE_KIND_VARIANTS: usize = 16;
+
+    fn leaf(tag: &str) -> Node {
+        Node::constant(0, Value::Identifier(tag.to_string()))
+    }
+
+    /// Exhaustive by construction: adding a `NodeKind` variant stops this
+    /// compiling until it is named here (there is deliberately no `_` arm).
+    fn variant_name(kind: &NodeKind) -> &'static str {
+        match kind {
+            NodeKind::Constant(_) => "Constant",
+            NodeKind::IdentifierString(_) => "IdentifierString",
+            NodeKind::BinaryOp { .. } => "BinaryOp",
+            NodeKind::UnaryOp { .. } => "UnaryOp",
+            NodeKind::Copy { .. } => "Copy",
+            NodeKind::Cast { .. } => "Cast",
+            NodeKind::Assign { .. } => "Assign",
+            NodeKind::CallMethod { .. } => "CallMethod",
+            NodeKind::Return { .. } => "Return",
+            NodeKind::PropertyAccess { .. } => "PropertyAccess",
+            NodeKind::ArrayCreate { .. } => "ArrayCreate",
+            NodeKind::ArrayLength { .. } => "ArrayLength",
+            NodeKind::ArrayAccess { .. } => "ArrayAccess",
+            NodeKind::StructCreate { .. } => "StructCreate",
+            NodeKind::IfElse { .. } => "IfElse",
+            NodeKind::While { .. } => "While",
+        }
+    }
+
+    /// One node per variant. Multi-child shapes get *distinguishable*
+    /// children so the comparison below catches a reordering, not just a
+    /// count change.
+    fn one_of_every_kind() -> Vec<Node> {
+        vec![
+            leaf("bare"),
+            Node::identifier_string(0, "Parent"),
+            Node {
+                kind: NodeKind::BinaryOp {
+                    left: Box::new(leaf("l")),
+                    op: "+".to_string(),
+                    right: Box::new(leaf("r")),
+                },
+                result: None,
+                begin: 0,
+                end: 0,
+                precedence: 0,
+            },
+            wrap(NodeKind::UnaryOp {
+                op: "!".to_string(),
+                operand: Box::new(leaf("o")),
+            }),
+            wrap(NodeKind::Copy {
+                value: Box::new(leaf("v")),
+            }),
+            wrap(NodeKind::Cast {
+                value: Box::new(leaf("v")),
+                target_type: "Int".to_string(),
+            }),
+            wrap(NodeKind::Assign {
+                dest: Box::new(leaf("d")),
+                value: Box::new(leaf("v")),
+            }),
+            wrap(NodeKind::CallMethod {
+                object: Box::new(leaf("obj")),
+                method: "Foo".to_string(),
+                params: vec![leaf("p0"), leaf("p1")],
+                experimental: false,
+            }),
+            wrap(NodeKind::Return {
+                value: Some(Box::new(leaf("rv"))),
+            }),
+            // The `None` payload is its own shape — zero children through a
+            // field that usually has one.
+            wrap(NodeKind::Return { value: None }),
+            wrap(NodeKind::PropertyAccess {
+                object: Box::new(leaf("obj")),
+                property: "Bar".to_string(),
+            }),
+            wrap(NodeKind::ArrayCreate {
+                element_type: "Int".to_string(),
+                size: Box::new(leaf("n")),
+            }),
+            wrap(NodeKind::ArrayLength {
+                array: Box::new(leaf("a")),
+            }),
+            wrap(NodeKind::ArrayAccess {
+                array: Box::new(leaf("a")),
+                index: Box::new(leaf("i")),
+            }),
+            wrap(NodeKind::StructCreate {
+                struct_type: "S".to_string(),
+            }),
+            wrap(NodeKind::IfElse {
+                condition: Box::new(leaf("c")),
+                body: vec![leaf("b0")],
+                else_body: vec![leaf("e0"), leaf("e1")],
+                else_if: vec![leaf("ei0")],
+            }),
+            wrap(NodeKind::While {
+                condition: Box::new(leaf("c")),
+                body: vec![leaf("b0"), leaf("b1")],
+            }),
+        ]
+    }
+
+    fn wrap(kind: NodeKind) -> Node {
+        Node {
+            kind,
+            result: None,
+            begin: 0,
+            end: 0,
+            precedence: 0,
+        }
+    }
+
+    #[test]
+    fn child_nodes_and_child_nodes_mut_enumerate_the_same_children() {
+        for mut node in one_of_every_kind() {
+            let name = variant_name(&node.kind);
+            let immutable: Vec<Node> = node.child_nodes().into_iter().cloned().collect();
+            let mutable: Vec<Node> = node
+                .child_nodes_mut()
+                .into_iter()
+                .map(|child| child.clone())
+                .collect();
+            assert_eq!(
+                immutable, mutable,
+                "{name}: child_nodes() and child_nodes_mut() disagree — \
+                 copy-propagation counts with one and substitutes with the \
+                 other, so a divergence here is a wrong AST (#2666)"
+            );
+        }
+    }
+
+    #[test]
+    fn every_node_kind_variant_is_covered() {
+        let mut names: Vec<&'static str> = one_of_every_kind()
+            .iter()
+            .map(|node| variant_name(&node.kind))
+            .collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(
+            names.len(),
+            NODE_KIND_VARIANTS,
+            "the parity sample must cover every NodeKind variant; covered: {names:?}"
+        );
+    }
+}

--- a/crates/pex/src/model.rs
+++ b/crates/pex/src/model.rs
@@ -248,10 +248,21 @@ pub struct FunctionInfo {
     pub object_name: String,
     pub state_name: String,
     pub function_name: String,
-    /// `Method` / `Getter` / `Setter`; `Method` when the byte is unknown.
+    /// `Method` / `Getter` / `Setter`; `None` when the byte is unknown — the
+    /// `Option` exists for exactly that case (`reader.rs`'s `_ => None` arm).
     pub function_type: Option<FunctionType>,
-    /// One source line per instruction — the decompiler's boolean-operator
-    /// reconstruction uses these to avoid merging across source lines.
+    /// One source line per instruction, parsed to keep the debug-info stream
+    /// aligned. **Currently unread** — no consumer anywhere in the workspace.
+    ///
+    /// #2665 — this used to claim the boolean-operator pass consults these to
+    /// reject merges spanning source lines. It does not, and the difference is
+    /// load-bearing rather than cosmetic: declining that check is
+    /// `decompile::boolean`'s deliberate departure 1 from Champollion, and the
+    /// *edge shape* is what carries the guard instead (#2655 — without it a
+    /// `While` whose body recomputes the loop condition was silently collapsed
+    /// into an `&&` and the loop vanished). A reader trusting this docstring
+    /// would conclude a line check already backstops that pass and dismiss a
+    /// real cross-line merge bug as impossible.
     pub line_numbers: Vec<u16>,
 }
 

--- a/crates/scripting/src/scene/quest_alias_tests.rs
+++ b/crates/scripting/src/scene/quest_alias_tests.rs
@@ -442,6 +442,95 @@ fn quest_alias_closest_to_alias_selects_by_world_distance() {
     );
 }
 
+/// Regression for #2664 (SCR-D7-NEW11-03): a distance-ranked alias whose only
+/// candidate is a logical identity stub — a REFR that produced no 3D — must
+/// still fill.
+///
+/// The ranking loop reads `world.get::<GlobalTransform>(entity)?` *inside a
+/// `filter_map`*, so a candidate without one is not ranked last, it is dropped
+/// from the `min_by` entirely and `chosen` comes back `None`. The alias then
+/// stays unfilled with no log line and no error. That is exactly the shape the
+/// worldspace persistent-cell loader used to spawn for remote / spawn-less
+/// persistent `ACHR`s — the population M47.3 was built around — because it
+/// open-coded `stamp_quest_reference` and inserted no transform.
+///
+/// Both directions are asserted: the transform-bearing stub fills, and the
+/// transform-less one silently does not. The second half is what makes the
+/// first half meaningful rather than incidentally true.
+#[test]
+fn quest_alias_closest_fill_needs_a_transform_on_its_only_candidate() {
+    use byroredux_core::math::{Quat, Vec3};
+
+    fn resolve_with_stub(stub_has_transform: bool) -> (World, Option<EntityId>) {
+        let mut world = World::new();
+        crate::register(&mut world);
+        world.register::<GlobalTransform>();
+        let anchor = world.spawn();
+        let stub = world.spawn();
+        for (entity, reference, base) in [(anchor, 0xA0, 0xB0), (stub, 0xA1, 0xB1)] {
+            world.insert(
+                entity,
+                SceneAliasCandidate {
+                    reference_form_id: reference,
+                    base_form_id: base,
+                    linked_refs: Vec::new(),
+                    location_ref_types: Vec::new(),
+                },
+            );
+        }
+        world.insert(
+            anchor,
+            GlobalTransform::new(Vec3::new(0.0, 0.0, 0.0), Quat::IDENTITY, 1.0),
+        );
+        if stub_has_transform {
+            world.insert(
+                stub,
+                GlobalTransform::new(Vec3::new(5.0, 0.0, 0.0), Quat::IDENTITY, 1.0),
+            );
+        }
+        install_scene_quest_aliases(
+            &mut world,
+            [QustRecord {
+                form_id: QUEST,
+                aliases: vec![
+                    QuestAlias {
+                        alias_id: 0,
+                        fill_type: Some(AliasFillType::ForcedReference(0xA0)),
+                        ..Default::default()
+                    },
+                    QuestAlias {
+                        alias_id: 1,
+                        fill_type: Some(AliasFillType::UniqueActor(0xB1)),
+                        closest_to_alias: Some(0),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+        );
+        refresh_scene_actor_bindings(&world);
+        let resolved = world
+            .resource::<SceneActorBindings>()
+            .resolve(QuestFormId(QUEST), 1);
+        (world, resolved)
+    }
+
+    let (_world, transform_bearing) = resolve_with_stub(true);
+    assert!(
+        transform_bearing.is_some(),
+        "a logical stub carrying a transform must still be rankable, or every \
+         distance-anchored alias over 3D-less references is unfillable"
+    );
+
+    let (_world, positionless) = resolve_with_stub(false);
+    assert_eq!(
+        positionless, None,
+        "premise check: without a transform the candidate is filtered out of the \
+         ranking entirely — this is the silent failure #2664 fixes at the spawn \
+         site, not something the resolver can recover from"
+    );
+}
+
 #[test]
 fn quest_alias_near_alias_resolves_linked_ref_child() {
     let mut world = World::new();


### PR DESCRIPTION
…stubs a transform, and stop three decompiler invariants from being inherited rather than local

Four findings from the 2026-08-12 scripting audit — one live, three latent.

#2664 (SCR-D7-NEW11-03) — the worldspace persistent-cell loader spawns a logical identity entity for every persistent ACHR with no 3D (remote actors, and local ones whose spawn produced no root). It built the FormIdComponent + SceneAliasCandidate pair by hand, a verbatim copy of stamp_quest_reference's body, and inserted no transform at all — even though placed.position was available and is converted elsewhere in the same file.

That is not cosmetic. resolve_alias_bindings ranks distance-anchored aliases (closest_to_alias, or ALIAS_FLAG_CLOSEST on the player) with world.get::<GlobalTransform>(entity)? inside a filter_map, so a transform-less candidate is not ranked last — it is dropped from the min_by entirely and `chosen` comes back None. An alias whose only candidates are persistent worldspace ACHRs silently never fills, with no log line and no error. That is precisely the population M47.3 was built around.

The stub now calls the same spawn_logical_quest_reference the interior / statics-miss path uses (widened to pub(crate)), with the REFR's own placement through the same conversion references::load_references_budgeted applies. The duplication goes with it, which is what #2541's invariant wanted. Pinned from both ends: a behavioural test in byroredux-scripting asserting a distance- ranked alias with a single stub candidate fills — and, as the premise check, that it does not when the transform is absent — plus a source pin on the call site, since driving PersistentCellApplyJob::apply needs Vulkan and game data. stamp_quest_reference is now the only production constructor of SceneAliasCandidate.

#2665 (SCR-D1-NEW11-01) — FunctionInfo::line_numbers claimed the boolean pass consults it to reject merges spanning source lines. It has zero readers anywhere in the workspace, and declining that check is decompile::boolean's deliberate departure 1 from Champollion. The docstring advertised a false-positive-merge guard that does not exist, on exactly the pass where #2655 showed the absent guard silently erasing a While loop — a reader trusting it would dismiss a real cross-line merge bug as impossible. function_type likewise claimed a Method fallback where the reader maps unknown bytes to None.

#2666 (SCR-D2-NEW11-01) — rebuild_expression's "verified single match must be consumed" postcondition was a debug_assert!, i.e. nothing in release. It spans two independently maintained traversals: count_constant_id walks child_nodes(), replace_constant_id walks child_nodes_mut(). If one ever gains an arm the other lacks, the release build takes the success path with the producer still in hand — the statement is unlinked and dropped while its consumer keeps a dangling ::tempN, a wrong AST emitted without an error. It now returns ExpressionRebuildFailed, the same fail-closed decline the >1 arm already makes. node.rs gains its first tests: a parity check over all 16 NodeKind variants whose exhaustive match makes adding a variant a compile error until it is covered. Verified the test bites by temporarily dropping else_if from the mutable traversal.

#2667 (SCR-D3-NEW11-02) — collapse's .expects were invariants inherited from the depth cap rather than held locally. rebuild verifies the block and scope before recursing into the operand range, but a nested collapse whose rejoin is an enclosing (on-stack) block removes that ancestor; the ancestor's own collapse then looks up a hole. The panic is unreachable today only because the adopted edge forces rebuild back into the range it is walking, so MAX_REBUILD_DEPTH fires first — a property of a cap, and no guarantee at all if the cap is raised or bypassed. Both are now declines, and a new guard rejects a self-referential operand/rejoin edge (sibling of #2028's degenerate-shape decline), which is also what makes the two remaining get_mut(&current).expect uses locally sound: after it, nothing can remove `current` mid-collapse.

The module doc's termination argument is narrowed to the iterative loop it actually covers — the same edge adoption can drive rebuild's recursion back into its own block range, and MAX_REBUILD_DEPTH is what bounds that. DecompileError::RecursionLimit gains a `pass` discriminant: two passes raise it and the message hardcoded "control-flow reconstruction", so a short-circuit chain overflow sent triage to the wrong file.

Corpus validation for the two decompiler changes: pex_corpus_smoke over Skyrim - Misc.bsa + Fallout4 - Misc.ba2 decompiles 21900/21901 (100.0%) with 0 panics — byte-identical to the pre-change baseline, so the added declines cost nothing on real content. The R5 fidelity gate passes against on-disk Skyrim SE data too.

Pre-existing and unrelated: byroredux/src/render/fire_lights.rs's derived_reach_is_currently_oversized_pending_a_unit_correct_derivation fails on main.