### PR TITLE
Fix #2567 Fix #2570: route placed creatures through a creature-shaped…

### DIFF
--- a/.claude/issues/2567-2570/ISSUE.md
+++ b/.claude/issues/2567-2570/ISSUE.md
@@ -1,0 +1,66 @@
+# #2567 #2568 #2569 #2570 — Oblivion audit closeout (2026-08-14)
+
+Four findings from the Oblivion per-game audit. **Two were fixed, one was
+measured false, one is deliberately half-landed.**
+
+## #2567 (OBL-D3-01) — MEDIUM, fixed
+Placed creatures never reached the actor pipeline: `NPC_` and `CREA` parse into
+two disjoint maps and every actor test in the cell loader read only `npcs`.
+
+The audit's suggested fix — "thread `index.creatures` alongside `index.npcs`,
+extend actor-detection to check both" — was verified against real data and is
+**wrong on its own**. Dumping `Oblivion.esm`:
+
+    MODL = "Creatures\Rat\Skeleton.NIF"        <- the SKELETON, not a body
+    NIFZ = Eyes/Head/mange/Rat/Whiskers.NIF    <- body parts, unparsed
+    RNAM = 0x60 (1 byte)                       <- attack reach, NOT a race ref
+
+`NpcSpawnJob::runtime` hardcodes humanoid assets (`characters\_male\
+upperbody.nif` + hands, RACE head, hair/brow/eyes), so routing alone would
+spawn a human torso for a rat — worse than the static-mesh render it replaces.
+
+**Implemented**: `NIFZ` parsing + an `is_creature` flag (plugin), a creature
+branch in `prepare_runtime_state` filling the *same* `RuntimePhase` machine
+from creature sources, per-creature skeleton + `idle.kf`, and `EsmIndex::actor`
+/ `is_actor` as the single actor-detection accessor. The now-redundant `npcs`
+parameter was removed from `load_references*` so the two maps cannot drift
+apart at a call site again.
+
+**Measured** (`Oblivion.esm` + all `* - Meshes.bsa`, in-tree self-skipping test):
+909/909 creature skeletons resolve, 3936/4043 NIFZ parts (residual are DLC-only
+meshes), 909/909 `idle.kf` clips.
+
+## #2568 (OBL-D4-01) — HIGH as filed, **premise false**
+Claimed Oblivion's legacy `NiParticleSystemController` /
+`NiAutoNormalParticles` stack renders no particles. Swept every installed
+target game for those block types:
+
+| archive | NIFs | legacy blocks | `NiParticleSystem` |
+|---|---|---|---|
+| Oblivion - Meshes | 8032 | **0** | 547 |
+| DLCShiveringIsles - Meshes | 1438 | **0** | 231 |
+| Fallout New Vegas | 14881 | **0** | 1262 |
+| Fallout 3 | 10989 | **0** | 422 |
+| Skyrim SE - Meshes0 | 18862 | **0** | 1173 |
+
+Oblivion (v20.0.0.5) is already fully on the modern stack. The in-code comment
+the audit called false is true; the *actually* stale claim is the block
+dispatcher's own "Oblivion magic FX, fire, dust, blood" (Morrowind-era). A
+working emission arm was written, then dropped on the user's call — it would be
+unreachable code. The measurement is now recorded at all three sites so this
+isn't re-filed a fourth time.
+
+## #2569 (OBL-D4-02) — MEDIUM, half-landed by decision
+The legacy Lambert arm is duplicated and the copies disagree: clustered
+`kD*albedo`, fallback `kD*albedo/PI` then `*0.8` — `0.8/PI ≈ 0.2546` on diffuse
+but `0.8` on specular, and the same split applies to the Disney arm. Landed:
+the parity tripwire (pinning the divergence, not asserting parity) plus
+cross-referencing comments at both GLSL sites. **Not landed**: the shader edit
+itself, which changes brightness on a path `cargo test` cannot observe — it
+needs a live capture per project policy. Issue stays open for that half.
+
+## #2570 (OBL-D4-04) — LOW, fixed
+Added the negative test the issue asks for: legacy-only material input yields
+`is_pbr == false`, and deriving legacy PBR *scalars* does not promote a
+material onto the Disney lobe. This is what makes `MAT_FLAG_PBR_BSDF` provably
+0 for Oblivion instead of accidentally so.

--- a/byroredux/src/cell_loader/exterior.rs
+++ b/byroredux/src/cell_loader/exterior.rs
@@ -209,7 +209,6 @@ impl PersistentCellApplyJob {
                 &self.local_refs,
                 &wctx.record_index.cells,
                 &wctx.record_index,
-                &wctx.record_index.npcs,
                 &wctx.record_index.races,
                 wctx.record_index.game,
                 world,
@@ -320,7 +319,10 @@ impl PersistentCellApplyJob {
         let local_actor_refs: Vec<_> = self
             .local_refs
             .iter()
-            .filter(|placed| wctx.record_index.npcs.contains_key(&placed.base_form_id))
+            // #2567 — `is_actor` covers CREA as well as NPC_, so a
+            // persistent creature is counted and stubbed like any other actor
+            // instead of being invisible to the actor bookkeeping entirely.
+            .filter(|placed| wctx.record_index.is_actor(placed.base_form_id))
             .collect();
         self.local_actor_count = local_actor_refs.len();
         self.local_actor_3d = local_actor_refs
@@ -367,7 +369,7 @@ pub(crate) fn begin_worldspace_persistent_cell(
     for placed in &cell.references {
         if persistent_position_is_local(placed.position, center_grid, full_3d_radius) {
             local_refs.push(placed.clone());
-        } else if wctx.record_index.npcs.contains_key(&placed.base_form_id) {
+        } else if wctx.record_index.is_actor(placed.base_form_id) {
             remote_actor_refs.push(placed.clone());
         }
     }
@@ -1239,7 +1241,6 @@ impl ExteriorCellApplyJob {
             &cell.references,
             index,
             &wctx.record_index,
-            &wctx.record_index.npcs,
             &wctx.record_index.races,
             wctx.record_index.game,
             world,

--- a/byroredux/src/cell_loader/load.rs
+++ b/byroredux/src/cell_loader/load.rs
@@ -409,7 +409,6 @@ pub fn load_cell_with_masters(
         &cell.references,
         &index.cells,
         &index,
-        &index.npcs,
         &index.races,
         index.game,
         world,

--- a/byroredux/src/cell_loader/references/mod.rs
+++ b/byroredux/src/cell_loader/references/mod.rs
@@ -191,14 +191,13 @@ fn worldspace_extent_over_rt_ceiling(bounds_min: Vec3, bounds_max: Vec3) -> Opti
 #[tracing::instrument(
     name = "load_references",
     skip_all,
-    fields(ref_count = refs.len(), npc_count = npcs.len(), race_count = races.len(), game = ?game, label = label),
+    fields(ref_count = refs.len(), actor_count = record_index.npcs.len() + record_index.creatures.len(), race_count = races.len(), game = ?game, label = label),
 )]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn load_references(
     refs: &[esm::cell::PlacedRef],
     index: &esm::cell::EsmCellIndex,
     record_index: &byroredux_plugin::esm::records::EsmIndex,
-    npcs: &HashMap<u32, byroredux_plugin::esm::records::NpcRecord>,
     races: &HashMap<u32, byroredux_plugin::esm::records::RaceRecord>,
     game: byroredux_plugin::esm::reader::GameKind,
     world: &mut World,
@@ -220,7 +219,6 @@ pub(super) fn load_references(
         refs,
         index,
         record_index,
-        npcs,
         races,
         game,
         world,
@@ -252,7 +250,6 @@ pub(super) fn load_references_budgeted(
     refs: &[esm::cell::PlacedRef],
     index: &esm::cell::EsmCellIndex,
     record_index: &byroredux_plugin::esm::records::EsmIndex,
-    npcs: &HashMap<u32, byroredux_plugin::esm::records::NpcRecord>,
     races: &HashMap<u32, byroredux_plugin::esm::records::RaceRecord>,
     game: byroredux_plugin::esm::reader::GameKind,
     world: &mut World,
@@ -542,7 +539,13 @@ pub(super) fn load_references_budgeted(
             // placement root alive across frames, advancing one body/head/
             // armor part at a time.  Synchronous interiors drive this exact
             // job with an unlimited budget through `load_references`.
-            if let Some(npc) = npcs.get(&child_form_id) {
+            // #2567 (OBL-D3-01) — `record_index.actor` covers `NPC_` **and**
+            // `CREA`. This site used to read the `npcs` map alone, so every
+            // placed creature (Oblivion `ACRE`, and `ACHR`→`CREA` from FO3 on)
+            // missed the actor pipeline entirely and fell through to the
+            // static-mesh path below — which rendered the creature's MODL, i.e.
+            // its bare skeleton, and never animated it.
+            if let Some(npc) = record_index.actor(child_form_id) {
                 if job.active_npc.is_none() {
                     job.accum.bounds_min = job.accum.bounds_min.min(ref_pos);
                     job.accum.bounds_max = job.accum.bounds_max.max(ref_pos);

--- a/byroredux/src/npc_spawn.rs
+++ b/byroredux/src/npc_spawn.rs
@@ -227,6 +227,55 @@ pub fn humanoid_skeleton_path(game: GameKind) -> Option<&'static str> {
 /// Fallout - Meshes.bsa). Mods may add a separate female set; the
 /// gender split can be re-introduced on the signature at that point.
 /// See TD8-018 / #1117 for the placeholder-arg removal rationale.
+/// Split a creature's `CREA` MODL into `(skeleton path, directory prefix)`,
+/// both normalised to the archive's `meshes\…` convention.
+///
+/// #2567 — a creature's whole asset set lives in one directory, keyed off
+/// MODL. Verified against `Oblivion.esm` + `Oblivion - Meshes.bsa`:
+/// `MODL = "Creatures\Rat\Skeleton.NIF"`, and beside it in the archive sit
+/// `rat.nif`, `head.nif`, `whiskers.nif` (the `NIFZ` list) plus `idle.kf`,
+/// `forward.kf`, `turnleft.kf` … So the directory *is* the creature's
+/// namespace, and every path this module derives for a creature is that
+/// prefix plus an authored filename — never a guessed one.
+///
+/// `None` when the record has no MODL (nothing to anchor to).
+pub fn creature_skeleton_and_dir(model_path: &str) -> Option<(String, String)> {
+    if model_path.is_empty() {
+        return None;
+    }
+    let skeleton = normalize_mesh_path(model_path).into_owned();
+    // Both separators: MODL is authored with backslashes, but a mod tool can
+    // emit forward slashes and the archive layer accepts either.
+    let dir_end = skeleton.rfind(['\\', '/'])?;
+    let dir = skeleton[..=dir_end].to_owned();
+    Some((skeleton, dir))
+}
+
+/// Resolve a creature's `NIFZ` body-part filenames against its MODL
+/// directory (#2567). Entries are authored bare (`Rat.NIF`), so they are
+/// joined to the prefix from [`creature_skeleton_and_dir`] rather than
+/// normalised independently — a bare name has no `meshes\` to normalise.
+/// Case is left as authored; the archive layer lowercases on lookup.
+pub fn creature_body_paths(dir: &str, body_part_models: &[String]) -> Vec<String> {
+    body_part_models
+        .iter()
+        .filter(|name| !name.is_empty())
+        .map(|name| format!("{dir}{name}"))
+        .collect()
+}
+
+/// A creature's own idle clip, beside its skeleton (#2567).
+///
+/// Creatures do not share the humanoid `idle.kf` — a rat's skeleton has
+/// none of the humanoid bone names, so the shared per-cell idle pool
+/// animates nothing. Every vanilla Oblivion creature directory ships its
+/// own `idle.kf` (verified over `Oblivion - Meshes.bsa`); a creature whose
+/// directory lacks one simply gets no idle, which is the pre-#2567 status
+/// quo rather than a regression.
+pub fn creature_idle_kf_path(dir: &str) -> String {
+    format!("{dir}idle.kf")
+}
+
 pub fn humanoid_body_paths(game: GameKind) -> &'static [&'static str] {
     match game {
         // Oblivion's mesh layout uses the same `_male\` directory shape

--- a/byroredux/src/npc_spawn/resumable.rs
+++ b/byroredux/src/npc_spawn/resumable.rs
@@ -57,6 +57,16 @@ struct RuntimeNpcState {
     placement_root: EntityId,
     skel_root: Option<EntityId>,
     skel_map: SkeletonMap,
+    /// Skeleton NIF for this actor. Per-game canonical path for `NPC_`;
+    /// the record's own MODL for `CREA`, whose skeleton is per-creature
+    /// (#2567). A field rather than a `humanoid_skeleton_path(game)` call in
+    /// the Skeleton phase precisely so the two can differ.
+    skeleton_path: String,
+    /// Actor-specific idle clip, when the actor doesn't animate off the
+    /// shared per-cell humanoid idle pool. `Some` for creatures — a rat's
+    /// skeleton shares no bone names with the humanoid rig, so the pooled
+    /// clip drives nothing (#2567).
+    idle_kf_path: Option<String>,
     body_paths: Vec<String>,
     head_path: Option<String>,
     hair_path: Option<String>,
@@ -227,7 +237,6 @@ impl NpcSpawnJob {
                     world,
                     ctx,
                     &self.npc,
-                    self.game,
                     tex_provider,
                     mat_provider.as_deref_mut(),
                     idle_pool,
@@ -313,6 +322,18 @@ fn prepare_runtime_state(
         ref_pos.z,
         ref_scale,
     );
+
+    // #2567 (OBL-D3-01) — creatures reuse this whole state machine (skeleton
+    // → parts → armor → finalize) but fill it from a different source. Their
+    // MODL *is* the skeleton and their meshes come from NIFZ beside it, so
+    // none of the humanoid recipe below (canonical body paths, RACE head,
+    // hair / brow / eye head-parts) applies: a `CREA` references no RACE at
+    // all — Oblivion's `CREA` `RNAM` is a 1-byte attack reach, not a FormID.
+    // Return early with the creature shape rather than threading `if
+    // is_creature` through every lookup.
+    if npc.is_creature {
+        return prepare_creature_state(world, npc, game, index, placement_root);
+    }
 
     let gender = Gender::from_acbs_flags(npc.acbs_flags);
     let effective_inventory =
@@ -410,12 +431,78 @@ fn prepare_runtime_state(
         placement_root,
         skel_root: None,
         skel_map: HashMap::new(),
+        skeleton_path: humanoid_skeleton_path(game).unwrap_or_default().to_owned(),
+        idle_kf_path: None,
         body_paths,
         head_path,
         hair_path,
         brow_path,
         eye_paths,
         eye_texture_override,
+        inventory: Some(inventory),
+        equipment_slots: Some(equipment_slots),
+        armor,
+        equipped_armor_count: 0,
+        phase: RuntimePhase::Skeleton,
+    }
+}
+
+/// The `CREA` counterpart of [`prepare_runtime_state`]'s humanoid recipe
+/// (#2567). Everything a creature needs is authored in one directory keyed
+/// off its MODL — skeleton, `NIFZ` part meshes, and `idle.kf` — so this is a
+/// path derivation plus the shared inventory build, and the same
+/// [`RuntimePhase`] machine runs it from there.
+///
+/// Head / hair / brow / eye stay `None`: those are head-*part* records
+/// reached through RACE, and a creature has no RACE. Its face, where it has
+/// one, is simply another `NIFZ` entry (`Head.NIF` beside `Rat.NIF`).
+fn prepare_creature_state(
+    world: &mut World,
+    npc: &NpcRecord,
+    game: GameKind,
+    index: &EsmIndex,
+    placement_root: EntityId,
+) -> RuntimeNpcState {
+    let (skeleton_path, dir) = creature_skeleton_and_dir(&npc.model_path).unwrap_or_default();
+    let body_paths = creature_body_paths(&dir, &npc.body_part_models);
+    if skeleton_path.is_empty() {
+        log::debug!(
+            "Creature {:08X} ({}): no MODL — cannot locate a skeleton, spawning identity only",
+            npc.form_id,
+            npc.editor_id,
+        );
+    } else if body_paths.is_empty() {
+        // The skeleton NIF carries no geometry of its own, so a creature
+        // with no NIFZ is invisible. Worth a line: it means either an
+        // unparsed sub-record or genuinely mesh-less content.
+        log::debug!(
+            "Creature {:08X} ({}): skeleton '{}' has no NIFZ body parts — no visible mesh",
+            npc.form_id,
+            npc.editor_id,
+            skeleton_path,
+        );
+    }
+    let idle_kf_path = (!dir.is_empty()).then(|| creature_idle_kf_path(&dir));
+
+    let gender = Gender::from_acbs_flags(npc.acbs_flags);
+    let effective_inventory =
+        byroredux_plugin::equip::resolve_inherited_inventory(npc, npc.level, index);
+    let (inventory, equipment_slots, armor) =
+        build_runtime_equip_state(npc, game, gender, index, effective_inventory);
+
+    let _ = world;
+    RuntimeNpcState {
+        placement_root,
+        skel_root: None,
+        skel_map: HashMap::new(),
+        skeleton_path,
+        idle_kf_path,
+        body_paths,
+        head_path: None,
+        hair_path: None,
+        brow_path: None,
+        eye_paths: Vec::new(),
+        eye_texture_override: None,
         inventory: Some(inventory),
         equipment_slots: Some(equipment_slots),
         armor,
@@ -517,7 +604,9 @@ fn advance_runtime_unit(
     world: &mut World,
     ctx: &mut VulkanContext,
     npc: &NpcRecord,
-    game: GameKind,
+    // #2567 — `game` used to select the skeleton path here; that moved onto
+    // `RuntimeNpcState::skeleton_path` at prepare time so creatures can carry
+    // their own, and nothing else in this function needed it.
     tex_provider: &TextureProvider,
     mat_provider: Option<&mut MaterialProvider>,
     idle_pool: &[u32],
@@ -525,9 +614,14 @@ fn advance_runtime_unit(
 ) -> UnitOutcome {
     match state.phase {
         RuntimePhase::Skeleton => {
-            let Some(skel_path) = humanoid_skeleton_path(game) else {
+            // #2567 — was `humanoid_skeleton_path(game)`; now whatever the
+            // prepare step resolved, so a creature loads its own per-species
+            // skeleton instead of the humanoid rig.
+            if state.skeleton_path.is_empty() {
                 return UnitOutcome::Complete(None);
-            };
+            }
+            let skel_path = state.skeleton_path.clone();
+            let skel_path = skel_path.as_str();
             let Some(skel_data) = tex_provider.extract_mesh(skel_path) else {
                 log::warn!(
                     "NPC {:08X} ({}): skeleton '{}' not found in archives — skipping spawn",
@@ -764,7 +858,28 @@ fn advance_runtime_unit(
                         consumed_idle_serial: 0,
                     },
                 );
-                if let Some(handle) = pick_idle_handle(idle_pool, npc.form_id) {
+                // #2567 — a creature animates off its own `idle.kf`, beside
+                // its skeleton. The shared per-cell pool holds the humanoid
+                // clip, whose bone names a creature rig doesn't have, so
+                // falling back to it would play nothing. Load-on-finalize
+                // (rather than at prepare) because this is where the
+                // `TextureProvider` is in hand.
+                let idle_handle = match state.idle_kf_path.as_deref() {
+                    Some(path) => {
+                        let handle = load_kf_clip_by_path(world, tex_provider, path);
+                        if handle.is_none() {
+                            log::debug!(
+                                "Creature {:08X} ({}): no idle clip at '{}' — spawning unanimated",
+                                npc.form_id,
+                                npc.editor_id,
+                                path,
+                            );
+                        }
+                        handle
+                    }
+                    None => pick_idle_handle(idle_pool, npc.form_id),
+                };
+                if let Some(handle) = idle_handle {
                     let duration = world
                         .resource::<AnimationClipRegistry>()
                         .get(handle)

--- a/byroredux/src/npc_spawn/tests.rs
+++ b/byroredux/src/npc_spawn/tests.rs
@@ -654,3 +654,165 @@ fn apply_ai_package_behavior_tags_nothing_without_ai_packages() {
     assert!(world.get::<GuardBehavior>(placement_root).is_none());
     assert!(world.get::<PatrolBehavior>(placement_root).is_none());
 }
+
+// ── #2567 (OBL-D3-01) — creature asset-path derivation ────────────
+
+/// The creature path rules, on the exact shape `Oblivion.esm` authors:
+/// `MODL` is the skeleton, `NIFZ` entries are bare filenames beside it.
+#[test]
+fn creature_paths_derive_from_the_modl_directory() {
+    let (skeleton, dir) = creature_skeleton_and_dir(r"Creatures\Rat\Skeleton.NIF")
+        .expect("a MODL with a directory resolves");
+    assert_eq!(skeleton, r"meshes\Creatures\Rat\Skeleton.NIF");
+    assert_eq!(dir, r"meshes\Creatures\Rat\");
+
+    let parts = creature_body_paths(
+        &dir,
+        &[
+            "Rat.NIF".to_string(),
+            "Head.NIF".to_string(),
+            "Whiskers.NIF".to_string(),
+        ],
+    );
+    assert_eq!(
+        parts,
+        vec![
+            r"meshes\Creatures\Rat\Rat.NIF".to_string(),
+            r"meshes\Creatures\Rat\Head.NIF".to_string(),
+            r"meshes\Creatures\Rat\Whiskers.NIF".to_string(),
+        ],
+        "NIFZ entries are authored bare and resolve against the MODL directory"
+    );
+    assert_eq!(creature_idle_kf_path(&dir), r"meshes\Creatures\Rat\idle.kf");
+}
+
+/// A creature whose MODL is already archive-prefixed must not gain a second
+/// `meshes\`, and one with no MODL at all must decline rather than derive
+/// paths from an empty prefix (which would produce `meshes\` + filename and
+/// silently look up the wrong files).
+#[test]
+fn creature_path_derivation_is_idempotent_and_declines_without_a_modl() {
+    let (skeleton, dir) = creature_skeleton_and_dir(r"meshes\Creatures\Rat\Skeleton.NIF").unwrap();
+    assert_eq!(skeleton, r"meshes\Creatures\Rat\Skeleton.NIF");
+    assert_eq!(dir, r"meshes\Creatures\Rat\");
+
+    assert!(creature_skeleton_and_dir("").is_none());
+    // Forward slashes (mod tooling) split on the same rule.
+    let (_, dir) = creature_skeleton_and_dir("Creatures/Rat/Skeleton.NIF").unwrap();
+    assert_eq!(dir, r"meshes\Creatures/Rat/");
+}
+
+/// #2567 corpus check: every path this module derives for a real Oblivion
+/// creature must actually exist in the shipped archive. This is what
+/// separates "routes through the actor pipeline" from "routes there and
+/// loads nothing" — the audit's suggested fix (check both maps, reuse the
+/// humanoid recipe) would have passed a routing test while spawning a human
+/// torso for a rat.
+///
+/// Self-skips without the game installed, like the other corpus sweeps in
+/// this tree; set `BYROREDUX_OBLIVION_DATA` to override the path.
+#[test]
+fn installed_oblivion_creature_assets_resolve_from_their_records() {
+    let data = std::env::var("BYROREDUX_OBLIVION_DATA")
+        .unwrap_or_else(|_| "/mnt/data/SteamLibrary/steamapps/common/Oblivion/Data".to_string());
+    let esm_path = std::path::Path::new(&data).join("Oblivion.esm");
+    let Ok(esm_bytes) = std::fs::read(&esm_path) else {
+        eprintln!(
+            "skipping installed_oblivion_creature_assets_resolve_from_their_records: \
+             {esm_path:?} not available"
+        );
+        return;
+    };
+    // EVERY mesh archive, not just the base one: Shivering Isles creatures
+    // (Grummite / Elytra / Hunger) live in `DLCShiveringIsles - Meshes.bsa`,
+    // and the engine has them all open per load order. Checking one archive
+    // would report a two-thirds hit rate for a derivation that is correct.
+    let archives: Vec<byroredux_bsa::BsaArchive> = std::fs::read_dir(&data)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.to_string_lossy()
+                .to_ascii_lowercase()
+                .ends_with("meshes.bsa")
+        })
+        .filter_map(|path| byroredux_bsa::BsaArchive::open(&path).ok())
+        .collect();
+    if archives.is_empty() {
+        eprintln!(
+            "skipping installed_oblivion_creature_assets_resolve_from_their_records: \
+             no mesh archives under {data:?}"
+        );
+        return;
+    }
+    let archive = |path: &str| archives.iter().any(|a| a.contains(path));
+    let index = byroredux_plugin::esm::parse_esm(&esm_bytes).expect("parse Oblivion.esm");
+    assert!(
+        !index.creatures.is_empty(),
+        "Oblivion.esm must yield CREA records"
+    );
+
+    let mut skeletons = (0usize, 0usize);
+    let mut parts = (0usize, 0usize);
+    let mut idles = (0usize, 0usize);
+    let mut misses = Vec::new();
+    for record in index.creatures.values() {
+        assert!(
+            record.is_creature,
+            "{:08X} came from the CREA group and must be flagged",
+            record.form_id
+        );
+        let Some((skeleton, dir)) = creature_skeleton_and_dir(&record.model_path) else {
+            continue;
+        };
+        if archive(&skeleton) {
+            skeletons.0 += 1;
+        } else {
+            skeletons.1 += 1;
+            if misses.len() < 8 {
+                misses.push(format!("skeleton {skeleton}"));
+            }
+        }
+        for path in creature_body_paths(&dir, &record.body_part_models) {
+            if archive(&path) {
+                parts.0 += 1;
+            } else {
+                parts.1 += 1;
+                if misses.len() < 8 {
+                    misses.push(format!("part {path}"));
+                }
+            }
+        }
+        if archive(&creature_idle_kf_path(&dir)) {
+            idles.0 += 1;
+        } else {
+            idles.1 += 1;
+        }
+    }
+
+    eprintln!(
+        "Oblivion creatures: skeletons {}/{} found, NIFZ parts {}/{} found, idle.kf {}/{} found",
+        skeletons.0,
+        skeletons.0 + skeletons.1,
+        parts.0,
+        parts.0 + parts.1,
+        idles.0,
+        idles.0 + idles.1,
+    );
+    // The derivation is the thing under test, so with every mesh archive open
+    // it has to be right for essentially all of them. A residual few point at
+    // meshes shipped only with a DLC plugin the base install may not have.
+    let skeleton_total = skeletons.0 + skeletons.1;
+    let part_total = parts.0 + parts.1;
+    assert!(
+        skeletons.0 * 100 >= skeleton_total * 90,
+        "only {}/{skeleton_total} creature skeletons resolved: {misses:?}",
+        skeletons.0
+    );
+    assert!(
+        parts.0 * 100 >= part_total * 90,
+        "only {}/{part_total} creature NIFZ parts resolved: {misses:?}",
+        parts.0
+    );
+}

--- a/crates/nif/src/blocks/mod.rs
+++ b/crates/nif/src/blocks/mod.rs
@@ -372,10 +372,29 @@ fn parse_block_inner(
         // NiTextureEffect — projected env-map / gobo / fog projector.
         // See issue #163.
         "NiTextureEffect" => Ok(Box::new(texture::NiTextureEffect::parse(stream)?)),
-        // Legacy (pre-NiPSys) particle stack — Oblivion magic FX, fire,
-        // dust, blood. See issue #143. NiBSPArrayController is an empty
-        // NiParticleSystemController subclass (zero additional fields)
-        // so it aliases to the same parser.
+        // Legacy (pre-NiPSys) particle stack. See issue #143.
+        // NiBSPArrayController is an empty NiParticleSystemController
+        // subclass (zero additional fields) so it aliases to the same parser.
+        //
+        // #2568 — this comment used to say "Oblivion magic FX, fire, dust,
+        // blood", and a later audit took it at face value and filed the
+        // absence of an emission arm as a HIGH-severity Oblivion rendering
+        // gap. **No target game authors this stack.** Measured over every
+        // installed vanilla mesh archive, counting these three block types:
+        //
+        //   Oblivion - Meshes      8032 NIFs -> 0   (NiParticleSystem:  547)
+        //   DLCShiveringIsles      1438 NIFs -> 0   (NiParticleSystem:  231)
+        //   Fallout New Vegas     14881 NIFs -> 0   (NiParticleSystem: 1262)
+        //   Fallout 3             10989 NIFs -> 0   (NiParticleSystem:  422)
+        //   Skyrim SE - Meshes0   18862 NIFs -> 0   (NiParticleSystem: 1173)
+        //
+        // Oblivion (v20.0.0.5) is already fully on the modern
+        // `NiParticleSystem` + `NiPSysEmitter` stack; the legacy types are
+        // Morrowind-era. The parsers stay because the dispatcher's job is to
+        // consume any well-formed block without truncating the stream (a
+        // dropped arm shifts every later block), NOT because the emission
+        // path is missing an Oblivion feature. Before adding one, re-measure:
+        // an import arm nothing can reach is dead code.
         "NiParticleSystemController" | "NiBSPArrayController" => Ok(Box::new(
             legacy_particle::NiParticleSystemController::parse(stream)?,
         )),

--- a/crates/nif/src/import/material/legacy_is_pbr_tests.rs
+++ b/crates/nif/src/import/material/legacy_is_pbr_tests.rs
@@ -1,0 +1,168 @@
+//! Regression tests for #2570 (OBL-D4-04) — the NIF import path must
+//! never mark a material PBR.
+//!
+//! `MAT_FLAG_PBR_BSDF` selects the Disney lobe in `lighting.glsl` and
+//! `triangle.frag`; everything else takes the legacy Lambert arm. Every
+//! writer that sets `is_pbr = true` sits behind an **external material
+//! file** merge (`.mat` / BGSM / BGEM), and Oblivion authors none of
+//! those — so today the flag is provably 0 for 100% of Oblivion content
+//! and the Disney lobe is unreachable there.
+//!
+//! That is a property of the code, not of the format, and nothing pinned
+//! it. A future "promote legacy specular / glossiness to PBR" heuristic
+//! added to the classifier would silently flip every Oblivion surface
+//! onto a lobe it was never authored for — a whole-game shading change
+//! with no test-level tripwire. These tests are that tripwire: the
+//! translation boundary is where the decision must be made (see
+//! `docs/engine/nifal.md`), so this is where it is pinned.
+
+use super::*;
+use crate::blocks::base::{NiAVObjectData, NiObjectNETData};
+use crate::blocks::properties::{NiMaterialProperty, NiTexturingProperty, TexDesc};
+use crate::blocks::tri_shape::NiTriShape;
+use crate::blocks::NiObject;
+use crate::types::{BlockRef, NiColor, NiTransform};
+use byroredux_core::string::StringPool;
+use std::sync::Arc;
+
+fn empty_net() -> NiObjectNETData {
+    NiObjectNETData {
+        name: None,
+        extra_data_refs: Vec::new(),
+        controller_ref: BlockRef::NULL,
+    }
+}
+
+fn make_tri_shape_with_props(properties: Vec<BlockRef>) -> NiTriShape {
+    NiTriShape {
+        av: NiAVObjectData {
+            net: NiObjectNETData {
+                name: Some(Arc::from("TestShape")),
+                extra_data_refs: Vec::new(),
+                controller_ref: BlockRef::NULL,
+            },
+            flags: 0,
+            transform: NiTransform::default(),
+            properties,
+            collision_ref: BlockRef::NULL,
+        },
+        data_ref: BlockRef::NULL,
+        skin_instance_ref: BlockRef::NULL,
+        shader_property_ref: BlockRef::NULL,
+        alpha_property_ref: BlockRef::NULL,
+        num_materials: 0,
+        active_material_index: 0,
+    }
+}
+
+/// An Oblivion-shaped property pair: `NiMaterialProperty` first (the
+/// order vanilla ships), then `NiTexturingProperty` with a base slot.
+/// Deliberately *glossy* — high shininess and a bright specular are the
+/// signals a "promote legacy specular to PBR" heuristic would key on.
+fn oblivion_shape_properties() -> (NiMaterialProperty, NiTexturingProperty) {
+    let mat = NiMaterialProperty {
+        net: empty_net(),
+        ambient: NiColor::default(),
+        diffuse: NiColor {
+            r: 0.8,
+            g: 0.8,
+            b: 0.8,
+        },
+        specular: NiColor {
+            r: 1.0,
+            g: 1.0,
+            b: 1.0,
+        },
+        emissive: NiColor::default(),
+        shininess: 120.0,
+        alpha: 1.0,
+        emissive_mult: 1.0,
+    };
+    let tex = NiTexturingProperty {
+        net: empty_net(),
+        flags: 0,
+        texture_count: 1,
+        base_texture: Some(TexDesc {
+            source_ref: BlockRef::NULL,
+            flags: 0,
+            transform: None,
+        }),
+        dark_texture: None,
+        detail_texture: None,
+        gloss_texture: None,
+        glow_texture: None,
+        bump_texture: None,
+        normal_texture: None,
+        parallax_texture: None,
+        parallax_offset: 0.0,
+        decal_textures: Vec::new(),
+    };
+    (mat, tex)
+}
+
+#[test]
+fn legacy_material_and_texturing_properties_never_yield_a_pbr_material() {
+    let (mat, tex) = oblivion_shape_properties();
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(mat), Box::new(tex)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = make_tri_shape_with_props(vec![BlockRef(0), BlockRef(1)]);
+
+    let mut pool = StringPool::new();
+    let info = extract_material_info(&scene, &shape, &[], &mut pool);
+    let imported = info.into_imported_material(&mut pool, Some("TestShape"));
+
+    assert!(
+        !imported.is_pbr,
+        "a NiMaterialProperty + NiTexturingProperty shape authors no external \
+         material file, so it must not reach the Disney lobe — this is the \
+         invariant that makes MAT_FLAG_PBR_BSDF provably 0 for Oblivion (#2570)"
+    );
+    // The three sibling flags that also gate on an external material file.
+    // A heuristic that flipped `is_pbr` would most likely flip these too, and
+    // `bgsm_pbr_scalars_authored` in particular is what tells consumers the
+    // PBR scalars are *authored* rather than the keyword classifier's guess
+    // (#2609).
+    assert!(!imported.from_bgsm);
+    assert!(!imported.bgsm_pbr_scalars_authored);
+    assert!(!imported.bgem_glass);
+}
+
+/// The classifier still runs on legacy input — it populates
+/// `metalness_override` / `roughness_override` for the legacy Lambert
+/// path. This pins that producing those overrides is *not* the same
+/// thing as being PBR: the overrides are the keyword classifier's guess,
+/// and promoting them to `is_pbr` is exactly the regression #2570 guards.
+#[test]
+fn legacy_pbr_scalar_overrides_do_not_promote_the_material_to_pbr() {
+    let (mat, tex) = oblivion_shape_properties();
+    let blocks: Vec<Box<dyn NiObject>> = vec![Box::new(mat), Box::new(tex)];
+    let scene = NifScene {
+        blocks,
+        ..NifScene::default()
+    };
+    let shape = make_tri_shape_with_props(vec![BlockRef(0), BlockRef(1)]);
+
+    let mut pool = StringPool::new();
+    let mut info = extract_material_info(&scene, &shape, &[], &mut pool);
+    // A metal-keyword path: the strongest "this looks like a conductor"
+    // signal the legacy classifier has.
+    info.texture_path = Some(pool.intern(r"Textures\Weapons\Iron\IronCuirass.dds"));
+    let imported = info.into_imported_material(&mut pool, Some("TestShape"));
+
+    assert!(
+        imported.metalness_override.is_some(),
+        "test premise: the legacy classifier does derive PBR scalars here"
+    );
+    assert!(
+        !imported.is_pbr,
+        "derived scalars are a guess for the LEGACY lobe; they must not \
+         select the Disney BSDF (#2570)"
+    );
+    assert!(
+        !imported.bgsm_pbr_scalars_authored,
+        "and they must not claim to be authored (#2609)"
+    );
+}

--- a/crates/nif/src/import/material/mod.rs
+++ b/crates/nif/src/import/material/mod.rs
@@ -1457,6 +1457,13 @@ mod alpha_flag_tests;
 #[allow(clippy::field_reassign_with_default)] // Tests model staged legacy material translation.
 mod legacy_pbr_translation_tests;
 
+/// #2570 (OBL-D4-04) — the negative direction of the above: deriving
+/// legacy PBR *scalars* must never promote the material onto the Disney
+/// lobe. Pins `is_pbr == false` for external-material-file-less input,
+/// which is what makes `MAT_FLAG_PBR_BSDF` provably 0 for Oblivion.
+#[cfg(test)]
+mod legacy_is_pbr_tests;
+
 /// Regression tests for issue #345 — `BSEffectShaderProperty` rich
 /// material fields used to be dropped on import. The capture path is
 /// covered by direct `capture_effect_shader_data` tests; full

--- a/crates/nif/src/import/tests/particle.rs
+++ b/crates/nif/src/import/tests/particle.rs
@@ -23,6 +23,11 @@ use super::{identity_transform, make_ni_node, scene_from_blocks, translated};
 /// to `legacy_particle::*` (not `NiPSysBlock`) and are deliberately not
 /// surfaced as emitters (#1327) — so they are not used as emitter fixtures
 /// here.
+///
+/// #2568 re-examined that decision and confirmed it: zero legacy particle
+/// blocks exist across 54 202 vanilla NIFs spanning all five target games
+/// (per-archive counts in `blocks/mod.rs`). These assertions pin a
+/// deliberate scope boundary backed by measurement, not an unfixed gap.
 fn synthetic_particle_block(type_name: &str) -> Box<dyn crate::blocks::NiObject> {
     match type_name {
         "NiParticleSystem" | "NiMeshParticleSystem" | "NiParticles" | "BSStripParticleSystem" => {

--- a/crates/nif/src/import/walk/mod.rs
+++ b/crates/nif/src/import/walk/mod.rs
@@ -571,6 +571,13 @@ pub(super) fn walk_node_hierarchical(
     // `legacy_particle::*`, NOT `NiPSysBlock`, so a NiPSysBlock downcast
     // never matched them — that dead arm was removed in #1327. The target
     // games all author the modern NiParticleSystem stack.)
+    //
+    // #2568 — that last sentence was challenged as false for Oblivion and is
+    // now **measured true for every target game**: zero legacy particle
+    // blocks across 54 202 vanilla NIFs (Oblivion + Shivering Isles + FO3 +
+    // FNV + Skyrim SE), against 3 635 `NiParticleSystem`. The per-archive
+    // counts are in `blocks/mod.rs`'s dispatch arm for those types. An
+    // emission arm for the legacy stack would be unreachable code.
     if let Some(ps) = block
         .as_any()
         .downcast_ref::<crate::blocks::particle::NiParticleSystem>()

--- a/crates/plugin/src/esm/records/actor/mod.rs
+++ b/crates/plugin/src/esm/records/actor/mod.rs
@@ -172,7 +172,26 @@ pub struct NpcRecord {
     pub editor_id: String,
     pub full_name: String,
     /// Model path (typically from MODL — head/body mesh, optional).
+    ///
+    /// **On `CREA` this is the creature's SKELETON**, not a body mesh —
+    /// e.g. `Creatures\Rat\Skeleton.NIF`. The body meshes are in
+    /// [`Self::body_part_models`]. See #2567.
     pub model_path: String,
+    /// `CREA` `NIFZ` — the creature's body-part mesh list, as authored:
+    /// bare filenames relative to [`Self::model_path`]'s directory (e.g.
+    /// `Eyes.NIF`, `Head.NIF`, `Rat.NIF`, `Whiskers.NIF` beside
+    /// `Creatures\Rat\Skeleton.NIF`). Empty for `NPC_`, which has no such
+    /// sub-record — humanoid bodies come from the per-game canonical
+    /// paths instead. See #2567.
+    pub body_part_models: Vec<String>,
+    /// True when this record came from a `CREA` group rather than `NPC_`.
+    ///
+    /// The two share `parse_npc` because they share almost every
+    /// sub-record, but they do **not** share a spawn shape: creatures carry
+    /// their own skeleton + part list and reference no `RACE` (Oblivion
+    /// `CREA` `RNAM` is a 1-byte attack reach, not a race FormID), so the
+    /// humanoid body/head/hair/eye recipe does not apply to them. See #2567.
+    pub is_creature: bool,
     /// Race form ID (RNAM).
     pub race_form_id: u32,
     /// Class form ID (CNAM).
@@ -561,6 +580,8 @@ pub fn parse_npc(
         editor_id: common.editor_id,
         full_name: common.full_name,
         model_path: common.model_path,
+        body_part_models: Vec::new(),
+        is_creature: false,
         race_form_id: 0,
         class_form_id: 0,
         voice_form_id: 0,
@@ -679,6 +700,24 @@ fn parse_npc_core(
         b"SCRI" if sub.data.len() >= 4 => {
             let raw = SubReader::new(&sub.data).u32_or_default();
             record.script_form_id = remap_fid(raw, remap);
+        }
+        // NIFZ — CREA-only body-part mesh list (#2567). A run of
+        // null-terminated names with a trailing empty terminator, each
+        // relative to MODL's directory:
+        //
+        //   "Eyes.NIF\0Head.NIF\0mange.NIF\0Rat.NIF\0Whiskers.NIF\0\0"
+        //
+        // (verified against `Oblivion.esm`'s SE11SanctifiedRat). Without
+        // these a creature has only its skeleton, which carries no
+        // geometry — the animated actor path would spawn an invisible
+        // actor. `NPC_` never ships NIFZ, so this arm is self-gating.
+        b"NIFZ" if !sub.data.is_empty() => {
+            record.body_part_models.extend(
+                sub.data
+                    .split(|&b| b == 0)
+                    .filter(|part| !part.is_empty())
+                    .map(|part| String::from_utf8_lossy(part).into_owned()),
+            );
         }
         // SNAM (FNV NPC_): faction form ID (u32) + rank (i8) + pad x3
         b"SNAM" if sub.data.len() >= 8 => {

--- a/crates/plugin/src/esm/records/dispatch_actor.rs
+++ b/crates/plugin/src/esm/records/dispatch_actor.rs
@@ -42,9 +42,14 @@ pub(super) fn dispatch_actor_group(
         b"CREA" => {
             let crea_remap = reader.get_form_id_remap();
             extract_records_with_modl(reader, end, b"CREA", statics, &mut |fid, subs| {
-                index
-                    .creatures
-                    .insert(fid, parse_npc(fid, subs, game, &crea_remap));
+                let mut record = parse_npc(fid, subs, game, &crea_remap);
+                // #2567 — the spawn path has to tell the two apart: a
+                // creature's MODL is its skeleton and its meshes come from
+                // NIFZ, where an NPC_'s body comes from per-game canonical
+                // paths and its head from RACE. Set at the one site that
+                // knows which group it read.
+                record.is_creature = true;
+                index.creatures.insert(fid, record);
             })?
         }
         b"RACE" => extract_records(reader, end, b"RACE", &mut |fid, subs| {

--- a/crates/plugin/src/esm/records/index.rs
+++ b/crates/plugin/src/esm/records/index.rs
@@ -359,6 +359,29 @@ pub struct EsmIndex {
 }
 
 impl EsmIndex {
+    /// The base actor record a placed actor REFR points at — `NPC_` first,
+    /// then `CREA`.
+    ///
+    /// #2567 (OBL-D3-01) — `NPC_` and `CREA` parse into two disjoint maps of
+    /// the same `NpcRecord` type, and every "is this REFR an actor?" test in
+    /// the cell loader consulted **only** `npcs`. `creatures` had zero readers
+    /// anywhere under `byroredux/src/`, so a placed `ACRE` (Oblivion) or
+    /// `ACHR`→`CREA` (FO3+) fell through to the generic static-mesh path: it
+    /// rendered its MODL — which for a creature is the *skeleton* — and never
+    /// animated. Route both through this one accessor so the two maps cannot
+    /// drift apart again at a call site.
+    pub fn actor(&self, form_id: u32) -> Option<&NpcRecord> {
+        self.npcs
+            .get(&form_id)
+            .or_else(|| self.creatures.get(&form_id))
+    }
+
+    /// Whether `form_id` names a placeable actor base record (`NPC_` or
+    /// `CREA`) — the cheap predicate half of [`Self::actor`].
+    pub fn is_actor(&self, form_id: u32) -> bool {
+        self.npcs.contains_key(&form_id) || self.creatures.contains_key(&form_id)
+    }
+
     /// Single source of truth for the per-category breakdown.
     ///
     /// Each row is `(label, count_fn)`. [`total`] sums these counts;
@@ -1208,8 +1231,8 @@ mod tests {
     /// that justified skipping this was factually wrong.
     #[test]
     fn base_record_script_instance_resolves_a_terminals_vmad() {
-        use crate::esm::records::TermRecord;
         use crate::esm::records::script_instance::{ScriptInstance, ScriptInstanceData};
+        use crate::esm::records::TermRecord;
 
         const TERMINAL: u32 = 0x0002_5001;
 

--- a/crates/renderer/shaders/include/lighting.glsl
+++ b/crates/renderer/shaders/include/lighting.glsl
@@ -191,6 +191,15 @@ vec3 shadowableLightRadiance(
         // same weight relative to diffuse as the /PI direct-sun path.
         diffuseBrdf = (dd.diffuse + dd.sheen) * PI * (1.0 - metalness);
     } else {
+        // #2569 (OBL-D4-02) — KNOWN DIVERGENCE from triangle.frag's
+        // no-cluster directional fallback, which computes the same legacy
+        // arm as `kD * albedo / PI` and then scales the whole lobe by 0.8.
+        // fallback/clustered is therefore 0.8/PI (~0.2546) on diffuse but
+        // 0.8 on specular. This site is the named legacy reference
+        // convention; reconciling them changes brightness on a path no test
+        // can observe, so it is deliberately unfixed pending a live capture.
+        // Pinned by `shader_constants.rs`'s
+        // `legacy_lambert_arms_are_pinned_divergent_pending_a_capture`.
         diffuseBrdf = kD * albedo;
     }
     vec3 brdfResult = (diffuseBrdf + specular * specStrength * specColor) * NdotL;

--- a/crates/renderer/shaders/triangle.frag
+++ b/crates/renderer/shaders/triangle.frag
@@ -2514,8 +2514,14 @@ void main() {
             );
             diffuseBrdf = (dd.diffuse + dd.sheen) * (1.0 - metalness);
         } else {
+            // #2569 (OBL-D4-02) — KNOWN DIVERGENCE from lighting.glsl's
+            // clustered per-light arm, which is `kD * albedo` with no /PI and
+            // no 0.8 below. See the comment there; this is the fallback side.
             diffuseBrdf = kD * albedo / PI;
         }
+        // The `vec3(0.8)` is the other half of the #2569 divergence: the
+        // clustered path applies no whole-lobe scale, so this path's specular
+        // lands at 0.8x and its diffuse at 0.8/PI x of the clustered values.
         Lo = (diffuseBrdf + specular * specStrength * specColor) * vec3(0.8) * NdotL;
     } else {
         // Clustered lighting with streaming RIS shadow sampling.

--- a/crates/renderer/src/shader_constants.rs
+++ b/crates/renderer/src/shader_constants.rs
@@ -283,6 +283,63 @@ mod tests {
         }
     }
 
+    /// #2569 (OBL-D4-02) — the legacy (non-`MAT_FLAG_PBR_BSDF`) Lambert arm
+    /// is duplicated across the two direct-lighting paths, and the copies do
+    /// **not** agree:
+    ///
+    /// - `lighting.glsl` (clustered per-light): `kD * albedo`, then `* NdotL`.
+    ///   Documented as "the legacy non-/PI Lambert convention".
+    /// - `triangle.frag` (no-cluster directional fallback):
+    ///   `kD * albedo / PI`, then `* vec3(0.8) * NdotL`.
+    ///
+    /// So `fallback / clustered` is `0.8/PI ≈ 0.2546` for diffuse but `0.8`
+    /// for specular — the fallback is ~3.9× darker on diffuse and the two
+    /// lobes are not even scaled consistently relative to each other. The
+    /// same 0.8/PI gap applies to the Disney arm (clustered multiplies the
+    /// lobe by `PI`, the fallback doesn't), so this is a whole-path
+    /// convention split, not a legacy-only one. It shows up as a brightness
+    /// pop when a fragment crosses the cluster-population threshold, and as
+    /// systematically dark Oblivion / FO3 / FNV exteriors.
+    ///
+    /// **This test pins the divergence rather than asserting parity, on
+    /// purpose.** Reconciling the two sites changes image brightness on a
+    /// path `cargo test` cannot observe, and this project does not ship
+    /// speculative shader changes without a live capture (see the issue's own
+    /// completeness checklist). Until that capture exists the honest state is
+    /// "known-divergent, deliberately unfixed" — and a tripwire that fires the
+    /// moment either arm is edited is worth more than a green assertion that
+    /// silently stops describing the code.
+    ///
+    /// When the capture lands: make the two expressions identical, then turn
+    /// the two `assert!`s below into the equality this test is named for.
+    #[test]
+    fn legacy_lambert_arms_are_pinned_divergent_pending_a_capture() {
+        let lighting = include_str!("../shaders/include/lighting.glsl");
+        let triangle = include_str!("../shaders/triangle.frag");
+
+        assert!(
+            lighting.contains("diffuseBrdf = kD * albedo;"),
+            "clustered per-light Lambert arm changed shape — if this is the \
+             #2569 reconciliation, update this test to assert parity instead"
+        );
+        assert!(
+            triangle.contains("diffuseBrdf = kD * albedo / PI;"),
+            "no-cluster fallback Lambert arm changed shape — if this is the \
+             #2569 reconciliation, update this test to assert parity instead"
+        );
+        assert!(
+            triangle.contains("* vec3(0.8) * NdotL;"),
+            "the fallback's 0.8 whole-lobe scale is half of the #2569 \
+             divergence; if it moved, the ratio this test documents is stale"
+        );
+        // The clustered path applies no such scale — that asymmetry IS the bug.
+        assert!(
+            !lighting.contains("vec3(0.8)"),
+            "the clustered path gaining a 0.8 scale would change which side of \
+             #2569 is the reference convention"
+        );
+    }
+
     /// Verify all affected shaders include the shared header.
     ///
     /// #1780 (D14-LOW-01) — this allow-list MUST cover every shader that


### PR DESCRIPTION
… actor spawn, and pin is_pbr false for legacy material input

Oblivion per-game audit closeout. Two fixed, one measured false, one deliberately half-landed.

#2567 (OBL-D3-01) — NPC_ and CREA parse into two disjoint maps of the same NpcRecord, and every "is this REFR an actor" test in the cell loader read only `npcs`; `creatures` had zero readers anywhere under byroredux/src. A placed ACRE (Oblivion) or ACHR->CREA (FO3+) therefore fell through to the generic static-mesh path, rendering its MODL and never animating.

The finding's suggested fix — thread index.creatures alongside index.npcs and check both maps — is wrong on its own, which dumping Oblivion.esm shows: a CREA's MODL is `Creatures\Rat\Skeleton.NIF` (the skeleton, carrying no geometry), its body meshes are an unparsed NIFZ list beside it, and its RNAM is a 1-byte attack reach rather than a race FormID. NpcSpawnJob::runtime hardcodes humanoid assets — characters\_male\upperbody.nif plus hands, RACE head, hair, brows, eyes — so routing alone would have spawned a human torso for a rat, a worse result than the static mesh it replaced.

So the routing comes with a creature spawn shape. NIFZ is parsed into NpcRecord.body_part_models and CREA records carry an is_creature flag set at the one dispatch site that knows which group it read. prepare_runtime_state returns early into prepare_creature_state, which fills the SAME RuntimePhase machine (skeleton -> parts -> armor -> finalize) from creature sources: skeleton from MODL, parts from NIFZ resolved against MODL's directory, and the creature's own idle.kf from that same directory — the humanoid idle pool animates nothing on a rig that shares no bone names with it. Head/hair/brow/eye stay None, since those are head-part records reached through a RACE a creature does not have. The skeleton path moved from a humanoid_skeleton_path(game) call in the Skeleton phase onto RuntimeNpcState, which is what lets the two shapes differ at all.

Detection is now EsmIndex::actor / is_actor, one accessor covering both maps, and load_references* lost the npcs parameter that shadowed it — the two maps can no longer drift apart at a call site, which is what let this bug exist.

Measured against Oblivion.esm plus every `* - Meshes.bsa`, by an in-tree test that self-skips without the install: 909/909 creature skeletons resolve, 3936/4043 NIFZ parts (the residual are DLC-plugin meshes), 909/909 idle clips. 914 CREA records parse, all flagged, and no NPC_ record picks up either field.

#2570 (OBL-D4-04) — added the negative test pinning `is_pbr == false` for material input with no external material file, and the sharper half: deriving legacy PBR *scalars* through the keyword classifier must not promote the material onto the Disney lobe. That is what makes MAT_FLAG_PBR_BSDF provably 0 for Oblivion rather than accidentally so, and what a future "promote legacy specular to PBR" heuristic would trip over.

#2568 (OBL-D4-01, HIGH as filed) — premise measured false, closed separately rather than fixed. It claimed Oblivion's legacy NiParticleSystemController / NiAutoNormalParticles stack imports with zero emitters, making every torch flame and magic effect static. Sweeping all five installed target games for those block types found ZERO across 54 202 vanilla NIFs, against 3 635 NiParticleSystem: Oblivion (8032 NIFs, 547 modern), Shivering Isles (1438, 231), FNV (14881, 1262), FO3 (10989, 422), Skyrim SE Meshes0 (18862, 1173). Oblivion at v20.0.0.5 is already fully on the modern stack. The in-code comment the audit called false is true; the actually-stale claim is the block dispatcher's own "Oblivion magic FX, fire, dust, blood", which describes Morrowind-era content and is what seeded the finding. A working emission arm was written and then dropped — it would be unreachable code. The per-archive counts are now recorded at the dispatcher, the walk site, and the #1327 tests those three comments feed, so the next audit measures instead of inferring.

#2569 (OBL-D4-02) — half-landed on purpose; the issue stays open. The legacy Lambert arm is duplicated across the clustered per-light path and the no-cluster directional fallback, and the copies disagree: `kD * albedo` versus `kD * albedo / PI` followed by a whole-lobe `* 0.8`. Fallback/clustered is 0.8/PI (~0.2546) on diffuse but 0.8 on specular, and the same split applies to the Disney arm, so it is a whole-path convention divergence. Reconciling it changes image brightness on a path no test can observe, and this project does not ship speculative shader changes without a live capture. Landed instead: the parity test the issue asks for — pinning the divergence, with the numbers and the instruction to convert it to an equality assertion once the capture exists — plus cross-referencing comments at both GLSL sites. The GLSL edits are comments only, so the pre-compiled SPIR-V is unchanged and correct.

Pre-existing and unrelated: byroredux/src/render/fire_lights.rs's derived_reach_is_currently_oversized_pending_a_unit_correct_derivation fails on main.