### PR TITLE
Fix #2872 Fix #2873 Fix #2874 Fix #2875: stop sourcing the water curr…

### DIFF
--- a/.claude/issues/2872-2875/ISSUE.md
+++ b/.claude/issues/2872-2875/ISSUE.md
@@ -1,0 +1,186 @@
+# #OPEN PHYS-D6-03: WaterFlow.speed carries the raw WATR wind_speed with no unit conversion — the same scalar is a shader scroll rate and a BU/s velocity target (SEAM)
+
+Found by `/audit-physics` Dimension 6 (WATAL Physics Sink). Report: `docs/audits/AUDIT_PHYSICS_2026-08-13.md`.
+
+**Severity**: MEDIUM · **Status**: NEW · **This is a cross-layer SEAM — reported once, here.**
+**Location**: `byroredux/src/env_translate.rs:475-488` (`resolve_water_material` flow synthesis), consumed at `crates/physics/src/water.rs:147` and `crates/core/src/ecs/components/water.rs:214-218` (the unit contract)
+
+## Trigger Conditions
+Any cell whose XCWT resolves to a WATR whose EDID matches the `rapid`/`waterfall`/`falls`/`river`/`stream` heuristic (`env_translate.rs:462-471`) — i.e. every river/rapids plane, in every game. Calm water carries no `WaterFlow` and is unaffected.
+
+## Description
+`WaterFlow::speed` is documented as *"World units per second. Typical: 0.5 (calm river) ... 8.0 (whitewater rapids) ... 25.0 (Tamriel-tall waterfall sheet)"* (`components/water.rs:216-218`). The single translate site assigns it `rec.params.wind_speed.abs().max(0.5)` — the WATR `DATA`/`DNAM` wind-velocity float, copied verbatim with **no scale factor and no documented unit** at the parse boundary (`crates/plugin/src/esm/records/misc/water.rs:96` says only "wind speed", default `1.0`).
+
+The **same** scalar is then also used as a shader scroll rate in the very next lines:
+
+```rust
+// env_translate.rs:477-488
+let speed = rec.params.wind_speed.abs().max(0.5);
+flow = Some(WaterFlow { direction: [cos_theta, 0.0, sin_theta], speed });
+mat.scroll_a = [cos_theta * speed * 0.5, sin_theta * speed * 0.5];   // vs default [0.020, 0.011]
+```
+
+against a `scroll_a` default of `[0.020, 0.011]` documented as *"world-space scroll vectors ... (xy = m/s)"*. Physics consumes it directly as a velocity target: `speed_error = target_speed - body_velocity.dot(direction)` (`water.rs:148`).
+
+A value that is simultaneously a ~0.02-magnitude UV scroll rate and a 0.5-25 BU/s world velocity **cannot be dimensionally correct in both consumers**. Nothing in the repo establishes which reading is right, and there is no clamp or sanity band on either.
+
+## Impact
+The physics current's terminal drift speed is set by a field of unverified unit.
+- If WATR wind velocity is the small normalised float the `scroll_a` defaults imply, the `.max(0.5)` floor pins every real river/rapids plane at ~0.5 BU/s ~ 7 mm/s — authored currents are effectively **inert** in the physics sink, and the "downstream drift" behaviour only exists in the hand-authored `speed: 8.0` test (`water.rs:726-729`).
+- If it is a large float on some records, an unclamped `speed` is the **unbounded** terminal velocity clutter converges to.
+
+**Vanilla WATR values were deliberately NOT verified on disk** — that is the disproof step this finding explicitly leaves open, per the no-guessing rule. What is proven from code alone is the two-consumers-one-scalar inconsistency and the total absence of unit documentation, conversion, or clamp.
+
+## Suggested Fix
+Establish the WATR wind-velocity unit from the Gamebryo 2.3 / nif.xml / UESP reference **first** (No-Guessing), then either:
+- (a) apply an explicit BU/s conversion at the single `resolve_water_material` site and derive `scroll_a` from the canonical `WaterFlow` rather than the raw field, or
+- (b) if the field genuinely is a scroll rate, stop feeding it to `WaterFlow.speed` and synthesize the physics current from a documented engine constant x `WaterKind`.
+
+Clamp the result to the documented 0.5-25 BU/s band either way.
+
+## Seam owners
+- Decode side: `/audit-esm` Dim 5 (WATR `DATA`/`DNAM` field semantics)
+- `scroll_a`/`scroll_b` consumer: `/audit-renderer` Dim 15 (cf. the already-open #2787 on the neighbouring `ampScale`/`freqScale` sentinels)
+
+`docs/engine/watal.md` §4 lists `WaterFlow` as "SYNTHESIZED from wind" for Oblivion/FO3/FNV and "AUTHORED flow" for Skyrim — the synthesis is currently the only path for all games, since no DNAM linear-velocity decode exists.
+## Completeness Checks
+- [ ] **SIBLING**: Same pattern checked in related files (other collider producers, other cast sites, other wake sites)
+- [ ] **LOCK_ORDER**: If a RwLock scope changes, `physics_sync_system` still releases read guards before taking write guards
+- [ ] **CANONICAL-BOUNDARY**: Per-game logic stays at the parse->canonical boundary; no `GameKind`/`bsver` branch is introduced downstream of it (PHYSAL doctrine, `docs/engine/physal.md`)
+- [ ] **TESTS**: A regression test pins this specific fix
+
+
+---
+# #OPEN PHYS-D7-02: step_toward's ground-snap ray self-hits the actor's own keyframed ragdoll-bone colliders — walking NPCs elevator upward
+
+Found by `/audit-physics` Dimension 7 (Queries & Diagnostics). Report: `docs/audits/AUDIT_PHYSICS_2026-08-13.md`.
+
+**Severity**: MEDIUM · **Status**: NEW
+**Location**: `byroredux/src/systems/locomotion.rs:49-70` (`step_toward`); `crates/physics/src/world.rs:563-588` (`cast_ray_down`); `byroredux/src/npc_spawn.rs:169-198` (`keyframe_live_ragdoll_bones`)
+
+## Trigger Conditions
+One of the six env-gated locomotion AI systems is enabled (`BYRO_WANDER` / `BYRO_TRAVEL` / `BYRO_FOLLOW` / `BYRO_ESCORT` / `BYRO_GUARD` / `BYRO_PATROL`), a `PhysicsWorld` resource exists, and the moving actor is a live NPC whose skeleton NIF authored bhk ragdoll bodies (Oblivion / FO3 / FNV / Skyrim — the classic-chain games where the bone bodies actually decode).
+
+Not reachable in the default scheduler, which is the only reason the severity is not higher.
+
+## Description
+`step_toward` ground-snaps the actor by casting straight down from `(new_pos.x, current.y + 256, new_pos.z)` and assigning the hit Y to `new_pos.y`. The cast is `PhysicsWorld::cast_ray_down`, whose only filter is `exclude_dynamic`.
+
+`keyframe_live_ragdoll_bones` (#1698) deliberately flips every live actor's ragdoll bone from `Dynamic` to `Keyframed` *before* first registration, so each bone registers as a `KinematicPositionBased` Rapier body with a real collider — its own doc puts this at *"~18 bones/NPC"* and *"~480+ such bodies across a dense interior"*.
+
+`exclude_dynamic` does **not** filter kinematic bodies, and the ray origin is 256 BU directly above the actor's root, so the first thing the ray meets on its way down is the actor's **own** upper-body bone collider, not the floor.
+
+There is no way for the caller to fix this locally: `cast_ray_down` accepts no exclusion, and `step_toward` receives only `Option<&PhysicsWorld>` — it is handed neither the actor's `EntityId` nor its `RapierHandles`.
+
+## Evidence
+Empirically confirmed with a throwaway test against the real `PhysicsWorld` (reverted after running):
+
+```
+// Fixed floor cuboid, top surface y=1.0, plus a KinematicPositionBased ball(6) at y=120
+// (stand-in for a keyframed head/spine bone), ray from y=256 as locomotion.rs does:
+locomotion ground ray -> Some(126.0)     // its own bone, not the floor at 1.0
+```
+
+`locomotion.rs:64-66` then does `new_pos.y = ground_y`, writing the actor's *root* to what is really its own bone's top surface.
+
+## Impact
+An actor under any of the six locomotion procedures is re-seated each tick at its own bone height rather than the ground. Because the bones are children driven from the actor's animated `GlobalTransform` (via `push_kinematic`), the whole rig rises with the root, so the next tick's ray hits the bone again from an even higher origin — **a monotonic elevator, not a one-off offset**. Symptom is NPCs ascending out of the cell while "walking". Also silently corrupts every `Travel`/`Escort` arrival test that depends on real ground Y.
+
+## Suggested Fix
+Thread the moving actor's `RigidBodyHandle` into `step_toward` and pass it to an exclusion-aware `cast_ray_down` (the same signature change PHYS-D7-01 needs — fix them together).
+
+Excluding a single body handle is **not sufficient on its own** — each bone is a *separate* body. The cleanest fix is a `QueryFilter` predicate that rejects colliders whose parent body resolves to an entity under the actor's skeleton root, or (cheaper) an interaction-group / collision-group bit for "actor bone" that ground probes mask out.
+
+## Related
+- PHYS-D7-01 (same missing-exclusion root cause, different caller)
+- `docs/audits/AUDIT_CONCURRENCY_2026-07-16.md:72,170` previously reviewed `step_toward`'s `cast_ray_down` for lock ordering only, never for filter correctness
+## Completeness Checks
+- [ ] **SIBLING**: Same pattern checked in related files (other collider producers, other cast sites, other wake sites)
+- [ ] **LOCK_ORDER**: If a RwLock scope changes, `physics_sync_system` still releases read guards before taking write guards
+- [ ] **CANONICAL-BOUNDARY**: Per-game logic stays at the parse->canonical boundary; no `GameKind`/`bsver` branch is introduced downstream of it (PHYSAL doctrine, `docs/engine/physal.md`)
+- [ ] **TESTS**: A regression test pins this specific fix
+
+
+---
+# #OPEN PHYS-D7-03: The spawn census cannot separate 'no collider authored' from 'dropped in translation', and is blind to 'present but not walkable'
+
+Found by `/audit-physics` Dimension 7 (Queries & Diagnostics). Report: `docs/audits/AUDIT_PHYSICS_2026-08-13.md`.
+
+**Severity**: MEDIUM · **Status**: NEW
+**Location**: `crates/physics/src/sync.rs:375-476` (`dump_spawn_collider_census`, its doc block, and the summary `log::warn!` at `:445-454`); `byroredux/src/scene.rs:1113-1128` (its only call site); `crates/physics/src/world.rs:694-727` (`cast_capsule_down_surface_and_normal`, private)
+
+## Trigger Conditions
+A door-teleport spawn whose floor probe misses all three rungs (`floor_probe_failed == true`, `scene.rs:1120`). Every such run produces a census that under-determines the cause.
+
+## Description
+The census's own doc block (`sync.rs:380-393`) enumerates four candidate causes and the summary log line (`:445-454`) maps them onto observable tallies. Two of the three cases this diagnostic exists to separate are not actually separable by that mapping:
+
+**(a) no collider authored vs (b) collider dropped in translation** — both land on the same bucket. The log says *"0 total => the collider never spawned (per-NIF trimesh-fallback gate, or a REFR-level gap)"*; that single sentence **is** the conflation. The engine already computes the discriminator elsewhere and the census never consults it: `summarize_collision_authoring` / `CollisionAuthoringSummary` (`crates/nif/src/import/collision/mod.rs`, retained on `CachedNifImport`) carries the classic / new-physics / phantom counts, and `docs/engine/physics.md:330-338` states its whole purpose is that *"an empty decoded-collision array no longer conflates 'intentionally no collision' with 'packed collision exists but is undecodable'"*. The census reads the Rapier side only, so it **re-introduces exactly the conflation that summary was built to remove**.
+
+**(c) collider present but not walkable** — invisible. All three spawn rungs call `cast_capsule_down_onto_walkable_surface`, which returns `None` for *both* "swept capsule hit nothing" and "swept capsule hit something whose `normal1.y` failed the walkable test" (`world.rs:675-692`). The normal is computed and then discarded: the surface-and-normal helper is private and only `cast_capsule_down` (surface only) is public.
+
+So a spawn that is blocked by a 60-degree ramp logs *"MISS on all 3 rungs"* and then a census showing `Fixed>0` — and the summary line instructs the reader to conclude *"Fixed>0 at a wrong Y => transform composition"*. **The diagnostic actively mis-attributes a walkability rejection to a transform bug.**
+
+## Evidence
+- `sync.rs:448-451` — the summary text: three arms, no walkability arm, no authoring-summary arm
+- `world.rs:689-691` — `.and_then(|(surface_y, normal_y)| (...).then_some(...))`, the `None` return collapsing miss and reject
+- `world.rs:694` — `fn cast_capsule_down_surface_and_normal` is private, so no caller can recover the normal
+- `sync.rs:343-353` — `SpawnCensusEntry` has no walkable/normal field and no authoring field
+
+## Impact
+The one diagnostic built for "why is there no floor here" leaves the operator with two of the three real causes indistinguishable, and steers them toward the wrong one in the third. This is the observability layer under a defect class that has already consumed #1295, #2013 and #2202 — and, per this audit, PHYS-D5-01 / D5-02 / D5-03.
+
+## Suggested Fix
+1. Make `cast_capsule_down_surface_and_normal` `pub`, and on the failure path re-run it unfiltered so the log can say *"unfiltered sweep hit y=... normal_y=... -> REJECTED as non-walkable (min=...)"* versus *"no hit"*.
+2. Add the cell's `CollisionAuthoringSummary` totals to the census header so `0 total` splits into "nothing authored" vs "N classic / M new-physics authored, none registered".
+
+## Related
+- PHYS-D7-04 (same function, different defect), PHYS-D7-05 (unreachable at runtime — worth fixing in the same change)
+- #2202 (the issue that created the census)
+## Completeness Checks
+- [ ] **SIBLING**: Same pattern checked in related files (other collider producers, other cast sites, other wake sites)
+- [ ] **LOCK_ORDER**: If a RwLock scope changes, `physics_sync_system` still releases read guards before taking write guards
+- [ ] **CANONICAL-BOUNDARY**: Per-game logic stays at the parse->canonical boundary; no `GameKind`/`bsver` branch is introduced downstream of it (PHYSAL doctrine, `docs/engine/physal.md`)
+- [ ] **TESTS**: A regression test pins this specific fix
+
+
+---
+# #OPEN PHYS-D7-04: The spawn census sorts by absolute world Y and truncates at 24 — in a dense column the floor is exactly what gets cut
+
+Found by `/audit-physics` Dimension 7 (Queries & Diagnostics). Report: `docs/audits/AUDIT_PHYSICS_2026-08-13.md`.
+
+**Severity**: MEDIUM · **Status**: NEW
+**Location**: `crates/physics/src/world.rs:761-817` (`colliders_near_xz` + its doc claim at `:777-778`); `crates/physics/src/sync.rs:335-338` (`SPAWN_CENSUS_DETAIL_CAP = 24`) and `:455`, `:470-475`; `byroredux/src/scene.rs:1121` (`SPAWN_CENSUS_RADIUS_BU = 256.0`)
+
+## Trigger Conditions
+A failed door spawn in any column containing more than 24 colliders within +/-256 BU in XZ — i.e. essentially every interior with an upper storey, beams or shelving, and every exterior grid cell.
+
+## Description
+`colliders_near_xz` takes `(x, z, radius)` and **no Y**. It sorts descending by AABB centre Y and its doc block claims this is *"so the nearest thing above the probe reads first"*. There is no probe Y in scope, so the sort key is not "nearest above the probe" — it is **"highest in the world column"**. `dump_spawn_collider_census` then prints only the first 24.
+
+The consequence inverts the diagnostic's purpose. The question being asked is *"is there a floor at/below the spawn?"*, whose answer lives at the **low** end of the sort. In a Skyrim inn (two storeys, roof beams, rafters, an upper landing) the 24 shown entries are the roof and the upper floor; the actual spawn-height geometry falls under *"... N further colliders omitted"*.
+
+The very cell shape the doc itself calls out — *"2560 fixed colliders and a hole exactly under the player's spawn"* (`world.rs:769-771`) — is the worst case for this ordering.
+
+## Evidence
+- `world.rs:779` signature `colliders_near_xz(&self, x: f32, z: f32, radius: f32)` — no Y parameter exists to sort relative to
+- `world.rs:811-815` sort comparator uses `a.aabb_min[1] + a.aabb_max[1]` (absolute centre Y)
+- `sync.rs:455` `entries.iter().take(SPAWN_CENSUS_DETAIL_CAP)`
+- the unit test that pins the ordering (`world.rs:1136-1153 census_sorts_by_aabb_centre_y_descending`) uses three slabs, so it can never observe the truncation interaction
+
+## Impact
+In precisely the dense-interior case the census was written for, it prints a wall of irrelevant ceiling geometry and omits the evidence. Degrades a MEDIUM-value diagnostic to a misleading one; costs a debugging session per occurrence.
+
+## Suggested Fix
+Pass the probe origin Y through to `colliders_near_xz` and sort by `|centre_y - probe_y|` (nearest to the probe first, which is what the doc already promises), or keep the descending sort but take 12 from each end. Fix the doc sentence either way.
+
+## Related
+- PHYS-D7-03 (same function), PHYS-D7-05
+## Completeness Checks
+- [ ] **SIBLING**: Same pattern checked in related files (other collider producers, other cast sites, other wake sites)
+- [ ] **LOCK_ORDER**: If a RwLock scope changes, `physics_sync_system` still releases read guards before taking write guards
+- [ ] **CANONICAL-BOUNDARY**: Per-game logic stays at the parse->canonical boundary; no `GameKind`/`bsver` branch is introduced downstream of it (PHYSAL doctrine, `docs/engine/physal.md`)
+- [ ] **TESTS**: A regression test pins this specific fix
+
+
+---

--- a/byroredux/src/boot.rs
+++ b/byroredux/src/boot.rs
@@ -502,6 +502,11 @@ pub(crate) fn build_world(debug_mode: bool, args: &[String]) -> World {
     // Pre-register component storages that the physics sync system
     // queries on the first frame (before anything has been inserted).
     world.register::<byroredux_physics::RapierHandles>();
+    // #2873 — registration reads this to file a live actor's ragdoll-bone
+    // colliders under `ACTOR_BONE_GROUP` so ground probes skip them. Must
+    // exist before the first `collect_newcomers`, which spawns NPCs' bones
+    // in the same frame the cell loads.
+    world.register::<byroredux_physics::ActorBoneCollider>();
     // MQ101 scene CTDAs read actor death and authored CELL identity through
     // shared sparse components. Register them before any scene/cell exists so
     // condition evaluation safely sees the default alive/unowned state.

--- a/byroredux/src/cell_loader/nif_import_registry.rs
+++ b/byroredux/src/cell_loader/nif_import_registry.rs
@@ -265,6 +265,43 @@ impl NifImportRegistry {
         self.core.len()
     }
 
+    /// Sum every cached model's [`CollisionAuthoringSummary`] into the
+    /// spawn-census view of "was collision authored at all?" (#2874).
+    ///
+    /// The spawn census reads the Rapier side only, so its `0 colliders in
+    /// this column` bucket cannot tell "the source NIFs author no collision"
+    /// from "they author it and every shape was dropped in translation" —
+    /// the exact conflation `CollisionAuthoringSummary` exists to remove.
+    /// These totals supply the discriminator.
+    ///
+    /// Scoped to the *cache*, not to one cell: the registry is keyed by model
+    /// path and lives for the process, so on a cell-to-cell traversal the
+    /// totals cover every model loaded so far. That is a superset of the
+    /// current cell, which is the safe direction for this diagnostic —
+    /// nonzero totals never prove the drop happened in *this* cell, but zero
+    /// totals do prove nothing colliding was ever authored, and that is the
+    /// arm the census was mis-reporting.
+    ///
+    /// [`CollisionAuthoringSummary`]: byroredux_nif::import::collision::CollisionAuthoringSummary
+    pub(crate) fn collision_authoring_totals(&self) -> byroredux_physics::SpawnCensusAuthoring {
+        let mut out = byroredux_physics::SpawnCensusAuthoring::default();
+        for key in self.core.keys() {
+            let Some(Some(entry)) = self.core.get(key) else {
+                continue;
+            };
+            out.classic = out
+                .classic
+                .saturating_add(entry.collision_authoring.classic);
+            out.new_physics = out
+                .new_physics
+                .saturating_add(entry.collision_authoring.new_physics);
+            out.phantom = out
+                .phantom
+                .saturating_add(entry.collision_authoring.phantom);
+        }
+        out
+    }
+
     /// Configured LRU cap (`0` = unlimited).
     pub(crate) fn max_entries(&self) -> usize {
         self.max_entries

--- a/byroredux/src/env_translate.rs
+++ b/byroredux/src/env_translate.rs
@@ -401,6 +401,19 @@ pub(crate) fn worldspace_name_chain(
     }
 }
 
+/// Shader UV-scroll rate produced by 1 BU/s of canonical [`WaterFlow`]
+/// (#2872).
+///
+/// Calibrated against the two constants the engine already documents, not
+/// invented: `WaterMaterial::default().scroll_a == [0.020, 0.011]` — a
+/// magnitude of `hypot(0.020, 0.011) ≈ 0.02283` UV/s — is the authored look
+/// of the slowest current [`WaterFlow::speed`] documents, its
+/// `SPEED_MIN` "calm river" anchor of 0.5 BU/s. So one BU/s of flow scrolls
+/// the wave layer `0.02283 / 0.5 ≈ 0.04565` UV/s, and a `River` plane
+/// reproduces the default appearance exactly while `Rapids` / `Waterfall`
+/// scale up in proportion to the current the physics sink is simulating.
+const WATER_SCROLL_UV_PER_BU_PER_S: f32 = 0.045_651;
+
 /// Resolve a cell's `XCWT` FormID to an engine [`WaterMaterial`]
 /// plus a [`WaterKind`] (currently always `Calm`) plus an optional
 /// [`WaterFlow`] and an optional normal-texture path the cell loader
@@ -470,22 +483,38 @@ pub(crate) fn resolve_water_material(
                 kind = WaterKind::River;
                 mat.foam_strength = 0.20;
             }
-            // Synthesise a flow vector from WATR's wind speed +
-            // direction when the kind implies flow. Bethesda's
-            // wind_direction is in radians from north (UESP).
+            // Synthesise a flow vector from WATR's wind direction + the
+            // canonical per-`WaterKind` current speed when the kind
+            // implies flow. Bethesda's wind_direction is in radians from
+            // north (UESP).
+            //
+            // #2872 — the *speed* deliberately does NOT come from
+            // `rec.params.wind_speed`. That field is `90.0` on every
+            // 196-byte (FO3/FNV) and 228-byte (Skyrim) vanilla WATR — a
+            // constant carrying no per-water information, three and a half
+            // times the top of `WaterFlow`'s documented BU/s band, and the
+            // same value the shorter legacy layouts carry in the direction
+            // slot. Feeding it straight through made one scalar serve as
+            // both a ~0.02-magnitude UV scroll rate and an unbounded
+            // physics velocity target, which cannot be dimensionally
+            // correct in both. `WaterFlow::for_kind` supplies the physics
+            // current from the band `WaterFlow::speed` already documents,
+            // and the shader scroll below is now *derived from* that
+            // canonical flow instead of sharing its raw source field — one
+            // scalar, one meaning. Re-deriving the true wind-velocity
+            // offset in the newer DATA/DNAM layouts is a decode-side fix.
             if !matches!(kind, WaterKind::Calm) {
                 let theta = rec.params.wind_direction;
                 // Compute once — cos/sin were duplicated pre-#1068 (F-WAT-06).
                 let (sin_theta, cos_theta) = theta.sin_cos();
-                let speed = rec.params.wind_speed.abs().max(0.5);
-                flow = Some(WaterFlow {
-                    direction: [cos_theta, 0.0, sin_theta],
-                    speed,
-                });
-                // Rebuild scroll vectors to bias along the flow axis.
-                mat.scroll_a = [cos_theta * speed * 0.5, sin_theta * speed * 0.5];
-                // Perpendicular shear at half speed for the second layer.
-                mat.scroll_b = [-sin_theta * speed * 0.25, cos_theta * speed * 0.25];
+                let canonical = WaterFlow::for_kind(kind, [cos_theta, 0.0, sin_theta]);
+                // Rebuild scroll vectors to bias along the flow axis,
+                // converting out of BU/s at the documented rate.
+                let scroll = canonical.speed * WATER_SCROLL_UV_PER_BU_PER_S;
+                mat.scroll_a = [cos_theta * scroll, sin_theta * scroll];
+                // Perpendicular shear at half rate for the second layer.
+                mat.scroll_b = [-sin_theta * scroll * 0.5, cos_theta * scroll * 0.5];
+                flow = Some(canonical);
             }
             // TNAM is the diffuse / noise texture — used as the
             // bindless normal map for the shader. Empty path =
@@ -1605,6 +1634,99 @@ mod tests {
             "wave_frequency must round-trip from WATR"
         );
         assert!(matches!(kind, WaterKind::Calm));
+    }
+
+    // ── #2872 — WaterFlow.speed unit ──────────────────────────────
+
+    /// The regression itself. Every vanilla FO3 / FNV / Skyrim WATR whose
+    /// DATA is 196 bytes (or DNAM 228) carries `90.0` in the float the
+    /// parser reads as `wind_speed` — a constant, the same value the shorter
+    /// legacy layouts put in the *direction* slot. Feeding it straight into
+    /// `WaterFlow::speed` made the physics current's terminal velocity 90
+    /// BU/s (3.6× the documented ceiling) and blew `scroll_a` out to ~45
+    /// against a documented default of `[0.020, 0.011]`.
+    ///
+    /// The canonical speed must now come from the `WaterKind` band and be
+    /// completely independent of that field.
+    #[test]
+    fn flow_speed_ignores_the_watr_wind_field_and_stays_in_band() {
+        // The real vanilla value, and two adversarial ones.
+        for wind_speed in [90.0_f32, 0.0, -1e9] {
+            let rec = calm_watr(
+                0x000B_0001,
+                "WaterRiverFallingSlow",
+                WaterParams {
+                    wind_speed,
+                    wind_direction: 0.0,
+                    ..WaterParams::default()
+                },
+            );
+            let mut waters = HashMap::new();
+            waters.insert(rec.form_id, rec);
+
+            let (mat, kind, flow, _) = resolve_water_material(&waters, Some(0x000B_0001));
+            let flow = flow.expect("a river EDID must synthesize a flow");
+            assert!(matches!(kind, WaterKind::River));
+            assert_eq!(
+                flow.speed,
+                WaterFlow::speed_for_kind(WaterKind::River),
+                "speed must come from the kind, not from wind_speed={wind_speed}"
+            );
+            assert!(
+                (WaterFlow::SPEED_MIN..=WaterFlow::SPEED_MAX).contains(&flow.speed),
+                "speed {} escaped the documented band",
+                flow.speed
+            );
+            // The shader scroll is derived from the same canonical scalar,
+            // so it can no longer diverge from the physics current.
+            let scroll = (mat.scroll_a[0].powi(2) + mat.scroll_a[1].powi(2)).sqrt();
+            assert!(
+                scroll < 0.05,
+                "scroll_a magnitude {scroll} is nowhere near the documented \
+                 [0.020, 0.011] default — the pre-fix value was ~45"
+            );
+        }
+    }
+
+    /// Rapids are faster than rivers, and the whole ladder stays inside the
+    /// band `WaterFlow::speed` documents — so `current_force`'s terminal
+    /// velocity target is bounded for every kind the translate site emits.
+    #[test]
+    fn flow_speed_ladder_is_ordered_and_bounded() {
+        let mut waters = HashMap::new();
+        for (form, edid) in [(0x000C_0001, "WhiteRapidsFast"), (0x000C_0002, "RiverSlow")] {
+            waters.insert(form, calm_watr(form, edid, WaterParams::default()));
+        }
+        let (_, rapids_kind, rapids, _) = resolve_water_material(&waters, Some(0x000C_0001));
+        let (_, river_kind, river, _) = resolve_water_material(&waters, Some(0x000C_0002));
+        assert!(matches!(rapids_kind, WaterKind::Rapids));
+        assert!(matches!(river_kind, WaterKind::River));
+
+        let rapids = rapids.expect("rapids flow");
+        let river = river.expect("river flow");
+        assert!(
+            rapids.speed > river.speed,
+            "rapids ({}) must run faster than a river ({})",
+            rapids.speed,
+            river.speed
+        );
+        for speed in [rapids.speed, river.speed] {
+            assert!((WaterFlow::SPEED_MIN..=WaterFlow::SPEED_MAX).contains(&speed));
+        }
+    }
+
+    /// Calm water carries no flow at all, so the physics current never
+    /// engages on a lake and the material keeps its default scroll.
+    #[test]
+    fn calm_water_carries_no_flow_and_default_scroll() {
+        let rec = calm_watr(0x000D_0001, "DefaultWater", WaterParams::default());
+        let mut waters = HashMap::new();
+        waters.insert(rec.form_id, rec);
+
+        let (mat, kind, flow, _) = resolve_water_material(&waters, Some(0x000D_0001));
+        assert!(matches!(kind, WaterKind::Calm));
+        assert!(flow.is_none());
+        assert_eq!(mat.scroll_a, WaterMaterial::default().scroll_a);
     }
 
     /// WATAL translate-up contract (docs/engine/watal.md §3/§4): a poorer

--- a/byroredux/src/npc_spawn.rs
+++ b/byroredux/src/npc_spawn.rs
@@ -184,15 +184,38 @@ pub fn build_character_ruleset(
 /// keeping it out of the dynamic solver entirely. Death-time ragdoll activation
 /// (`RagdollActive` / `build_ragdoll`) is unaffected — it rebuilds the
 /// simulated ragdoll separately.
+///
+/// #2873 — each skeleton bone that carries a collision shape also gets an
+/// [`ActorBoneCollider`](byroredux_physics::ActorBoneCollider) marker, so
+/// registration files its colliders under
+/// [`ACTOR_BONE_GROUP`](byroredux_physics::ACTOR_BONE_GROUP) and downward
+/// floor probes skip them. Without it, `locomotion::step_toward`'s ground-snap
+/// ray — cast from 256 BU above the actor's own root — meets the actor's
+/// upper-body bone before it reaches the floor and re-seats the root at that
+/// bone's height; because the bones are then driven from the root's
+/// `GlobalTransform`, the next tick casts from higher still. That is a
+/// monotonic elevator, not a one-off offset: walking NPCs ascend out of the
+/// cell. `exclude_rigid_body` cannot fix it — each bone is a separate body.
 fn keyframe_live_ragdoll_bones(
     world: &mut World,
     skel_map: &std::collections::HashMap<std::sync::Arc<str>, EntityId>,
 ) {
+    use byroredux_core::ecs::components::collision::CollisionShape;
+
     for &bone in skel_map.values() {
         if let Some(body) = world.get_mut::<RigidBodyData>(bone) {
             if body.motion_type == MotionType::Dynamic {
                 body.motion_type = MotionType::Keyframed;
             }
+        }
+        // Tag every bone that actually registers a collider, whatever its
+        // authored motion type — a bone shipped Keyframed upstream is just as
+        // self-hittable as one flipped above.
+        let has_shape = world
+            .query::<CollisionShape>()
+            .is_some_and(|q| q.contains(bone));
+        if has_shape {
+            world.insert(bone, byroredux_physics::ActorBoneCollider);
         }
     }
 }

--- a/byroredux/src/save_io/registry_completeness_tests.rs
+++ b/byroredux/src/save_io/registry_completeness_tests.rs
@@ -210,6 +210,7 @@ fn every_component_or_resource_impl_is_saved_or_explicitly_allowlisted() {
         ("TwoStateTransitionBatch", "one-shot presentation batch drained every tick; the state it summarizes (TwoStateActivator) is already registered"),
         ("UiMessageCommand", "one-shot command marker drained every frame; its only writer is unreachable in production today (same reason as MG07LabyrinthianDoor)"),
         // ── crates/physics/src/ ──────────────────────────────────────
+        ("ActorBoneCollider", "derived label, not state: re-applied to every skeleton bone by keyframe_live_ragdoll_bones on each NPC spawn, which a load re-runs (#2873)"),
         ("CharacterController", "mutable per-frame fields (velocity/grounded/jump) are deliberately zeroed on reload by the pose-restore path, not carried over"),
         ("ContactConfig", "boot-time tunable resource, no runtime mutator (no resource_mut call exists outside tests)"),
         ("PhysicsWaterConstants", "boot-time tunable resource, no runtime mutator (no resource_mut call exists outside tests)"),

--- a/byroredux/src/scene.rs
+++ b/byroredux/src/scene.rs
@@ -1192,11 +1192,27 @@ pub(crate) fn setup_scene(
             // healthy spawn pays nothing.
             if floor_probe_failed {
                 const SPAWN_CENSUS_RADIUS_BU: f32 = 256.0;
+                // Mirror rung 1's geometry exactly so the census's unfiltered
+                // re-sweep answers for the probe that actually failed (#2874),
+                // and so the column ordering centres on the height the floor
+                // was expected at rather than on the world's ceiling (#2875).
+                let probe_lift = floor_probe_lift(cc);
+                let authoring = world
+                    .try_resource::<crate::cell_loader::NifImportRegistry>()
+                    .map(|registry| registry.collision_authoring_totals());
                 byroredux_physics::dump_spawn_collider_census(
                     world,
-                    spawn.x,
-                    spawn.z,
-                    SPAWN_CENSUS_RADIUS_BU,
+                    byroredux_physics::SpawnCensusProbe {
+                        x: spawn.x,
+                        y: door_pos.y + probe_lift,
+                        z: spawn.z,
+                        radius: SPAWN_CENSUS_RADIUS_BU,
+                        capsule_half_height: cc.half_height,
+                        capsule_radius: cc.radius,
+                        max_distance: FLOOR_PROBE_CLEARANCE_BU + FLOOR_PROBE_REACH_BELOW_DOOR_BU,
+                        min_walkable_normal_y: min_walkable_normal_y(cc),
+                        authoring,
+                    },
                 );
             }
             if floor_probe_failed {

--- a/byroredux/src/systems/locomotion.rs
+++ b/byroredux/src/systems/locomotion.rs
@@ -61,14 +61,16 @@ pub(crate) fn step_toward(
             current.y + LOCOMOTION_GROUND_RAY_UP_OFFSET,
             new_pos.z,
         );
-        // NOTE: `None` here is a known, separately-tracked defect (#2873),
-        // not an assertion that nothing needs excluding. `step_toward`
-        // receives neither the actor's `EntityId` nor its `RapierHandles`,
-        // and each of an actor's ~18 keyframed ragdoll bones is a *separate*
-        // `KinematicPositionBased` body, so a single `exclude_rigid_body`
-        // would not be sufficient anyway — #2873 needs either a skeleton-root
-        // filter predicate or an "actor bone" collision-group bit. Left
-        // explicit so the gap stays visible at the call site.
+        // `None` is correct here, not a gap (#2873, fixed). The thing this
+        // ray must not hit is the moving actor's own ~18 keyframed ragdoll
+        // bones, and `exclude_rigid_body` could never cover them: each bone
+        // is a *separate* `KinematicPositionBased` body, and `step_toward`
+        // receives neither the actor's `EntityId` nor its `RapierHandles`.
+        // They are masked out wholesale instead — the bones carry
+        // `ACTOR_BONE_GROUP` and `cast_ray_down` filters that group out for
+        // every caller. Pre-fix, the ray hit the actor's upper body, re-seated
+        // its root at that bone's height, and — since the bones follow the
+        // root — climbed again next tick: an elevator, not an offset.
         if let Some(ground_y) =
             pw.cast_ray_down(ray_origin, LOCOMOTION_GROUND_RAY_MAX_DISTANCE, None)
         {

--- a/crates/core/src/ecs/components/water.rs
+++ b/crates/core/src/ecs/components/water.rs
@@ -213,9 +213,80 @@ pub struct WaterFlow {
     /// currents (rivers) keep Y=0. Set from the WATR `wind_direction`
     /// angle after the Z→Y swizzle in `cell_loader/water.rs`.
     pub direction: [f32; 3],
-    /// World units per second. Typical: 0.5 (calm river) … 8.0
-    /// (whitewater rapids) … 25.0 (Tamriel-tall waterfall sheet).
+    /// World units per second, always inside
+    /// [`WaterFlow::SPEED_MIN`]`..=`[`WaterFlow::SPEED_MAX`] when built
+    /// through [`WaterFlow::new`] / [`WaterFlow::for_kind`]. Typical:
+    /// 0.5 (calm river) … 8.0 (whitewater rapids) … 25.0 (Tamriel-tall
+    /// waterfall sheet).
     pub speed: f32,
+}
+
+impl WaterFlow {
+    /// Slowest current the physics sink will simulate — the "calm river"
+    /// anchor of [`Self::speed`]'s documented band. BU/s.
+    pub const SPEED_MIN: f32 = 0.5;
+    /// Fastest current the physics sink will simulate — the "Tamriel-tall
+    /// waterfall sheet" anchor of [`Self::speed`]'s documented band. BU/s.
+    ///
+    /// This is a hard ceiling, not a hint: `physics::water::current_force`
+    /// drives clutter toward `speed` as a terminal velocity, so an
+    /// unclamped value is an unbounded velocity target (#2872).
+    pub const SPEED_MAX: f32 = 25.0;
+
+    /// Speed for the "whitewater rapids" anchor of the documented band.
+    pub const SPEED_RAPIDS: f32 = 8.0;
+
+    /// Build a canonical flow: `direction` normalised, `speed` clamped into
+    /// the documented [`Self::SPEED_MIN`]`..=`[`Self::SPEED_MAX`] band.
+    ///
+    /// Every translate-side producer must come through here. A
+    /// degenerate/non-finite direction resolves to `+Z` at `SPEED_MIN`
+    /// rather than propagating NaN into the solver.
+    pub fn new(direction: [f32; 3], speed: f32) -> Self {
+        let [x, y, z] = direction;
+        let len = (x * x + y * y + z * z).sqrt();
+        let direction = if len.is_finite() && len > 1e-6 {
+            [x / len, y / len, z / len]
+        } else {
+            [0.0, 0.0, 1.0]
+        };
+        let speed = if speed.is_finite() {
+            speed.clamp(Self::SPEED_MIN, Self::SPEED_MAX)
+        } else {
+            Self::SPEED_MIN
+        };
+        Self { direction, speed }
+    }
+
+    /// Canonical current speed implied by a [`WaterKind`], in BU/s.
+    ///
+    /// #2872 — the physics current is synthesized from the *kind* rather
+    /// than from the WATR wind field, which carries no usable per-record
+    /// speed: across vanilla Fallout 3, Fallout: New Vegas and Skyrim SE,
+    /// the float at the head of `WATR.DATA` / `DNAM` is `90.0` on 146 of
+    /// 165 records (every 196- and 228-byte record, i.e. all of Skyrim and
+    /// ~85% of the Fallouts) — a constant, and exactly the value the
+    /// shorter legacy layouts carry in the *direction* slot. A field with
+    /// no variance across three games cannot be an authored per-water
+    /// velocity, and 90 BU/s is 3.6× this band's ceiling. Resolving which
+    /// offset actually holds the wind velocity in the newer layouts is a
+    /// decode-side question owned by the ESM parser, not something the
+    /// physics sink should guess at; these three values are the anchors
+    /// [`Self::speed`] already documents.
+    pub const fn speed_for_kind(kind: WaterKind) -> f32 {
+        match kind {
+            // Calm water carries no `WaterFlow` at all; the arm exists so
+            // the match stays total if a caller asks anyway.
+            WaterKind::Calm | WaterKind::River => Self::SPEED_MIN,
+            WaterKind::Rapids => Self::SPEED_RAPIDS,
+            WaterKind::Waterfall => Self::SPEED_MAX,
+        }
+    }
+
+    /// Canonical flow for a `kind` travelling along `direction`.
+    pub fn for_kind(kind: WaterKind, direction: [f32; 3]) -> Self {
+        Self::new(direction, Self::speed_for_kind(kind))
+    }
 }
 
 impl Component for WaterFlow {

--- a/crates/physics/src/components.rs
+++ b/crates/physics/src/components.rs
@@ -19,6 +19,27 @@ impl Component for RapierHandles {
     type Storage = SparseSetStorage<Self>;
 }
 
+/// Marks an entity whose collider belongs to a **live actor's skeleton** —
+/// one of the ~18 ragdoll bone bodies `keyframe_live_ragdoll_bones` flips
+/// from Dynamic to Keyframed before first registration (#1698).
+///
+/// `physics_sync_system` Phase 1 reads this to put the resulting colliders in
+/// [`crate::ACTOR_BONE_GROUP`], which every downward floor probe masks out.
+/// Without it a ground-snap ray cast from above an actor's root hits the
+/// actor's own upper-body bone instead of the floor, and because the bones
+/// are driven from the root's animated transform the actor climbs a little
+/// further every tick — a monotonic elevator, not a fixed offset (#2873).
+///
+/// Purely a query-side label: contact generation is unaffected (the bones'
+/// collision *filter* mask stays `Group::ALL`), and death-time ragdoll
+/// activation rebuilds its own simulated bodies regardless.
+#[derive(Debug, Clone, Copy)]
+pub struct ActorBoneCollider;
+
+impl Component for ActorBoneCollider {
+    type Storage = SparseSetStorage<Self>;
+}
+
 /// Kinematic character-controller body (M28.5). The high-level
 /// player rig — combines the capsule shape used by the physics layer
 /// with the movement-state fields the per-frame controller system

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -25,17 +25,18 @@ pub mod sync;
 pub mod water;
 pub mod world;
 
-pub use components::{CharacterController, Ragdoll, RapierHandles};
+pub use components::{ActorBoneCollider, CharacterController, Ragdoll, RapierHandles};
 pub use config::{ContactConfig, TriMeshFlagBits};
 pub use ragdoll::{
     build_ragdoll, RagdollBodySpec, RagdollConstraintSpec, RagdollJointSpec, RagdollSpec,
 };
 pub use sync::{
     dump_spawn_collider_census, physics_sync_system, set_kinematic_translation,
-    set_linear_velocity, SpawnCensusEntry,
+    set_linear_velocity, SpawnCensusAuthoring, SpawnCensusEntry, SpawnCensusProbe,
+    SpawnProbeVerdict,
 };
 pub use water::{buoyancy_force, submerged_fraction, PhysicsWaterConstants};
 pub use world::{
     CharacterMoveParams, CharacterMoveResult, NearbyCollider, PhysicsRayHit, PhysicsWorld,
-    PHYSICS_DT,
+    ACTOR_BONE_GROUP, PHYSICS_DT,
 };

--- a/crates/physics/src/sync.rs
+++ b/crates/physics/src/sync.rs
@@ -24,7 +24,7 @@ use rapier3d::prelude::{ColliderBuilder, RigidBodyBuilder, RigidBodyType};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::components::RapierHandles;
+use crate::components::{ActorBoneCollider, RapierHandles};
 use crate::config::ContactConfig;
 use crate::convert::{
     collision_shape_to_parts, iso_from_trs, quat_from_na, vec3_from_translation, vec3_to_na,
@@ -335,7 +335,96 @@ fn dump_awake_fallers(world: &World) {
 /// Number of nearby colliders named individually by
 /// [`dump_spawn_collider_census`]. A vestibule is a handful of architecture
 /// pieces; anything past this is a wall of log that hides the answer.
+///
+/// Safe to truncate at because the entries are ordered by distance from the
+/// probe height (#2875) — the cut falls on the far end of the column, not on
+/// the floor. Before that fix the ordering was absolute-Y descending, so in
+/// any two-storey interior these 24 slots went to roof beams and the upper
+/// landing while the spawn-height geometry landed in the "omitted" tail.
 const SPAWN_CENSUS_DETAIL_CAP: usize = 24;
+
+/// Cell-wide collision-authoring totals, forwarded into the census so a
+/// `0 total` column can name its cause (#2874).
+///
+/// Summed by the caller over the cell's `CachedNifImport` entries — the same
+/// `CollisionAuthoringSummary` counts the spawn path already uses to pick the
+/// packed-Havok proxy. Without them the census's `0 total` bucket conflates
+/// "nothing was authored" with "N classic shapes were authored and every one
+/// was dropped in translation", which is exactly the distinction that summary
+/// was built to remove (`docs/engine/physics.md`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SpawnCensusAuthoring {
+    /// `BhkCollisionObject` chains — decodable classic Havok.
+    pub classic: u32,
+    /// `BhkNPCollisionObject` — FO4+ packed Havok, payload still opaque.
+    pub new_physics: u32,
+    /// `BhkPCollisionObject` — Skyrim+ phantom / trigger volumes.
+    pub phantom: u32,
+}
+
+/// Everything [`dump_spawn_collider_census`] needs about the spawn probe that
+/// failed, so the diagnostic can reproduce the sweep instead of guessing at
+/// its geometry.
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnCensusProbe {
+    /// Probe XZ — the column to census.
+    pub x: f32,
+    /// Probe height. Both the census sort key and the origin of the
+    /// unfiltered re-sweep.
+    pub y: f32,
+    pub z: f32,
+    /// Column half-width, BU.
+    pub radius: f32,
+    /// Capsule the failing rungs swept, so the re-sweep matches them.
+    pub capsule_half_height: f32,
+    pub capsule_radius: f32,
+    pub max_distance: f32,
+    /// Walkability threshold the rungs applied to `normal1.y`.
+    pub min_walkable_normal_y: f32,
+    /// Cell-wide authoring totals; `None` when the caller has no NIF cache to
+    /// sum (a synthetic World, or the loose-NIF path).
+    pub authoring: Option<SpawnCensusAuthoring>,
+}
+
+/// Verdict of the unfiltered re-sweep run on the census path (#2874).
+///
+/// `cast_capsule_down_onto_walkable_surface` returns `None` for both "hit
+/// nothing" and "hit something too steep to stand on", so the three-rung
+/// ladder cannot report which happened. Re-running through
+/// `cast_capsule_down_surface_and_normal` recovers the normal it discarded.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SpawnProbeVerdict {
+    /// The swept capsule met nothing at all within `max_distance`.
+    NoHit,
+    /// It met a surface whose slope failed the walkable test — the spawn was
+    /// blocked by a ramp/wall, NOT by a missing or mis-transformed collider.
+    RejectedNonWalkable { surface_y: f32, normal_y: f32 },
+    /// It met a walkable surface. Reaching this from the all-rungs-missed
+    /// path means the census probe and the spawn rungs disagree (different
+    /// origin, capsule, or a query pipeline refreshed in between).
+    Walkable { surface_y: f32, normal_y: f32 },
+}
+
+impl SpawnProbeVerdict {
+    fn classify(hit: Option<(f32, f32)>, min_walkable_normal_y: f32) -> Self {
+        match hit {
+            None => Self::NoHit,
+            Some((surface_y, normal_y)) => {
+                if normal_y.abs() >= min_walkable_normal_y.clamp(0.0, 1.0) {
+                    Self::Walkable {
+                        surface_y,
+                        normal_y,
+                    }
+                } else {
+                    Self::RejectedNonWalkable {
+                        surface_y,
+                        normal_y,
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// One line of a spawn-column census (#2202). Pure data so the grouping is
 /// unit-testable without a live `World`.
@@ -394,13 +483,46 @@ fn census_tally(entries: &[SpawnCensusEntry]) -> (usize, usize, usize, usize, us
 ///
 /// Pure logging, no state change. Called only on the all-rungs-missed path,
 /// so a healthy spawn costs nothing.
-pub fn dump_spawn_collider_census(world: &World, x: f32, z: f32, radius: f32) {
+///
+/// `probe` is the failed spawn probe itself: the XZ column to census, the Y
+/// the floor was expected near, and the capsule the three rungs swept. It
+/// drives three things the pre-fix census could not do (#2874 / #2875) —
+/// ordering the column by distance from the probe rather than by absolute
+/// world Y, re-running the sweep *unfiltered* so a walkability rejection is
+/// distinguishable from a genuine miss, and (via `authoring`) splitting
+/// "no collider authored" from "authored but dropped in translation".
+pub fn dump_spawn_collider_census(world: &World, probe: SpawnCensusProbe) {
+    let SpawnCensusProbe {
+        x,
+        y: probe_y,
+        z,
+        radius,
+        capsule_half_height,
+        capsule_radius,
+        max_distance,
+        min_walkable_normal_y,
+        authoring,
+    } = probe;
     // Same lock-order discipline as `dump_awake_fallers` (#2136): snapshot
     // everything `PhysicsWorld` can answer, drop the guard, then open ECS
     // storages.
-    let nearby = {
+    let (nearby, verdict) = {
         let pw = world.resource::<PhysicsWorld>();
-        pw.colliders_near_xz(x, z, radius)
+        let nearby = pw.colliders_near_xz(x, probe_y, z, radius);
+        // Re-run the rungs' own sweep WITHOUT the walkability filter, so the
+        // normal `cast_capsule_down_onto_walkable_surface` discards is
+        // available to the log (#2874).
+        let hit = pw.cast_capsule_down_surface_and_normal(
+            byroredux_core::math::Vec3::new(x, probe_y, z),
+            capsule_half_height,
+            capsule_radius,
+            max_distance,
+            None,
+        );
+        (
+            nearby,
+            SpawnProbeVerdict::classify(hit, min_walkable_normal_y),
+        )
     };
 
     let mut body_to_entity: HashMap<rapier3d::prelude::RigidBodyHandle, EntityId> = HashMap::new();
@@ -442,13 +564,70 @@ pub fn dump_spawn_collider_census(world: &World, x: f32, z: f32, radius: f32) {
         .collect();
 
     let (fixed, dynamic, kinematic, sensors, orphan) = census_tally(&entries);
+    // #2874 — the walkability arm the pre-fix summary was missing entirely.
+    // It comes FIRST because when it fires, the column tallies below are a
+    // red herring: there is a surface here, it is simply too steep to stand
+    // on, and the old text would have steered the reader at "Fixed>0 at a
+    // wrong Y ⇒ transform composition".
+    match verdict {
+        SpawnProbeVerdict::RejectedNonWalkable {
+            surface_y,
+            normal_y,
+        } => log::warn!(
+            "#2874 unfiltered sweep from y={probe_y:.0} HIT y={surface_y:.1} with \
+             normal_y={normal_y:.3} ⇒ REJECTED as non-walkable (min={min_walkable_normal_y:.3}). \
+             The spawn is blocked by a slope, not by a missing or mis-transformed collider — \
+             the collider census below is NOT the cause.",
+        ),
+        SpawnProbeVerdict::NoHit => log::warn!(
+            "#2874 unfiltered sweep from y={probe_y:.0} over {max_distance:.0} BU hit NOTHING \
+             (walkability is not the cause; the column census below is).",
+        ),
+        SpawnProbeVerdict::Walkable {
+            surface_y,
+            normal_y,
+        } => log::warn!(
+            "#2874 unfiltered sweep from y={probe_y:.0} hit a WALKABLE surface y={surface_y:.1} \
+             normal_y={normal_y:.3} — the census probe and the spawn rungs disagree (different \
+             origin/capsule, or the query pipeline was refreshed between them).",
+        ),
+    }
+    // #2874 — split `0 total` into "nothing authored" vs "authored, dropped
+    // in translation". `CollisionAuthoringSummary` already computes the
+    // discriminator; the pre-fix census read the Rapier side only and so
+    // re-introduced the exact conflation that summary exists to remove.
+    match authoring {
+        Some(a) if entries.is_empty() && a.classic + a.new_physics + a.phantom > 0 => log::warn!(
+            "#2874 …but the cell's NIFs DID author collision: classic={} new_physics={} \
+             phantom={} ⇒ the shapes were DROPPED IN TRANSLATION (decode/registration), not \
+             absent from the source. `new_physics>0` additionally means FO4+ packed Havok whose \
+             payload is still opaque — the compatibility proxy should have covered it.",
+            a.classic,
+            a.new_physics,
+            a.phantom,
+        ),
+        Some(_) if entries.is_empty() => log::warn!(
+            "#2874 …and the cell's NIFs authored NO collision at all (classic=0 new_physics=0 \
+             phantom=0) ⇒ genuinely non-colliding content or a REFR-level gap, NOT a \
+             translation drop.",
+        ),
+        Some(a) => log::warn!(
+            "#2874 cell collision authoring: classic={} new_physics={} phantom={}.",
+            a.classic,
+            a.new_physics,
+            a.phantom,
+        ),
+        None => log::warn!(
+            "#2874 cell collision authoring unavailable (no NIF import cache) — `0 total` below \
+             cannot be split into 'nothing authored' vs 'dropped in translation'.",
+        ),
+    }
     log::warn!(
-        "#2202 spawn-column census at XZ ({x:.1}, {z:.1}) ±{radius:.0} BU: {} colliders \
-         (Fixed={fixed} Dynamic={dynamic} Kinematic={kinematic} orphan={orphan}, of which \
-         {sensors} sensors). Fixed=0 with Dynamic>0 ⇒ the floor is authored non-Fixed and both \
-         the spawn probe (exclude_dynamic) and the static census are blind to it; Fixed>0 at a \
-         wrong Y ⇒ transform composition; 0 total ⇒ the collider never spawned (per-NIF \
-         trimesh-fallback gate, or a REFR-level gap). Nearest {} by AABB centre Y:",
+        "#2202 spawn-column census at XZ ({x:.1}, {z:.1}) ±{radius:.0} BU around y={probe_y:.0}: \
+         {} colliders (Fixed={fixed} Dynamic={dynamic} Kinematic={kinematic} orphan={orphan}, of \
+         which {sensors} sensors). Fixed=0 with Dynamic>0 ⇒ the floor is authored non-Fixed and \
+         both the spawn probe (exclude_dynamic) and the static census are blind to it; Fixed>0 \
+         at a wrong Y ⇒ transform composition. Nearest {} by distance from the probe height:",
         entries.len(),
         entries.len().min(SPAWN_CENSUS_DETAIL_CAP),
     );
@@ -489,6 +668,9 @@ struct Newcomer {
     shape: CollisionShape,
     body_data: RigidBodyData,
     global: GlobalTransform,
+    /// Entity carries [`ActorBoneCollider`] — its colliders join
+    /// [`crate::ACTOR_BONE_GROUP`] so ground probes skip them (#2873).
+    is_actor_bone: bool,
 }
 
 impl Newcomer {
@@ -539,6 +721,9 @@ fn collect_newcomers(world: &World) -> Vec<Newcomer> {
         return out;
     };
 
+    // Optional — a World with no live actors never registers the storage.
+    let bone_q = world.query::<ActorBoneCollider>();
+
     for (entity, shape) in shape_q.iter() {
         if handles_q.contains(entity) {
             continue;
@@ -554,6 +739,7 @@ fn collect_newcomers(world: &World) -> Vec<Newcomer> {
             shape: shape.clone(),
             body_data: body_data.clone(),
             global: *global,
+            is_actor_bone: bone_q.as_ref().is_some_and(|q| q.contains(entity)),
         });
     }
 
@@ -637,6 +823,18 @@ fn register_newcomers(world: &World, newcomers: Vec<Newcomer>) {
         let part_mass = n.body_data.mass.max(0.0) / parts.len() as f32;
         let contact_skin = cfg.default_contact_skin_bu.max(0.0);
         let mut first_collider_handle: Option<rapier3d::prelude::ColliderHandle> = None;
+        // #2873 — label a live actor's ragdoll-bone colliders so downward
+        // floor probes can mask them out. Membership only: the filter half
+        // stays `Group::ALL`, so the bones still collide with everything
+        // they did before; this changes what *queries* see, not the solver.
+        let groups = if n.is_actor_bone {
+            rapier3d::prelude::InteractionGroups::new(
+                crate::ACTOR_BONE_GROUP,
+                rapier3d::prelude::Group::ALL,
+            )
+        } else {
+            rapier3d::prelude::InteractionGroups::all()
+        };
         for (iso, shape) in parts {
             let collider = ColliderBuilder::new(shape)
                 .position(iso)
@@ -644,6 +842,7 @@ fn register_newcomers(world: &World, newcomers: Vec<Newcomer>) {
                 .restitution(n.body_data.restitution)
                 .mass(part_mass)
                 .contact_skin(contact_skin)
+                .collision_groups(groups)
                 .build();
             let handle = colliders.insert_with_parent(collider, body_handle, bodies);
             if first_collider_handle.is_none() {
@@ -1158,5 +1357,125 @@ mod faller_diag_tests {
     #[test]
     fn resolves_to_none_when_neither_present() {
         assert_eq!(resolve_source_form(None, None), None);
+    }
+}
+
+// ── #2873 / #2874 ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod actor_bone_group_tests {
+    use super::*;
+    use crate::components::ActorBoneCollider;
+    use crate::world::PhysicsWorld;
+    use byroredux_core::ecs::components::collision::{CollisionShape, MotionType, RigidBodyData};
+    use byroredux_core::ecs::components::{GlobalTransform, Parent, Transform};
+    use byroredux_core::ecs::world::World;
+    use glam::{Quat, Vec3};
+
+    fn world() -> World {
+        let mut world = World::new();
+        world.register::<Transform>();
+        world.register::<GlobalTransform>();
+        world.register::<Parent>();
+        world.register::<CollisionShape>();
+        world.register::<RigidBodyData>();
+        world.register::<RapierHandles>();
+        world.register::<ActorBoneCollider>();
+        world.insert_resource(PhysicsWorld::new());
+        world
+    }
+
+    fn spawn_bone(world: &mut World, tag: bool) -> EntityId {
+        let e = world.spawn();
+        world.insert(e, Transform::new(Vec3::ZERO, Quat::IDENTITY, 1.0));
+        world.insert(e, GlobalTransform::new(Vec3::ZERO, Quat::IDENTITY, 1.0));
+        world.insert(
+            e,
+            CollisionShape::Cuboid {
+                half_extents: Vec3::splat(4.0),
+            },
+        );
+        world.insert(
+            e,
+            RigidBodyData {
+                motion_type: MotionType::Keyframed,
+                ..Default::default()
+            },
+        );
+        if tag {
+            world.insert(e, ActorBoneCollider);
+        }
+        e
+    }
+
+    /// #2873 — registration must file a tagged bone's collider under
+    /// `ACTOR_BONE_GROUP` (membership only, filter untouched) and leave an
+    /// untagged body on the default groups, so ground probes discriminate
+    /// between an actor's shoulder and the packed-Havok floor proxy.
+    #[test]
+    fn tagged_bones_register_into_the_actor_bone_group() {
+        let mut world = world();
+        let bone = spawn_bone(&mut world, true);
+        let prop = spawn_bone(&mut world, false);
+
+        physics_sync_system(&world, 0.0);
+
+        let handles = world.query::<RapierHandles>().expect("storage");
+        let pw = world.resource::<PhysicsWorld>();
+        let groups = |e: EntityId| {
+            let h = handles.get(e).copied().expect("registered");
+            pw.colliders
+                .get(h.collider)
+                .expect("collider")
+                .collision_groups()
+        };
+
+        assert_eq!(groups(bone).memberships, crate::ACTOR_BONE_GROUP);
+        assert_eq!(
+            groups(bone).filter,
+            rapier3d::prelude::Group::ALL,
+            "the mask is query-side only — contact generation must be unchanged"
+        );
+        assert_eq!(
+            groups(prop),
+            rapier3d::prelude::InteractionGroups::all(),
+            "an untagged keyframed body keeps the default groups"
+        );
+    }
+
+    /// #2874 — `cast_capsule_down_onto_walkable_surface` collapses "hit
+    /// nothing" and "hit something too steep" into a single `None`, which is
+    /// what made the census mis-attribute a ramp to a transform bug. The
+    /// verdict must keep them apart.
+    #[test]
+    fn probe_verdict_separates_a_miss_from_a_walkability_rejection() {
+        assert_eq!(
+            SpawnProbeVerdict::classify(None, 0.6),
+            SpawnProbeVerdict::NoHit
+        );
+        assert_eq!(
+            SpawnProbeVerdict::classify(Some((12.0, 0.45)), 0.6),
+            SpawnProbeVerdict::RejectedNonWalkable {
+                surface_y: 12.0,
+                normal_y: 0.45,
+            },
+            "a 63° ramp is a rejection, not a missing collider"
+        );
+        assert_eq!(
+            SpawnProbeVerdict::classify(Some((12.0, 0.98)), 0.6),
+            SpawnProbeVerdict::Walkable {
+                surface_y: 12.0,
+                normal_y: 0.98,
+            }
+        );
+        // Legacy Havok architecture can be inward-wound, so orientation is
+        // deliberately ignored — matching the walkable wrapper's own contract.
+        assert_eq!(
+            SpawnProbeVerdict::classify(Some((12.0, -0.98)), 0.6),
+            SpawnProbeVerdict::Walkable {
+                surface_y: 12.0,
+                normal_y: -0.98,
+            }
+        );
     }
 }

--- a/crates/physics/src/world.rs
+++ b/crates/physics/src/world.rs
@@ -56,6 +56,39 @@ pub const BU_PER_METER: f32 = byroredux_core::lighting::BETHESDA_UNITS_PER_METER
 /// [`PhysicsWorld::step`].
 pub const KILL_PLANE_Y: f32 = -25_000.0;
 
+/// Collision-group bit reserved for a **live actor's keyframed ragdoll-bone**
+/// colliders (#2873).
+///
+/// `keyframe_live_ragdoll_bones` flips each of an actor's ~18 skeleton bone
+/// bodies from Dynamic to Keyframed *before* first registration, so every
+/// bone lands in Rapier as a `KinematicPositionBased` body with a real
+/// collider — ~480+ of them across a dense interior. `exclude_dynamic()` does
+/// not filter kinematic bodies, so a ground probe cast from above an actor's
+/// root meets the actor's own upper-body bone long before it reaches the
+/// floor. Excluding a single rigid-body handle cannot fix that: each bone is a
+/// *separate* body.
+///
+/// Registration puts exactly those colliders in this membership group (and
+/// nothing else), and every downward floor probe filters it out via
+/// [`ground_probe_groups`]. Their *filter* mask stays `Group::ALL`, so contact
+/// generation against the rest of the world is unchanged — this bit is a
+/// query-side label, not a solver-side layer.
+pub const ACTOR_BONE_GROUP: rapier3d::prelude::Group = rapier3d::prelude::Group::GROUP_32;
+
+/// Interaction groups every downward floor probe queries with: sees
+/// everything except [`ACTOR_BONE_GROUP`].
+///
+/// Deliberately *not* a blanket "fixed bodies only" filter. The FO4+/Starfield
+/// packed-Havok compatibility proxy (`cell_loader::spawn`) registers real
+/// architecture as `MotionType::Keyframed`, so excluding the whole kinematic
+/// family would blind the spawn probe to the very floors that fallback exists
+/// to provide.
+#[inline]
+fn ground_probe_groups() -> rapier3d::prelude::InteractionGroups {
+    use rapier3d::prelude::{Group, InteractionGroups};
+    InteractionGroups::new(Group::ALL, Group::ALL & !ACTOR_BONE_GROUP)
+}
+
 /// One collider found by [`PhysicsWorld::colliders_near_xz`] (#2202).
 ///
 /// `body_type` is the Rapier label of the *parent* body, because that is the
@@ -584,6 +617,11 @@ impl PhysicsWorld {
     /// (rather than a defaulted sibling method) so every call site has to
     /// decide — a silent self-hit is invisible, since the returned
     /// `origin.y` is exactly what most callers use as their fallback (#2859).
+    ///
+    /// A live actor's keyframed ragdoll bones need no handle here: they carry
+    /// [`ACTOR_BONE_GROUP`] and are masked out wholesale by
+    /// [`ground_probe_groups`] (#2873). That matters because each bone is a
+    /// separate body — `excluded_body` could never cover all ~18 of them.
     pub fn cast_ray_down(
         &self,
         origin: byroredux_core::math::Vec3,
@@ -599,7 +637,7 @@ impl PhysicsWorld {
         // standing on a dropped barrel. `exclude_dynamic()` is an
         // associated-fn constructor on `QueryFilter`, not a builder
         // method; call it directly.
-        let mut filter = QueryFilter::exclude_dynamic();
+        let mut filter = QueryFilter::exclude_dynamic().groups(ground_probe_groups());
         if let Some(body) = excluded_body {
             filter = filter.exclude_rigid_body(body);
         }
@@ -723,7 +761,20 @@ impl PhysicsWorld {
         })
     }
 
-    fn cast_capsule_down_surface_and_normal(
+    /// The unfiltered form of [`cast_capsule_down_onto_walkable_surface`]:
+    /// returns `(surface_y, normal1.y)` for the first hit, walkable or not.
+    ///
+    /// Public because the walkable wrapper collapses two very different
+    /// outcomes into `None` — "the swept capsule hit nothing" and "it hit
+    /// something whose slope failed the walkable test" — and a spawn that
+    /// misses every rung needs to tell those apart. Re-running the probe
+    /// through this entry point on the failure path is what lets
+    /// `dump_spawn_collider_census` report *"unfiltered sweep hit y=… with
+    /// normal_y=… → REJECTED as non-walkable"* instead of mis-attributing a
+    /// 60° ramp to a transform-composition bug (#2874).
+    ///
+    /// [`cast_capsule_down_onto_walkable_surface`]: Self::cast_capsule_down_onto_walkable_surface
+    pub fn cast_capsule_down_surface_and_normal(
         &self,
         origin: byroredux_core::math::Vec3,
         capsule_half_height: f32,
@@ -735,7 +786,7 @@ impl PhysicsWorld {
         use rapier3d::prelude::*;
         let shape = SharedShape::capsule_y(capsule_half_height.max(1e-3), capsule_radius.max(1e-3));
         let pos = Isometry::translation(origin.x, origin.y, origin.z);
-        let mut filter = QueryFilter::exclude_dynamic();
+        let mut filter = QueryFilter::exclude_dynamic().groups(ground_probe_groups());
         if let Some(body) = excluded_body {
             filter = filter.exclude_rigid_body(body);
         }
@@ -810,9 +861,22 @@ impl PhysicsWorld {
     /// This one is deliberately unfiltered: the *point* is to see colliders
     /// the spawn probe cannot. Returned entries carry the parent body handle
     /// so the caller can resolve it back to an entity and its
-    /// `PhysicsSourceForm`; sorted by AABB centre Y, descending, so the
-    /// nearest thing above the probe reads first.
-    pub fn colliders_near_xz(&self, x: f32, z: f32, radius: f32) -> Vec<NearbyCollider> {
+    /// `PhysicsSourceForm`.
+    ///
+    /// Sorted by **distance from `probe_y`**, nearest first (#2875). The
+    /// pre-fix ordering sorted by absolute AABB centre Y descending and took
+    /// only the first N, which inverted the diagnostic: the question is "is
+    /// there a floor at or below the spawn?", whose answer lives at the low
+    /// end of the column, while a two-storey inn's roof beams and upper
+    /// landing monopolise the high end. In the dense-interior case this
+    /// census exists for, the evidence was exactly what got truncated away.
+    pub fn colliders_near_xz(
+        &self,
+        x: f32,
+        probe_y: f32,
+        z: f32,
+        radius: f32,
+    ) -> Vec<NearbyCollider> {
         use rapier3d::prelude::*;
         let mut out = Vec::new();
         for (_h, c) in self.colliders.iter() {
@@ -844,10 +908,19 @@ impl PhysicsWorld {
                 aabb_max: [aabb.maxs.x, aabb.maxs.y, aabb.maxs.z],
             });
         }
+        // Distance from the probe height, nearest first. Ties (a floor slab
+        // and a ceiling slab equidistant from the probe) break downward, so
+        // the one that could actually be a floor reads first.
+        let distance = |c: &NearbyCollider| {
+            let centre = 0.5 * (c.aabb_min[1] + c.aabb_max[1]);
+            ((centre - probe_y).abs(), centre > probe_y)
+        };
         out.sort_by(|a, b| {
-            let ac = a.aabb_min[1] + a.aabb_max[1];
-            let bc = b.aabb_min[1] + b.aabb_max[1];
-            bc.partial_cmp(&ac).unwrap_or(std::cmp::Ordering::Equal)
+            let (ad, a_above) = distance(a);
+            let (bd, b_above) = distance(b);
+            ad.partial_cmp(&bd)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a_above.cmp(&b_above))
         });
         out
     }
@@ -1129,7 +1202,7 @@ mod tests {
             "exclude_dynamic probe must not see a Dynamic floor"
         );
 
-        let near = w.colliders_near_xz(0.0, 0.0, 64.0);
+        let near = w.colliders_near_xz(0.0, 0.0, 0.0, 64.0);
         assert_eq!(near.len(), 1, "census must see it");
         assert_eq!(near[0].body_type, "Dynamic");
         assert!(!near[0].is_sensor);
@@ -1150,7 +1223,7 @@ mod tests {
             w.static_colliders_aabb().is_some(),
             "cell-wide census still reports a populated collision world"
         );
-        assert!(w.colliders_near_xz(0.0, 0.0, 64.0).is_empty());
+        assert!(w.colliders_near_xz(0.0, 0.0, 0.0, 64.0).is_empty());
     }
 
     /// Column overlap is an AABB test, not a centre-distance test: a slab
@@ -1163,30 +1236,71 @@ mod tests {
         // Centre 60 BU away in X, half-extent 50 ⇒ AABB spans x ∈ [10, 110].
         insert_slab(&mut w, Vec3::new(60.0, 0.0, 0.0), false);
         w.update_query_pipeline();
-        assert_eq!(w.colliders_near_xz(0.0, 0.0, 16.0).len(), 1);
+        assert_eq!(w.colliders_near_xz(0.0, 0.0, 0.0, 16.0).len(), 1);
         // Same slab, column now well clear of x ∈ [10, 110].
-        assert!(w.colliders_near_xz(-100.0, 0.0, 16.0).is_empty());
+        assert!(w.colliders_near_xz(-100.0, 0.0, 0.0, 16.0).is_empty());
     }
 
-    /// Results come back nearest-above-first so the entry most likely to be
-    /// the missing floor reads at the top of the dump.
+    /// #2875 — results come back nearest-to-the-probe first, so the entry
+    /// most likely to be the missing floor reads at the top of the dump.
     #[test]
-    fn census_sorts_by_aabb_centre_y_descending() {
+    fn census_sorts_by_distance_from_the_probe_height() {
         let mut w = PhysicsWorld::new();
         insert_slab(&mut w, Vec3::new(0.0, -500.0, 0.0), false);
         insert_slab(&mut w, Vec3::new(0.0, 300.0, 0.0), false);
         insert_slab(&mut w, Vec3::new(0.0, 0.0, 0.0), false);
         w.update_query_pipeline();
 
-        let near = w.colliders_near_xz(0.0, 0.0, 16.0);
+        // Probe at y=40: the floor at 0 is 40 away, the ceiling at 300 is
+        // 260, the basement at -500 is 540.
+        let near = w.colliders_near_xz(0.0, 40.0, 0.0, 16.0);
         assert_eq!(near.len(), 3);
         let centres: Vec<f32> = near
             .iter()
             .map(|n| 0.5 * (n.aabb_min[1] + n.aabb_max[1]))
             .collect();
-        assert!(
-            centres[0] > centres[1] && centres[1] > centres[2],
-            "expected descending centre Y, got {centres:?}"
+        assert_eq!(
+            centres,
+            vec![0.0, 300.0, -500.0],
+            "expected nearest-to-probe ordering, got {centres:?}"
+        );
+    }
+
+    /// #2875 — the ordering fix only matters because the census truncates,
+    /// and the pre-fix absolute-Y-descending sort put the floor *past* the
+    /// cut in exactly the dense column the diagnostic was written for.
+    ///
+    /// Models a two-storey interior: a stack of ceiling/beam/upper-landing
+    /// slabs above the probe, and one floor slab just below it. With
+    /// `SPAWN_CENSUS_DETAIL_CAP` entries printed, the floor must survive.
+    #[test]
+    fn census_keeps_the_floor_inside_the_detail_cap_in_a_dense_column() {
+        const DETAIL_CAP: usize = 24;
+        let mut w = PhysicsWorld::new();
+        let probe_y = 100.0;
+        // 40 slabs stacked above the probe — roof, rafters, upper floor.
+        for i in 0..40 {
+            insert_slab(
+                &mut w,
+                Vec3::new(0.0, probe_y + 200.0 * (i + 1) as f32, 0.0),
+                false,
+            );
+        }
+        // The floor the spawn is actually looking for, 20 BU under the probe.
+        insert_slab(&mut w, Vec3::new(0.0, probe_y - 20.0, 0.0), false);
+        w.update_query_pipeline();
+
+        let near = w.colliders_near_xz(0.0, probe_y, 0.0, 64.0);
+        assert_eq!(near.len(), 41);
+        let printed: Vec<f32> = near
+            .iter()
+            .take(DETAIL_CAP)
+            .map(|n| 0.5 * (n.aabb_min[1] + n.aabb_max[1]))
+            .collect();
+        assert_eq!(
+            printed[0],
+            probe_y - 20.0,
+            "the floor must be the FIRST entry printed, got {printed:?}"
         );
     }
 
@@ -1691,6 +1805,107 @@ mod audit_2026_08_13_regressions {
         assert!(
             filtered.is_some_and(|y| (y - 0.0).abs() < 0.5),
             "excluding the player body must reach the floor, got {filtered:?}"
+        );
+    }
+
+    // ── #2873 — ground probes must not see an actor's own bones ──────
+
+    /// Register a keyframed ragdoll-bone body the way `physics_sync_system`
+    /// does for a live actor: `KinematicPositionBased`, real collider,
+    /// membership in [`ACTOR_BONE_GROUP`].
+    fn actor_bone(w: &mut PhysicsWorld, centre: Vec3, tagged: bool) -> RigidBodyHandle {
+        use rapier3d::prelude::{Group, InteractionGroups};
+        let body = w.bodies.insert(
+            RigidBodyBuilder::kinematic_position_based()
+                .translation(vector![centre.x, centre.y, centre.z])
+                .build(),
+        );
+        let groups = if tagged {
+            InteractionGroups::new(ACTOR_BONE_GROUP, Group::ALL)
+        } else {
+            InteractionGroups::all()
+        };
+        w.colliders.insert_with_parent(
+            ColliderBuilder::ball(6.0).collision_groups(groups).build(),
+            body,
+            &mut w.bodies,
+        );
+        body
+    }
+
+    /// The defect: `step_toward` casts from `current.y + 256` straight down
+    /// through the actor it is trying to ground-snap. Its ~18 bones are
+    /// separate `KinematicPositionBased` bodies, which `exclude_dynamic()`
+    /// keeps, so the ray reports the actor's own upper body as the floor —
+    /// and since the bones follow the root, the next tick casts from higher
+    /// still. `ACTOR_BONE_GROUP` masks all of them at once.
+    #[test]
+    fn ground_ray_skips_actor_bones_and_reaches_the_floor() {
+        let mut w = PhysicsWorld::new();
+        floor_slab(&mut w, 0.0, 500.0);
+        // Stand-in for a head/spine bone at chest height, and the
+        // locomotion ray origin 256 BU above the actor's root.
+        let origin = Vec3::new(0.0, 256.0, 0.0);
+
+        let mut untagged = PhysicsWorld::new();
+        floor_slab(&mut untagged, 0.0, 500.0);
+        actor_bone(&mut untagged, Vec3::new(0.0, 120.0, 0.0), false);
+        untagged.update_query_pipeline();
+        assert_eq!(
+            untagged.cast_ray_down(origin, 1000.0, None),
+            Some(126.0),
+            "pre-fix behaviour: the ray stops on the actor's own bone, not the floor"
+        );
+
+        actor_bone(&mut w, Vec3::new(0.0, 120.0, 0.0), true);
+        w.update_query_pipeline();
+        let hit = w.cast_ray_down(origin, 1000.0, None);
+        assert!(
+            hit.is_some_and(|y| y.abs() < 0.5),
+            "a tagged actor bone must be invisible to the ground ray, got {hit:?}"
+        );
+    }
+
+    /// The capsule probes share the filter, so a spawn sweep cannot land the
+    /// player on an NPC's shoulder either.
+    #[test]
+    fn capsule_floor_probe_skips_actor_bones() {
+        let mut w = PhysicsWorld::new();
+        floor_slab(&mut w, 0.0, 500.0);
+        actor_bone(&mut w, Vec3::new(0.0, 120.0, 0.0), true);
+        w.update_query_pipeline();
+
+        let surface = w.cast_capsule_down(Vec3::new(0.0, 400.0, 0.0), 46.0, 18.0, 1000.0, None);
+        assert!(
+            surface.is_some_and(|y| y.abs() < 1.0),
+            "capsule sweep must pass through a tagged actor bone, got {surface:?}"
+        );
+    }
+
+    /// The mask is query-side only. Non-bone kinematic colliders — above all
+    /// the FO4+/Starfield packed-Havok proxy, which registers real
+    /// architecture as `MotionType::Keyframed` — must stay probeable, or the
+    /// fix would blind the spawn probe to the floors that fallback provides.
+    #[test]
+    fn ground_probe_still_sees_untagged_kinematic_architecture() {
+        let mut w = PhysicsWorld::new();
+        let body = w.bodies.insert(
+            RigidBodyBuilder::kinematic_position_based()
+                .translation(vector![0.0, 0.0, 0.0])
+                .build(),
+        );
+        w.colliders.insert_with_parent(
+            ColliderBuilder::cuboid(500.0, 10.0, 500.0).build(),
+            body,
+            &mut w.bodies,
+        );
+        w.update_query_pipeline();
+
+        let hit = w.cast_ray_down(Vec3::new(0.0, 300.0, 0.0), 1000.0, None);
+        assert!(
+            hit.is_some_and(|y| (y - 10.0).abs() < 0.5),
+            "an untagged Keyframed floor (the packed-Havok proxy) must stay \
+             probeable, got {hit:?}"
         );
     }
 

--- a/crates/plugin/examples/watr_wind_census.rs
+++ b/crates/plugin/examples/watr_wind_census.rs
@@ -1,0 +1,118 @@
+//! Census the leading wind floats of every `WATR` record in an ESM.
+//!
+//! Evidence harness for #2872. `WATR.DATA` (Oblivion / FO3 / FNV) and
+//! `WATR.DNAM` (Skyrim+, after a 4-byte tag) both open with a wind
+//! velocity / wind direction pair, and
+//! `esm::records::misc::water::decode_data` reads them at offsets 0 and 4
+//! for every layout. Running this over vanilla masters shows that is not
+//! true of the newer layouts:
+//!
+//! ```text
+//! FalloutNV.esm  len=186 n=8   field0=["0.100"]  field1=["90.000"]
+//! FalloutNV.esm  len=196 n=69  field0=["90.000"] field1=["0.200","0.500"]
+//! Skyrim.esm     len=228 n=31  field0=["90.000"] field1=["0.500"]
+//! Oblivion.esm   len=102 n=17  field0=["0.100","5.000","9.000","15.000"]
+//!                              field1=["35.000","62.000","90.000","100.000"]
+//! ```
+//!
+//! The 196/228-byte layouts hold `90.0` — a constant, and exactly the value
+//! the shorter layouts carry in the *direction* slot — in the float the
+//! parser treats as the wind velocity. That is what disqualified the field
+//! as a source for `WaterFlow::speed`; resolving which offset really holds
+//! the velocity in those layouts is the open decode-side half.
+//!
+//! Usage:
+//!   cargo run -p byroredux-plugin --example watr_wind_census -- <file.esm> [...]
+
+use byroredux_plugin::esm::reader::EsmReader;
+
+/// One record: `(editor_id, payload_len, field0, field1)`.
+type WatrRow = (String, usize, f32, f32);
+
+fn main() -> anyhow::Result<()> {
+    for path in std::env::args().skip(1) {
+        let bytes = std::fs::read(&path)?;
+        let mut reader = EsmReader::new(&bytes);
+        let _header = reader.read_file_header()?;
+        let mut rows: Vec<WatrRow> = Vec::new();
+        walk_groups(&mut reader, bytes.len(), &mut rows)?;
+
+        println!("== {path} — {} WATR records ==", rows.len());
+        // Group by payload length: the layouts differ per length, and the
+        // whole point is that the field meanings move with it.
+        let mut by_len: std::collections::BTreeMap<usize, Vec<(f32, f32)>> = Default::default();
+        for (_, len, field0, field1) in &rows {
+            by_len.entry(*len).or_default().push((*field0, *field1));
+        }
+        for (len, values) in &by_len {
+            println!(
+                "  len={len:<5} n={:<4} field0(parsed as wind_speed)={:?}  \
+                 field1(parsed as wind_direction)={:?}",
+                values.len(),
+                distinct(values.iter().map(|v| v.0)),
+                distinct(values.iter().map(|v| v.1)),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn distinct(values: impl Iterator<Item = f32>) -> Vec<String> {
+    let mut out: Vec<String> = values.map(|v| format!("{v:.3}")).collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn walk_groups(
+    reader: &mut EsmReader<'_>,
+    end: usize,
+    rows: &mut Vec<WatrRow>,
+) -> anyhow::Result<()> {
+    while reader.position() < end && reader.remaining() > 0 {
+        if reader.is_group() {
+            let group = reader.read_group_header()?;
+            let inner_end = reader.group_content_end(&group);
+            walk_groups(reader, inner_end, rows)?;
+            continue;
+        }
+        let header = reader.read_record_header()?;
+        if header.record_type != *b"WATR" {
+            reader.skip_record(&header);
+            continue;
+        }
+        let subs = reader.read_sub_records(&header)?;
+        let editor_id = subs
+            .iter()
+            .find(|sub| sub.sub_type == *b"EDID")
+            .map(|sub| zstring(&sub.data))
+            .unwrap_or_default();
+        // Oblivion / FO3 / FNV carry the prefix in DATA at offset 0;
+        // Skyrim+ carries it in DNAM after a 4-byte tag.
+        let (payload, base) = match subs.iter().find(|sub| sub.sub_type == *b"DATA") {
+            Some(sub) if sub.data.len() >= 8 => (&sub.data, 0usize),
+            _ => match subs.iter().find(|sub| sub.sub_type == *b"DNAM") {
+                Some(sub) if sub.data.len() >= 12 => (&sub.data, 4usize),
+                _ => continue,
+            },
+        };
+        let read = |off: usize| {
+            f32::from_le_bytes([
+                payload[off],
+                payload[off + 1],
+                payload[off + 2],
+                payload[off + 3],
+            ])
+        };
+        rows.push((editor_id, payload.len(), read(base), read(base + 4)));
+    }
+    Ok(())
+}
+
+fn zstring(bytes: &[u8]) -> String {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}


### PR DESCRIPTION
…ent from WATR wind, and make ground probes and the spawn census tell the truth

Four MEDIUM findings from /audit-physics dimensions 6 and 7.

#2872 — WaterFlow.speed carried the raw WATR wind field with no unit conversion, and the same scalar was also a shader UV scroll rate. The audit left the on-disk disproof open; running it settles the question. Across vanilla Fallout 3, Fallout: New Vegas and Skyrim SE the float the parser reads as `wind_speed` is 90.0 on 146 of 165 WATR records — every 196-byte DATA and every 228-byte DNAM, i.e. all of Skyrim and ~85% of the Fallouts — and 90.0 is exactly the value the shorter legacy layouts carry in the *direction* slot. A field with no variance across three games is not an authored per-water velocity. So every river/rapids plane got a 90 BU/s terminal-velocity target (3.6x the documented ceiling) and a scroll_a of ~[44.1, 8.9] against a documented default of [0.020, 0.011].

Takes the issue's option (b): the physics current is now synthesized from the WaterKind, using the three anchors WaterFlow::speed already documents (0.5 river / 8.0 rapids / 25.0 waterfall), through a new WaterFlow::new / for_kind that normalises the direction and clamps into the documented band. The shader scroll is derived from that canonical flow via an explicit BU/s -> UV/s constant calibrated so a River reproduces today's default look exactly — one scalar, one meaning, so the two consumers can no longer disagree. Re-deriving which offset holds the real wind velocity in the newer DATA/DNAM layouts stays a decode-side question; the evidence harness that produced these numbers lands as examples/watr_wind_census.rs.

#2873 — step_toward's ground-snap ray self-hit the moving actor's own keyframed ragdoll bones. exclude_dynamic does not filter kinematic bodies, the ray starts 256 BU above the actor's root, and the bones follow the root, so each tick re-seated the actor a little higher: an elevator, not an offset. No per-call exclusion could fix it — each of the ~18 bones is a separate body. Adds an ActorBoneCollider marker (stamped by keyframe_live_ragdoll_bones alongside the motion-type flip), files those colliders under ACTOR_BONE_GROUP at registration, and masks that group out of every downward floor probe. Membership only: the bones' filter mask stays Group::ALL, so contact generation is untouched. Deliberately not a blanket "fixed bodies only" filter — the FO4+/Starfield packed-Havok proxy registers real architecture as Keyframed, and a test pins that it stays probeable.

#2874 — the spawn census could not separate "no collider authored" from "dropped in translation", and was blind to "present but not walkable". The walkable capsule probe returns None for both a miss and a slope rejection, so a spawn blocked by a ramp logged "MISS on all 3 rungs" and the summary then pointed the reader at transform composition. cast_capsule_down_surface_and_- normal is now public and re-run unfiltered on the failure path, yielding a typed SpawnProbeVerdict that names the slope. The cell's CollisionAuthoringSummary totals are threaded in as well, so a 0-collider column splits into "nothing authored" versus "N classic / M new-physics authored, none registered" — the discriminator that summary exists to provide and that the census was re-conflating.

#2875 — colliders_near_xz took no Y and sorted by absolute world centre Y descending, then the census printed only the first 24. In any two-storey interior those 24 slots went to the roof and upper landing while the spawn-height geometry fell into the omitted tail — the exact dense-column case the diagnostic was written for. It now takes the probe Y and sorts by distance from it, ties breaking downward. The old test used three slabs and so could never observe the truncation interaction; the replacement models a 41-collider column and asserts the floor is the first line printed.