### PR TITLE
Fix #2687: sanitize non-finite Material scalars at the save/restore b…

### DIFF
--- a/byroredux/src/save_io.rs
+++ b/byroredux/src/save_io.rs
@@ -262,6 +262,20 @@ pub fn build_save_registry() -> SaveRegistry {
         // reverted every edited/permanent/temporary/damage layer to the
         // re-derived spawn base. Also a MUTABLE_DELTA_COLUMN (delta-safe).
         .register_component::<ActorValues>("ActorValues")
+        // #3027 (SAVE-D1-2026-08-16-02) — registered (so a hand load of an
+        // older save still resolves the column), but deliberately absent
+        // from `MUTABLE_DELTA_COLUMNS` below: despite the name/field
+        // reading like a live HP value, `ActorVitals.health` is a stable
+        // per-game AVIF FormID key (see the type's own doc comment,
+        // `crates/core/src/ecs/components/actor_values.rs`), stamped once
+        // at NPC spawn from static game data and never mutated at runtime
+        // — combat damage writes through `ActorValues` (already a delta
+        // column) using this FormID as the lookup key, not through this
+        // struct. Mid-session health changes already survive a reload via
+        // that path; this is write-once/re-derivable, the same shape as
+        // `CharacterLevel`/`Perks` below, just not listed in
+        // `REDERIVED_NOT_SAVED` because it's plain-registered (not the
+        // save-omitted case that allowlist tracks).
         .register_component::<ActorVitals>("ActorVitals")
         .register_component::<EquippedWeapon>("EquippedWeapon")
         .register_component::<Dead>("Dead")

--- a/byroredux/src/save_io/round_trip_tests.rs
+++ b/byroredux/src/save_io/round_trip_tests.rs
@@ -746,6 +746,11 @@ fn npc_spawn_stamped_components_are_saved_or_intentionally_rederived() {
         "Inventory",
         "EquipmentSlots",
         "ActorValues",
+        // #3027 — registered (not re-derived), so it satisfies the XOR
+        // below via `saved`, not `REDERIVED_NOT_SAVED`. See the
+        // registration-site comment in `save_io.rs` for why it's still
+        // excluded from `MUTABLE_DELTA_COLUMNS`.
+        "ActorVitals",
         "FactionRanks",
         "CharacterLevel",
         "Background",

--- a/crates/core/src/ecs/components/actor_values.rs
+++ b/crates/core/src/ecs/components/actor_values.rs
@@ -73,6 +73,14 @@ pub struct ActorValues {
 /// ActorValues remains a game-agnostic map. This companion supplies the
 /// resolved per-game Health AVIF FormID so combat never hard-codes or guesses
 /// which entry is health.
+///
+/// **`health` is a FormID, not an HP value** — despite how it reads, this is
+/// not where an actor's current/max health lives. It's stamped once at NPC
+/// spawn from static per-game AVIF data and never mutated afterward; the
+/// actual mutable health (base/damage/mods) lives in [`ActorValues`], looked
+/// up using this FormID as the key. See #3027 (SAVE-D1-2026-08-16-02) — this
+/// note exists because the name alone reads as live vital-signs state, which
+/// cost an audit pass a false "is this an oversight?" investigation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "inspect", derive(serde::Serialize, serde::Deserialize))]
 pub struct ActorVitals {

--- a/crates/core/src/ecs/components/material.rs
+++ b/crates/core/src/ecs/components/material.rs
@@ -929,6 +929,84 @@ impl Material {
         self.metalness = self.metalness.clamp(0.0, 1.0);
         self.roughness = self.roughness.clamp(0.04, 1.0);
     }
+
+    /// Reset every non-finite (NaN / ±inf) scalar to its
+    /// [`Material::default()`] value. `metalness`/`roughness` defer to
+    /// [`Self::resolve_pbr`] instead of a blind default, since that already
+    /// runs the keyword classifier and clamp for NaN and also normalizes
+    /// ±inf via the same clamp. Returns `true` if any field was non-finite
+    /// (and has now been repaired), `false` if the material was already
+    /// clean — callers use this to decide whether to log/reject rather than
+    /// diffing the struct themselves.
+    ///
+    /// #2687 (SAFE-D9-01) — `translate_material` is the only NIF-import
+    /// producer of a renderer-bound `Material`, and it is NaN-safe end to
+    /// end. Save/restore is a second producer with no equivalent gate: a
+    /// hand-edited or corrupted save file can carry a non-finite scalar
+    /// straight through `restore_world` into `GpuMaterial` on the next
+    /// frame — NaN/Inf feeding the GPU is undefined behavior, not just a
+    /// visual glitch. This is the *repair* half, called once per restored
+    /// `Material` (`crates/save/src/driver.rs::restore_world`); the
+    /// *prevention* half is `crates/save/src/validate.rs`'s pre-save gate
+    /// (which probes a clone with this same method rather than duplicating
+    /// the field list), refusing to persist an already-poisoned world in
+    /// the first place. Every field is reset independently — a NaN `ior`
+    /// does not take down an otherwise-valid `metalness`.
+    pub fn sanitize_finite(&mut self) -> bool {
+        let mut changed = !self.metalness.is_finite() || !self.roughness.is_finite();
+        self.resolve_pbr();
+
+        let default = Self::default();
+
+        macro_rules! fix_scalar {
+            ($field:ident) => {
+                if !self.$field.is_finite() {
+                    self.$field = default.$field;
+                    changed = true;
+                }
+            };
+        }
+        macro_rules! fix_vec {
+            ($field:ident) => {
+                for i in 0..self.$field.len() {
+                    if !self.$field[i].is_finite() {
+                        self.$field[i] = default.$field[i];
+                        changed = true;
+                    }
+                }
+            };
+        }
+
+        fix_vec!(emissive_color);
+        fix_scalar!(emissive_mult);
+        fix_vec!(specular_color);
+        fix_scalar!(specular_strength);
+        fix_vec!(diffuse_color);
+        fix_vec!(ambient_color);
+        fix_scalar!(glossiness);
+        fix_vec!(uv_offset);
+        fix_vec!(uv_scale);
+        fix_scalar!(alpha);
+        fix_scalar!(env_map_scale);
+        fix_scalar!(alpha_threshold);
+        fix_vec!(translucency_subsurface_color);
+        fix_scalar!(translucency_transmissive_scale);
+        fix_scalar!(translucency_turbulence);
+        fix_scalar!(lighting_effect_1);
+        fix_scalar!(lighting_effect_2);
+        fix_scalar!(subsurface_rolloff);
+        fix_scalar!(rimlight_power);
+        fix_scalar!(backlight_power);
+        fix_scalar!(fresnel_power);
+        fix_scalar!(grayscale_to_palette_scale);
+        fix_scalar!(ior);
+        fix_scalar!(subsurface);
+        fix_scalar!(sheen);
+        fix_scalar!(sheen_tint);
+        fix_scalar!(anisotropic);
+
+        changed
+    }
 }
 
 /// ASCII case-insensitive substring match. Zero allocations. Assumes
@@ -1566,6 +1644,69 @@ mod tests {
         m.resolve_pbr();
         assert_eq!(m.metalness, 1.0);
         assert_eq!(m.roughness, 0.04);
+    }
+
+    // ── `sanitize_finite` — #2687 (SAFE-D9-01), the save/restore boundary's
+    //   NaN/Inf gate (repair half; `crates/save/src/validate.rs`'s
+    //   pre-save check is the prevention half, via a clone-and-probe of
+    //   this same method).
+
+    #[test]
+    fn sanitize_finite_repairs_metalness_and_roughness_via_resolve_pbr() {
+        let mut m = Material {
+            texture_path: Some(r"Textures\Weapons\Iron\IronSword.dds".to_string()),
+            metalness: f32::NAN,
+            roughness: f32::INFINITY,
+            ..Material::default()
+        };
+        assert!(m.sanitize_finite());
+        assert!(m.metalness.is_finite());
+        assert!(m.roughness.is_finite());
+        assert!(m.roughness <= 1.0, "resolve_pbr's clamp catches the +inf");
+    }
+
+    #[test]
+    fn sanitize_finite_resets_other_scalars_to_default_independently() {
+        // A poisoned `ior` must not disturb an otherwise-valid `alpha`,
+        // and vice versa — every field is checked and reset on its own.
+        let mut m = Material {
+            ior: f32::NAN,
+            alpha: 0.42,
+            ..Material::default()
+        };
+        assert!(m.sanitize_finite());
+        assert_eq!(m.ior, Material::default().ior);
+        assert_eq!(m.alpha, 0.42, "a valid field must survive the sweep untouched");
+    }
+
+    #[test]
+    fn sanitize_finite_resets_a_poisoned_vec3_component_only() {
+        let mut m = Material {
+            specular_color: [1.0, f32::NAN, 0.5],
+            ..Material::default()
+        };
+        assert!(m.sanitize_finite());
+        let default_specular = Material::default().specular_color;
+        assert_eq!(m.specular_color[0], 1.0, "clean component untouched");
+        assert_eq!(m.specular_color[1], default_specular[1]);
+        assert_eq!(m.specular_color[2], 0.5, "clean component untouched");
+    }
+
+    #[test]
+    fn sanitize_finite_is_a_noop_on_an_already_clean_material() {
+        let mut m = Material::default();
+        assert!(!m.sanitize_finite());
+        assert_eq!(m.diffuse_color, Material::default().diffuse_color);
+    }
+
+    #[test]
+    fn sanitize_finite_handles_negative_infinity_too() {
+        let mut m = Material {
+            fresnel_power: f32::NEG_INFINITY,
+            ..Material::default()
+        };
+        assert!(m.sanitize_finite());
+        assert!(m.fresnel_power.is_finite());
     }
 
     /// #2591 (SKY-D7-03) — either a black color or a zero multiplier

--- a/crates/core/src/ecs/world.rs
+++ b/crates/core/src/ecs/world.rs
@@ -6,6 +6,31 @@
 //! The `RwLock` enables query methods to take `&self` instead of `&mut self`,
 //! so multiple queries can be held simultaneously across different component
 //! types without fighting the borrow checker.
+//!
+//! ## House rule: snapshot before you iterate
+//!
+//! A system that reads one or more storages/resources and then, per entity,
+//! calls into a shared helper that itself acquires storages/resources should
+//! copy what it needs into an owned local (a `Vec`, a `HashMap`, a `Copy`
+//! struct) and drop its own guards *before* the per-entity loop — not hold
+//! them across the call into the helper. Two guards on the same `RwLock`
+//! read-locked simultaneously on one thread is the textbook recursive-read
+//! hazard (`std::sync::RwLock` is write-preferring, so it can park behind a
+//! queued writer that is itself waiting on the guard you're still holding);
+//! nested acquisition of *different* locks in an order that varies by call
+//! site is the general ABBA case. Both are avoided by simply not being in
+//! the storage when the helper runs.
+//!
+//! This isn't enforced by the type system — [`RwLock`] will happily let you
+//! hold a guard across an arbitrary call — so it's a convention, not a
+//! guarantee. Established examples: `physics_sync_system`'s
+//! `collect_newcomers` phase (`crates/physics/src/sync.rs`) snapshots into an
+//! owned `Vec` and returns before any write guard opens; the M42
+//! AI-procedure systems (`follow.rs`/`escort.rs`/etc., per #2134) do the
+//! same for their per-entity physics reads; `scene_playback_system`
+//! (`crates/scripting/src/scene/playback.rs`) collects `SceneStartRequest`/
+//! `SceneStopRequest`/`SceneActionCompletionBatch` into owned locals via
+//! `snapshot_entities` before touching anything else. #2270.
 
 use super::lock_tracker;
 use super::query::{ComponentRef, QueryRead, QueryWrite};

--- a/crates/save/src/driver.rs
+++ b/crates/save/src/driver.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use byroredux_core::ecs::components::FormIdComponent;
+use byroredux_core::ecs::components::{FormIdComponent, Material};
 use byroredux_core::ecs::world::World;
 use byroredux_core::form_id::{FormIdPair, FormIdPool};
 use byroredux_core::string::StringPool;
@@ -131,6 +131,30 @@ pub fn restore_world(
     for (name, _save, load) in registry.resource_entries() {
         if let Some(value) = snapshot.resources.get(name) {
             load(world, value.clone())?;
+        }
+    }
+
+    // #2687 (SAFE-D9-01) — `restore_world` is a second renderer-bound
+    // `Material` producer alongside `translate_material`, and unlike that
+    // boundary it had no NaN/Inf gate: a hand-edited or corrupted save file
+    // could carry a non-finite scalar straight into `GpuMaterial` on the
+    // next frame. Sweep every restored `Material` through
+    // `sanitize_finite()` before this function returns — see that method's
+    // doc for why this is the repair half (the save-side `validate_world`
+    // gate below is the prevention half).
+    if let Some(mut q) = world.query_mut::<Material>() {
+        let mut repaired = 0u32;
+        for (_entity, material) in q.iter_mut() {
+            if material.sanitize_finite() {
+                repaired += 1;
+            }
+        }
+        if repaired > 0 {
+            log::warn!(
+                "restore_world: repaired {repaired} Material component(s) carrying a \
+                 non-finite (NaN/Inf) scalar — save may predate a validation rule, or \
+                 was hand-edited (#2687)"
+            );
         }
     }
 

--- a/crates/save/src/validate.rs
+++ b/crates/save/src/validate.rs
@@ -15,7 +15,8 @@
 use byroredux_core::animation::{AnimationClipRegistry, AnimationPlayer};
 use byroredux_core::character::CharacterLevel;
 use byroredux_core::ecs::components::{
-    Children, EquipmentSlots, EquippedWeapon, EscortState, FollowState, Inventory, Parent, Seated,
+    Children, EquipmentSlots, EquippedWeapon, EscortState, FollowState, Inventory, Material,
+    Parent, Seated,
 };
 use byroredux_core::ecs::resources::ItemInstancePool;
 use byroredux_core::ecs::storage::EntityId;
@@ -57,6 +58,9 @@ pub enum ValidationKind {
     /// "re-derived from static ESM data, write-once" now holds state that
     /// isn't actually re-derivable — see [`validate_progression_state`].
     UnsavedProgression,
+    /// A `Material` carries a non-finite (NaN/Inf) scalar — see
+    /// [`validate_material_finiteness`] and [`Material::sanitize_finite`].
+    NonFiniteMaterial,
 }
 
 /// Walk the world and collect every referential-integrity violation.
@@ -74,6 +78,7 @@ pub fn validate_world(world: &World) -> Vec<ValidationError> {
     validate_animation(world, next_entity, &mut errors);
     validate_inventory_instances(world, &mut errors);
     validate_progression_state(world, &mut errors);
+    validate_material_finiteness(world, &mut errors);
 
     errors
 }
@@ -433,6 +438,30 @@ fn validate_progression_state(world: &World, errors: &mut Vec<ValidationError>) 
     }
 }
 
+/// Every `Material` must carry only finite (non-NaN, non-±inf) scalars —
+/// see [`Material::sanitize_finite`] for why. Probes a clone rather than
+/// mutating the live world: `validate_world` takes `&World` and is meant
+/// to be a pure pre-save check, and reusing `sanitize_finite`'s own field
+/// list here (instead of re-deriving one) means a future field added to
+/// `Material` can't drift the two checks apart. #2687 (SAFE-D9-01).
+fn validate_material_finiteness(world: &World, errors: &mut Vec<ValidationError>) {
+    let Some(q) = world.query::<Material>() else {
+        return;
+    };
+    for (entity, material) in q.iter() {
+        let mut probe = material.clone();
+        if probe.sanitize_finite() {
+            errors.push(ValidationError {
+                entity,
+                kind: ValidationKind::NonFiniteMaterial,
+                detail: "Material has a non-finite (NaN/Inf) scalar field — would poison \
+                         GpuMaterial on the GPU"
+                    .to_string(),
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -580,6 +609,35 @@ mod tests {
         let mut world = World::new();
         let e = world.spawn();
         world.insert(e, CharacterLevel { level: 5, xp: 0 });
+        assert!(validate_world(&world).is_empty());
+    }
+
+    /// #2687 (SAFE-D9-01) — a `Material` with a non-finite scalar (the
+    /// shape a hand-edited/corrupted save would carry) trips the gate
+    /// rather than being written silently. A clean `Material` passes.
+    #[test]
+    fn material_with_non_finite_scalar_trips_the_gate() {
+        let mut world = World::new();
+        let e = world.spawn();
+        world.insert(
+            e,
+            Material {
+                roughness: f32::NAN,
+                ..Material::default()
+            },
+        );
+
+        let errors = validate_world(&world);
+        assert_eq!(errors.len(), 1, "{errors:?}");
+        assert_eq!(errors[0].entity, e);
+        assert_eq!(errors[0].kind, ValidationKind::NonFiniteMaterial);
+    }
+
+    #[test]
+    fn material_with_only_finite_scalars_is_clean() {
+        let mut world = World::new();
+        let e = world.spawn();
+        world.insert(e, Material::default());
         assert!(validate_world(&world).is_empty());
     }
 

--- a/docs/engine/save-load-roundtrip.md
+++ b/docs/engine/save-load-roundtrip.md
@@ -7,16 +7,18 @@ how it's written safely to disk, and — the part that makes this engine's
 save/load different from a typical "restart and reload a level" design —
 how a save gets applied to a *running* engine without a process restart.
 
-> **Currency note.** Verified against the tree as of 2026-08-18, all
-> citations checked against current source. One real contradiction found
-> in ROADMAP.md while writing this: its M45 milestone row (line 314)
-> says "M45.1 player-pose restore closed 2026-06-21" with full
-> implementation detail, but its Known Issues list (line 671) still
-> says "Open refinement: precise player/camera-pose restore (load
-> currently lands at cell default)" — directly contradicting the row
-> above it. The code confirms pose restore is implemented and tested
-> (`PlayerPose`, `capture_player_pose`, `apply_player_pose`, three
-> dedicated tests). Fixed alongside this doc.
+> **Currency note.** Refreshed 2026-08-24 (#3028 / SAVE-D6-2026-08-16-03),
+> all citations re-checked against current source. §2/§3/§6 had drifted:
+> the registered component/resource count roughly doubled since the
+> 2026-08-18 pass (M42 AI-procedure state, cinematic/quest-fragment
+> resources, `Material`, `RigidBodyData`, `RumbleOnActivate`, …),
+> `validate_world` gained three more invariant checks, and §6's death
+> handling changed from "additive-only, nothing removes state" to a
+> marker-plus-reconciler pattern (#3022). Sections below are written to
+> point at the registration/column-list source rather than hand-enumerate
+> it, since that enumeration is what went stale last time — see each
+> section's own note. Also reconciles #3021 (an exterior save taken after
+> visiting an interior no longer masquerades as an interior save).
 
 ## 1. Save trigger
 
@@ -26,28 +28,30 @@ all call the same `save_io::quicksave`/`SaveCommand` implementation. It resolves
 the validation gates (§3), then calls `save_world` → `encode` →
 `disk::write_slot`. It only needs `&World`, so it's a plain
 `ConsoleCommand`, not a deferred/queued action. `SaveInfoCommand`
-(`save_io.rs:449`, `"save.info"`) is the read-only companion — decode +
+(`save_io.rs:783`, `"save.info"`) is the read-only companion — decode +
 verify a slot without touching the live world.
 
 ## 2. ECS snapshot capture
 
 Despite "full-ECS snapshot" shorthand elsewhere, this is a **curated
-subset by design**: "only types that carry player-visible game state —
-derived data, GPU handles, transient event markers are reconstructed on
-load, never serialised" (`crates/save/src/registry.rs:146-151`).
-`SaveRegistry` (`registry.rs:70`) is a type-erased registry — the same
+subset by design** — only types that carry player-visible game state;
+derived data, GPU handles, and transient event markers are reconstructed
+on load, never serialised (`crates/save/src/registry.rs`'s module doc).
+`SaveRegistry` (`registry.rs:74`) is a type-erased registry — the same
 shape as debug-server's `ComponentDescriptor` (per CLAUDE.md) — storing
 a boxed save/load closure pair per component or resource, keyed by a
-stable string name. `build_save_registry()` (`byroredux/src/save_io.rs:162`)
-is the binary-side population point: today 10+ components (`Transform`,
-`Name`, `Parent`, `Children`, `Inventory`, `EquipmentSlots`,
-`LightSource`, `LightFlicker`, `AnimationPlayer`, `AnimationStack`,
-`ScriptTimer`, `ActorValues`, `FormIdComponent`) and gameplay resources
-including `ItemInstancePool`, `CurrentCellContext`, `PlayerPose`, quest
-stage/objective state, and the persistent `GameTimeRes` day/night clock.
-`save_world` (`crates/save/src/driver.rs:28`) walks the
+stable string name. `build_save_registry()` (`byroredux/src/save_io.rs:223`)
+is the binary-side population point and the authoritative list — don't
+hand-copy its contents here, it has grown fast (roughly two dozen
+components — actor/AI/inventory/equipment/animation/scripting state,
+NPC vitals, cinematic and rigid-body data — plus about a dozen resources
+including `ItemInstancePool`, `CurrentCellContext`/
+`CurrentExteriorContext`, `PlayerPose`, `GameTimeRes`, and the quest/
+scripting-fragment resources). Each registration site carries its own
+comment explaining *why* that type is saved, which is more durable than
+a count. `save_world` (`crates/save/src/driver.rs:28`) walks the
 registry's component/resource entries and a `StringPool` dump (symbol
-order) into a `Snapshot` (`crates/save/src/snapshot.rs:64`); rows are
+order) into a `Snapshot` (`crates/save/src/snapshot.rs:78`); rows are
 sorted by entity id first for a reproducible CRC.
 
 Entity ids round-trip **exactly** — load doesn't remap ids from scratch
@@ -61,15 +65,27 @@ even though they're logically the same game objects.)
 
 ## 3. Validation gates
 
-`validate_world` (`crates/save/src/validate.rs:60`) checks four
-invariants: Hierarchy (`Parent`⇄`Children` agreement, dangling refs),
-Equipment (`EquipmentSlots` occupant indexes resolve into `Inventory`),
-AnimationClip (`AnimationPlayer.clip_handle` resolves in the registry),
-ItemInstance (`ItemStack.instance` resolves in `ItemInstancePool`) —
-plus a binary-side `validate_form_ids` (`byroredux/src/save_io.rs:352`,
-needs `FormIdPool`, which the save crate doesn't own).
+`validate_world` (`crates/save/src/validate.rs:67`) has grown to seven
+invariants, each its own `ValidationKind`: Hierarchy (`Parent`⇄`Children`
+agreement, dangling refs), Equipment (`EquipmentSlots` occupant indexes
+resolve into `Inventory`), DanglingEntity (saved `FollowState`/
+`EscortState`/`Seated` entity references point at a spawned id —
+`validate_saved_entity_references`), AnimationClip
+(`AnimationPlayer.clip_handle` resolves in the registry), ItemInstance
+(`ItemStack.instance` resolves in `ItemInstancePool`), UnsavedProgression
+(`CharacterLevel.xp != 0` while that type is still save-exempt as
+re-derivable — #2947, aborts loudly rather than silently discarding
+progress), and NonFiniteMaterial (a `Material` scalar is NaN/Inf — #2687,
+probes a clone via `Material::sanitize_finite` rather than a second field
+list) — plus a binary-side `validate_form_ids` (`byroredux/src/save_io.rs`,
+needs `FormIdPool`, which the save crate doesn't own) and
+`validate_cinematic_entity_refs` (#2535, needs `byroredux-scripting`
+types). New invariants get added here often enough that, as with §2,
+treat `validate.rs`'s `ValidationKind` enum as the source of truth.
 
-The two run **before** writing (`save_io.rs:407-408`): a non-empty
+The three (`validate_world` + `validate_form_ids` +
+`validate_cinematic_entity_refs`) run **before** writing
+(`save_io.rs`, `SaveCommand::execute`): a non-empty
 result aborts the save outright — `save_world`/`write_slot` are never
 called, and the command reports the first 20 issues instead. On the
 **load** side the same checks run again, but only as a diagnostic
@@ -87,9 +103,9 @@ asymmetry).
 isn't durable until the directory entry is synced too; Unix-only, this
 last step is skipped on Windows).
 
-`SaveRing` (`disk.rs:117`) is a fixed-size round-robin cursor — size
-`10`, directory `saves/` (both set at `boot.rs:894-897`), filename
-scheme `save_<n>.ess`. `SaveRing::resume` (`disk.rs:140`) scans on-disk
+`SaveRing` (`disk.rs:143`) is a fixed-size round-robin cursor — size
+`10`, directory `saves/` (both set at `boot.rs:1558-1561`), filename
+scheme `save_<n>.ess`. `SaveRing::resume` (`disk.rs:166`) scans on-disk
 mtimes at boot and starts one slot *past* the newest, so a post-restart
 quicksave can't clobber the most recent good save.
 
@@ -112,43 +128,65 @@ onto yet.
 
 ## 6. Live load-apply (M45.1)
 
-Orchestrator: `execute_pending_save_loads` (`byroredux/src/save_io.rs:589`),
-drained once per frame by `App::step_save_loads` (`byroredux/src/app_step.rs:230`),
-called from `main.rs` in tick order `step_streaming → step_debug_loads →
-step_save_loads → step_cell_transition`. Sequence:
+Orchestrator: `execute_pending_save_loads` (`byroredux/src/save_io.rs:1203`),
+drained once per frame by `App::step_save_loads` (`byroredux/src/app_step.rs:642`),
+called from `app_events.rs`'s per-frame driver in tick order
+`step_streaming → step_debug_loads → step_save_loads →
+step_cell_transition`. Sequence:
 
-1. **Pre-flight**: `cell_loader::validate_cell_loadable` (`save_io.rs:625`)
-   — non-destructively parses the ESM and confirms the target cell
-   exists, so a corrupt/stale save can't strand the player mid-teardown.
+1. **Pre-flight**: `cell_loader::validate_cell_loadable`
+   (`byroredux/src/cell_loader/load.rs:272`) — non-destructively parses
+   the ESM and confirms the target cell exists, so a corrupt/stale save
+   can't strand the player mid-teardown.
 2. **Tear down**: drain the streaming state, unload the current interior
    (`streaming_helpers::drain_streaming_state`,
-   `cell_loader::unload_current_interior`).
+   `cell_loader::unload_current_interior`). The latter clears both
+   `CurrentCellRoot` and `CurrentCellContext` together (#3021 — before
+   this fix an exterior save taken after visiting *any* interior still
+   carried the departed interior's `CurrentCellContext`, so loading it
+   reloaded the wrong worldspace entirely; the two resources are one
+   invariant now, cleared at every site that clears either).
 3. **Reload**: the **same** `cell_loader::load_cell_with_masters`
-   [Pipeline Overview](pipeline-overview.md) traces (`save_io.rs:646`)
-   — not a load-specific variant. The cell comes back exactly as a fresh
-   visit would: full GPU upload, physics bodies, everything.
-4. **Restore whole resources**: `restore_resources` (`save_io.rs:681`)
-   replaces resources like `ItemInstancePool` and `GameTimeRes` wholesale,
-   first, so instance ids resolve correctly and the next weather tick
-   re-derives sky, fog, sun, and exterior directional lighting from the saved
-   clock.
+   (`cell_loader/load.rs:298`) [Pipeline Overview](pipeline-overview.md)
+   traces — not a load-specific variant. The cell comes back exactly as a
+   fresh visit would: full GPU upload, physics bodies, everything.
+4. **Restore whole resources**: `restore_resources`
+   (`crates/save/src/driver.rs`, called from `save_io.rs:1260`) replaces
+   resources like `ItemInstancePool` and `GameTimeRes` wholesale, first,
+   so instance ids resolve correctly and the next weather tick re-derives
+   sky, fog, sun, and exterior directional lighting from the saved clock.
 5. **Reconcile entity identity**: `build_form_id_remap`
-   (`crates/save/src/driver.rs:143`) matches each saved `FormIdPair`
+   (`crates/save/src/driver.rs:226`) matches each saved `FormIdPair`
    against the freshly-reloaded cell's live `FormIdComponent`s, building
    a saved-entity → live-entity map. (This is the piece §2's "entity ids
    round-trip exactly" doesn't cover — those ids are stable *within* a
    snapshot, but the reload just spawned brand-new session-local ids for
    the same logical objects.)
-6. **Overlay deltas**: `apply_deltas` (`driver.rs:205`) — additive-only,
-   over a curated *mutable* column set (`Transform`, `Inventory`,
-   `EquipmentSlots`, `LightSource`, `LightFlicker`, `ScriptTimer`,
-   `ActorValues`). Structural columns and `AnimationPlayer`/
+6. **Overlay deltas**: `apply_deltas` (`driver.rs:318`) — additive-only,
+   over `MUTABLE_DELTA_COLUMNS` (`save_io.rs`), a curated mutable-column
+   set that has grown well past its original seven entries (now ~20:
+   `Transform`, `Inventory`, `EquipmentSlots`, `ActorValues`, `Dead`, the
+   M42 AI-procedure state, `CharacterController`, `RigidBodyData`, …) —
+   see that constant's own doc for the session-stability checklist a new
+   entry must pass, and step 7 below for why *this* list can't just be
+   "everything registered." Structural columns and `AnimationPlayer`/
    `AnimationStack` are deliberately excluded — their values embed
    session-local entity/registry-handle fields a key-based remap can't
    fix.
-7. **Player pose**: `apply_player_pose` (`save_io.rs:288`), last. Backed
+7. **Reconcile derived removals**: `combat::reconcile_dead_actor_runtime_state`
+   (`byroredux/src/save_io.rs`, called immediately after step 6, both on
+   success and on an apply failure). `apply_deltas` can only insert/update
+   a row, never remove one, so a runtime removal that's a *consequence* of
+   overlaid state has to be rebuilt explicitly afterward. Death is the one
+   case wired today: `Dead` is overlaid as a normal delta, then this call
+   removes the respawned AI/animation state and reactivates ragdoll —
+   `reconcile_dead_actor` is the same reconciler the live combat-kill path
+   uses, so save/load and in-session death can't drift apart (#3022). See
+   "What's not covered" below for why this is a pattern, not blanket
+   removal support.
+8. **Player pose**: `apply_player_pose` (`save_io.rs:493`), last. Backed
    by a `PlayerPose` resource refreshed every frame post-scheduler by
-   `capture_player_pose` (`save_io.rs:242`) — position plus yaw/pitch
+   `capture_player_pose` (`save_io.rs:447`) — position plus yaw/pitch
    restored onto `InputState` (both camera systems rebuild rotation from
    that each frame, so writing `Transform.rotation` directly wouldn't
    survive the next tick), with a Character-vs-FlyCam branch (Character
@@ -158,10 +196,22 @@ step_save_loads → step_cell_transition`. Sequence:
 
 ## What's not covered
 
-Per ROADMAP's M45 row (closed 2026-06-21) and `crates/save/src/driver.rs:194-204`:
-delta application is **additive-only** — there's no enable/disable/
-delete persistence mechanism yet (a latent gap, not an active bug: an
-entity despawned mid-session and then loaded-over just comes back).
+Delta application is still structurally **additive-only**
+(`crates/save/src/driver.rs`, `apply_deltas`'s doc comment) — it can
+insert or update a row, never remove one. That was an unqualified latent
+gap as of the 2026-08-18 pass ("an entity despawned mid-session and then
+loaded-over just comes back"); it no longer is, for the one case that
+started depending on removal semantics. §6 step 7 above is the general
+shape the fix established: persist a marker fact via the normal additive
+overlay (`Dead`), then run the *same* reconciler the live-session path
+already uses to rebuild whatever runtime state that fact implies removing
+(`combat::reconcile_dead_actor`, shared between the in-session kill branch
+and this load path — see #3022). There is still no generic enable/disable/
+delete persistence mechanism; a future one (a scripted `Disable()`/
+`Delete()` call, say) needs the same explicit marker-plus-reconciler
+contract rather than teaching the generic `apply_deltas` driver domain
+semantics — `driver.rs`'s doc comment says this outright now.
+
 Full original-engine cosave compatibility is explicitly out of scope
 ("speculative and not a priority," ROADMAP design-decisions table).
 There's no versioned migrator chain for save-schema changes — a


### PR DESCRIPTION
…oundary

Fix #3027: document why ActorVitals is excluded from MUTABLE_DELTA_COLUMNS
Fix #2270: document the snapshot-before-iterate lock discipline
Fix #3028: refresh save-load-roundtrip.md against current code

#2687 (SAFE-D9-01) — translate_material is the only NIF-import producer of a renderer-bound Material and is NaN-safe end to end via resolve_pbr. Save/restore was a second producer with no equivalent gate: a hand-edited or corrupted save file could carry a non-finite scalar straight through restore_world into GpuMaterial on the next frame, which is undefined behavior on the GPU. Added Material::sanitize_finite() (repairs every scalar field independently, deferring metalness/roughness to the existing resolve_pbr classify+clamp), wired it into restore_world as the repair half, and added a NonFiniteMaterial validate_world check (probing a clone via the same method, so the field list can't drift between the two call sites) as the pre-save prevention half.

#3027 (SAVE-D1-2026-08-16-02) — investigated whether ActorVitals should be a mutable delta column. It shouldn't: despite the name and the `health: u32` field reading like live HP, it's actually a stable per-game AVIF FormID key stamped once at NPC spawn and never mutated at runtime; combat damage writes through ActorValues (already a delta column) using this FormID as the lookup key. The exclusion was already correct, just undocumented — added the reasoning at both the type definition and the save_io.rs registration site, and added ActorVitals to NPC_SPAWN_STAMPED (it is demonstrably stamped at spawn; the round-trip guard test already requires every stamped component be either a delta column or explicitly re-derived).

#2270 (NEW-CONC-2) — added a module-doc paragraph to crates/core/src/ecs/world.rs naming the "snapshot before iterate" convention that physics_sync_system, the M42 AI-procedure systems, and scene_playback_system already follow by repeated local convention, so a future system has something concrete to be pointed at during review.

#3028 (SAVE-D6-2026-08-16-03) — refreshed save-load-roundtrip.md's §2 (component/resource registry — now rewritten to point at build_save_registry() as the source of truth instead of an enumeration that goes stale, since the registered set has roughly doubled since the last refresh), §3 (validate_world grew from 4 to 7 invariants), and §6 (MUTABLE_DELTA_COLUMNS has ~20 entries now, and death handling changed from "additive-only, nothing removes state" to the Dead-marker-plus- reconciler pattern landed for #3022). Also reconciled the "What's not covered" section against #3022's actual resolution, and fixed several other stale file:line citations found while verifying the scoped ones.

Both #3021 and #3022 (which #3028 asked to reconcile against) were independently re-verified as genuinely fixed in code before trusting their CLOSED status.