### PR TITLE
Fix #2289: add decline-path tests for untested effect primitives

### DIFF
--- a/.claude/issues/2289 2387 2396 2540/ISSUE.md
+++ b/.claude/issues/2289 2387 2396 2540/ISSUE.md
@@ -1,0 +1,55 @@
+# Issue Batch: 2289, 2387, 2396, 2540
+
+All four are LOW-severity test-coverage-gap findings from audit sweeps. No behavior is broken;
+each asks for regression tests pinning an invariant that today is only correct "by inspection".
+
+## #2289 — SCR-D5-NEW5-02 (scripting)
+`crates/scripting/src/translate/effects.rs` — ~half of the ~26 new effect primitives (SetOpen,
+SetPlayerRestrained, SetPlayerControls/DisablePlayerControls/EnablePlayerControls,
+SetPlayerAiDriven, SetHudCartMode, PlayIdle, SetVehicle, TetherToHorse, SetMotionType's decline
+path, SetSittingRotation, ExitCart, PlayerImodAnimation/PlayerFurnitureAnimation,
+EvaluatePackage, Wait, StartScene/StopScene) have a positive-path test but no decline-path
+(`?`/arg-count/arg-type guard) test.
+
+Fix: one `assert_eq!(lower_fragment(&body), None)` decline test per untested primitive.
+
+## #2387 — ECS-D1-04 (ecs)
+`crates/core/src/ecs/lock_tracker.rs:505-571` — the cross-rayon-worker ABBA deadlock-detection
+guarantee has no real multi-thread test. The existing `global_graph_detector_end_to_end` test
+runs single-threaded, calling `track_read`/`untrack_read` directly, bypassing `World` entirely.
+
+Fix: add a `#[cfg(debug_assertions)]` test building a real `World` with two registered storages,
+driving `query::<A>() → query::<B>()` on one `std::thread` and `query::<B>() → query::<A>()` on
+another (barrier-synchronized, `catch_unwind` both sides) under `set_enabled_for_tests(true)`,
+asserting exactly one side panics with "cross-thread deadlock risk".
+
+## #2396 — ECS-D2-NEW-02 (ecs)
+`crates/core/src/ecs/packed.rs:256-288` — `PackedStorage::remove_entities_erased`'s two
+load-bearing invariants (ascending sort order after merge-compaction; `TRACK_CHANGES` dirty
+marking via hand-inlined `self.dirty.push`) have no dedicated test. This is the only removal
+route used by cell unload (`unload.rs:245` → `despawn_batch`).
+
+Fix: two tests in `packed.rs`'s test module — (1) `iter()` order still ascending after removing a
+scattered victim set from a >3-element storage; (2) on a `TRACK_CHANGES` fixture, `take_dirty()`
+contains exactly the removed ids.
+
+## #2540 — SCR-D5-NEW10-02 (scripting)
+`crates/scripting/src/translate/effects.rs:529,541,552` — the `u16`→`i32` widen for
+`SetObjective{Displayed,Completed,Failed}`'s index field (`i32::try_from(int_arg(args, 0)?).ok()?`)
+is a correct fix (matches `QuestObjective::index`'s documented i32-on-FO3/FNV representation) but
+has no test exercising a negative index or an i32-overflow decline. Explicitly folds into #2289's
+tracking.
+
+Fix: one test per `SetObjective*` primitive for negative-index-lowers-correctly and
+overflow-declines cases.
+
+## Domain classification
+- #2289, #2540 → **scripting** → `byroredux-scripting` (crate path is `crates/scripting`; note:
+  need to confirm actual crate name via Cargo.toml)
+- #2387, #2396 → **ecs** → `byroredux-core`
+
+## Plan
+All four are additive test-only changes, no production code path changes expected (except
+possibly routing `packed.rs`'s inline `self.dirty.push` through `mark_dirty` per #2396's
+suggestion, which is optional/mechanical). Implement together since they're small and related in
+pairs (2289+2540 same file; 2387+2396 same crate).

--- a/crates/core/src/ecs/packed.rs
+++ b/crates/core/src/ecs/packed.rs
@@ -273,9 +273,7 @@ impl<T: Component<Storage = Self>> DynStorage for PackedStorage<T> {
                 victim_idx += 1;
             }
             if victim_idx < victims.len() && victims[victim_idx] == entity {
-                if T::TRACK_CHANGES {
-                    self.dirty.push(entity);
-                }
+                self.mark_dirty(entity);
                 victim_idx += 1;
                 continue;
             }
@@ -770,5 +768,72 @@ mod tests {
 
         s.remove(2); // remove → dirty
         assert_eq!(s.take_dirty(), vec![2]);
+    }
+
+    // ── remove_entities_erased (#2396) ──────────────────────────────────
+
+    #[test]
+    fn remove_entities_erased_preserves_ascending_order() {
+        // The merge-compaction path rebuilds `entities`/`data` from scratch
+        // rather than inheriting sort order from `Vec::remove`, so pin it
+        // directly: iteration must still yield entities in ascending order
+        // after removing a scattered victim set from a >3-element storage.
+        let mut s = PackedStorage::<Transform>::default();
+        for i in [1u32, 2, 3, 4, 5, 6, 7] {
+            s.insert(
+                i,
+                Transform {
+                    x: i as f32,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            );
+        }
+        // Victims must be sorted, per the method's own debug_assert.
+        let victims = [2u32, 4, 6];
+        s.remove_entities_erased(&victims);
+
+        let entities: Vec<_> = s.iter().map(|(e, _)| e).collect();
+        assert_eq!(entities, vec![1, 3, 5, 7]);
+    }
+
+    #[test]
+    fn remove_entities_erased_marks_exactly_the_removed_ids_dirty() {
+        // The merge loop's dirty marking (now routed through `mark_dirty`,
+        // previously hand-inlined) is the only marking site for this
+        // removal path — pin that it fires for exactly the removed
+        // entities, no more and no fewer, on a TRACK_CHANGES fixture.
+        let mut s = PackedStorage::<Tracked>::default();
+        for i in [1u32, 2, 3, 4, 5] {
+            s.insert(i, Tracked(i));
+        }
+        let _ = s.take_dirty(); // clear the insert marks
+
+        let victims = [2u32, 4];
+        s.remove_entities_erased(&victims);
+
+        let mut dirty = s.take_dirty();
+        dirty.sort_unstable();
+        assert_eq!(dirty, vec![2, 4]);
+
+        let entities: Vec<_> = s.iter().map(|(e, _)| e).collect();
+        assert_eq!(entities, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn remove_entities_erased_on_untracked_storage_stays_dirty_free() {
+        let mut s = PackedStorage::<Transform>::default();
+        for i in [1u32, 2, 3] {
+            s.insert(
+                i,
+                Transform {
+                    x: i as f32,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            );
+        }
+        s.remove_entities_erased(&[2u32]);
+        assert!(s.take_dirty().is_empty());
     }
 }

--- a/crates/scripting/src/translate/effects.rs
+++ b/crates/scripting/src/translate/effects.rs
@@ -1256,7 +1256,7 @@ fn bool_arg(args: &[byroredux_papyrus::ast::CallArg], idx: usize) -> Option<Opti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use byroredux_papyrus::ast::{Identifier, ScriptItem, StateItem};
+    use byroredux_papyrus::ast::{CallArg, Identifier, ScriptItem, StateItem};
     use byroredux_papyrus::parse_script;
 
     /// Wrap a node with a dummy span, for ASTs the `.psc` parser cannot
@@ -2136,5 +2136,342 @@ mod tests {
         let body =
             first_fn_body("ScriptName QF extends Quest\n Function Fragment_6()\n EndFunction\n");
         assert_eq!(lower_fragment(&body), Some(vec![]));
+    }
+
+    // ── Decline-path coverage for SCR-D5-NEW5-02 / #2289 ────────────────
+    // One `?`/arg-count/arg-type guard test per primitive that previously
+    // shipped with a positive-path test only.
+
+    #[test]
+    fn set_open_declines_with_extra_arg() {
+        let body = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_20()\n\
+             KeepGate.SetOpen(true, true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&body), None);
+    }
+
+    #[test]
+    fn set_player_restrained_declines_on_non_player_receiver_and_extra_arg() {
+        let non_player = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_21()\n\
+             SomeActor.SetRestrained(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&non_player), None);
+
+        let extra_arg = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_45()\n\
+             Game.GetPlayer().SetRestrained(true, true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&extra_arg), None);
+    }
+
+    #[test]
+    fn player_controls_toggles_decline_with_too_many_args() {
+        // Shared `prim_player_controls`'s `args.len() > 9` guard — covers
+        // both DisablePlayerControls and EnablePlayerControls.
+        let disable = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_22()\n\
+             Game.DisablePlayerControls(false, true, true, false, false, false, true, true, 0, false)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&disable), None);
+
+        let enable = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_23()\n\
+             Game.EnablePlayerControls(false, true, true, false, false, false, true, true, 0, false)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&enable), None);
+    }
+
+    #[test]
+    fn set_player_ai_driven_declines_with_extra_arg() {
+        let body = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_24()\n\
+             Game.SetPlayerAIDriven(true, true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&body), None);
+    }
+
+    #[test]
+    fn set_hud_cart_mode_declines_with_extra_arg() {
+        let body = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_25()\n\
+             Game.SetHudCartMode(true, true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&body), None);
+    }
+
+    #[test]
+    fn play_idle_declines_on_wrong_arg_count() {
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_26()\n\
+             Game.GetPlayer().PlayIdle()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let two_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_27()\n\
+             Game.GetPlayer().PlayIdle(SomeIdle, SomeIdle)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&two_args), None);
+    }
+
+    #[test]
+    fn set_vehicle_declines_on_wrong_arg_count() {
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_28()\n\
+             Alias_Rider.GetActorRef().SetVehicle()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let two_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_29()\n\
+             Alias_Rider.GetActorRef().SetVehicle(Alias_Cart.GetRef(), Alias_Cart.GetRef())\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&two_args), None);
+    }
+
+    #[test]
+    fn tether_to_horse_declines_on_wrong_arg_count() {
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_30()\n\
+             Alias_Cart.GetRef().TetherToHorse()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let two_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_47()\n\
+             Alias_Cart.GetRef().TetherToHorse(Alias_Horse.GetActorRef() as ObjectReference, Alias_Horse.GetActorRef() as ObjectReference)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&two_args), None);
+    }
+
+    #[test]
+    fn set_motion_type_declines_on_arg_count_and_unrecognized_member() {
+        // #2289 flags this as the most structurally intricate untested case.
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_31()\n\
+             Cart.SetMotionType()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let three_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_32()\n\
+             Cart.SetMotionType(6, true, false)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&three_args), None);
+
+        // An unrecognized member access on the (correctly matched) receiver
+        // falls through `motion_type_arg`'s match arm to `None`.
+        let unrecognized_member = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_33()\n\
+             Cart.SetMotionType(Cart.Motion_NotARealValue, true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&unrecognized_member), None);
+    }
+
+    #[test]
+    fn set_sitting_rotation_declines_on_wrong_arg_count() {
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_34()\n\
+             Game.SetSittingRotation()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let two_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_48()\n\
+             Game.SetSittingRotation(-55.0, 1.0)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&two_args), None);
+    }
+
+    #[test]
+    fn exit_cart_declines_on_wrong_arg_count_and_seat_out_of_range() {
+        let wrong_arg_count = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_35()\n\
+             Quest temp = Self as Quest\n\
+             mq101questscript kmyQuest = temp as mq101questscript\n\
+             kmyQuest.ExitCart(Alias_Prisoner)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&wrong_arg_count), None);
+
+        let seat_too_low = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_36()\n\
+             Quest temp = Self as Quest\n\
+             mq101questscript kmyQuest = temp as mq101questscript\n\
+             kmyQuest.ExitCart(Alias_Prisoner, 0)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&seat_too_low), None);
+
+        let seat_too_high = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_37()\n\
+             Quest temp = Self as Quest\n\
+             mq101questscript kmyQuest = temp as mq101questscript\n\
+             kmyQuest.ExitCart(Alias_Prisoner, 6)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&seat_too_high), None);
+    }
+
+    #[test]
+    fn player_animation_events_decline_with_args() {
+        let imod = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_38()\n\
+             Quest temp = Self as Quest\n\
+             mq101questscript kmyQuest = temp as mq101questscript\n\
+             kmyQuest.PlayerImodAnimation(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&imod), None);
+
+        let furniture = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_39()\n\
+             Quest temp = Self as Quest\n\
+             mq101questscript kmyQuest = temp as mq101questscript\n\
+             kmyQuest.PlayerFurnitureAnimation(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&furniture), None);
+    }
+
+    #[test]
+    fn evaluate_package_declines_with_args() {
+        let body = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_40()\n\
+             Alias_Hadvar.GetActorRef().EvaluatePackage(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&body), None);
+    }
+
+    #[test]
+    fn wait_declines_on_wrong_arg_count_and_negative_seconds() {
+        let zero_args = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_41()\n\
+             Utility.Wait()\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&zero_args), None);
+
+        let negative = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_42()\n\
+             Utility.Wait(-1.0)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&negative), None);
+    }
+
+    #[test]
+    fn start_and_stop_scene_decline_with_args() {
+        let start = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_43()\n\
+             IntroScene.Start(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&start), None);
+
+        let stop = first_fn_body(
+            "ScriptName QF extends Quest\n\
+             Function Fragment_44()\n\
+             OldScene.Stop(true)\n EndFunction\n",
+        );
+        assert_eq!(lower_fragment(&stop), None);
+    }
+
+    // ── #2540 / SCR-D5-NEW10-02 — the objective-index `u16`→`i32` widen ──
+
+    /// A genuinely negative index (i32 on FO3/FNV per `QuestObjective::
+    /// index`'s doc) arrives from the PEX decompiler as a direct signed
+    /// `IntLit`, never as a `.psc`-source `UnaryOp::Neg` — the `.psc` text
+    /// parser lexes `-N` as `Minus` + `IntLit(N)`, which `int_arg` does not
+    /// unwrap. Matching #2657's `::X_var` precedent, this decompiled shape
+    /// has to be built by hand rather than round-tripped through the `.psc`
+    /// parser to exercise the real input this primitive actually receives.
+    #[test]
+    fn objective_primitives_lower_a_negative_index() {
+        for (method, expected) in [
+            (
+                "SetObjectiveDisplayed",
+                Effect::SetObjectiveDisplayed {
+                    quest: QuestRef::SelfRef,
+                    objective: -5,
+                    displayed: true,
+                },
+            ),
+            (
+                "SetObjectiveCompleted",
+                Effect::SetObjectiveCompleted {
+                    quest: QuestRef::SelfRef,
+                    objective: -5,
+                    completed: true,
+                },
+            ),
+            (
+                "SetObjectiveFailed",
+                Effect::SetObjectiveFailed {
+                    quest: QuestRef::SelfRef,
+                    objective: -5,
+                    failed: true,
+                },
+            ),
+        ] {
+            let call = Expr::Call {
+                callee: Box::new(sp(Expr::MemberAccess {
+                    object: Box::new(sp(Expr::Ident(Identifier("Self".into())))),
+                    member: sp(Identifier(method.into())),
+                })),
+                args: vec![CallArg {
+                    name: None,
+                    value: sp(Expr::IntLit(-5)),
+                }],
+            };
+            assert_eq!(
+                classify_effect(&call, &Scope::default()),
+                Some(expected),
+                "{method} must lower a negative index correctly"
+            );
+        }
+    }
+
+    /// An index literal outside `i32`'s range must still decline via
+    /// `i32::try_from(..).ok()?`, not silently truncate.
+    #[test]
+    fn objective_primitives_decline_on_index_overflow() {
+        for method in [
+            "SetObjectiveDisplayed",
+            "SetObjectiveCompleted",
+            "SetObjectiveFailed",
+        ] {
+            let body = first_fn_body(&format!(
+                "ScriptName QF extends Quest\n\
+                 Function Fragment_46()\n\
+                 Self.{method}(5000000000)\n EndFunction\n"
+            ));
+            assert_eq!(
+                lower_fragment(&body),
+                None,
+                "{method} must decline an i32-overflowing index"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fix #2396: pin PackedStorage::remove_entities_erased's sort-order and dirty-marking invariants
Fix #2540: add negative-index and overflow-decline tests for SetObjective{Displayed,Completed,Failed}

#2289 (SCR-D5-NEW5-02) — ~15 effect primitives in effects.rs had a positive-path test but no test pinning their `?`/arg-count/arg-type decline guard: SetOpen, SetPlayerRestrained, Set/Disable/EnablePlayerControls, SetPlayerAiDriven, SetHudCartMode, PlayIdle, SetVehicle, TetherToHorse, SetMotionType (arg-count + unrecognized-member), SetSittingRotation, ExitCart (arg-count + seat-range boundary), PlayerImodAnimation/ PlayerFurnitureAnimation, EvaluatePackage, Wait, StartScene/StopScene. Added one decline test per primitive (bundled where a primitive has more than one guard).

#2396 (ECS-D2-NEW-02) — PackedStorage::remove_entities_erased is the only removal route used by cell unload and re-derives both its class invariants by hand (rebuilt sort order, hand-inlined TRACK_CHANGES marking) with no test pinning either. Added tests for ascending order after a scattered removal and take_dirty() exact-match on a TRACK_CHANGES fixture. Also routed the hand-inlined `self.dirty.push` through the existing `mark_dirty` helper per the issue's suggested cleanup — one marking site instead of two. Checked the sibling SparseSetStorage::remove_entities_erased: it delegates to the ordinary tracked remove() per victim, so it doesn't share this bug pattern.

#2540 (SCR-D5-NEW10-02) — the u16->i32 widen for SetObjective{Displayed, Completed,Failed}'s index field had no test for a negative index (legal on FO3/FNV) or an i32-overflowing literal. The negative-index case is built via a hand-constructed AST (classify_effect + Expr::IntLit(-5)) rather than round-tripped through the .psc text parser, because `-N` lexes as UnaryOp::Neg + IntLit(N) there and int_arg only matches IntLit directly — the hand-built shape matches what the PEX decompiler actually emits for a signed negative constant.

#2387 (ECS-D1-04) is already fixed by 5428e872 (Scenario 5 in global_graph_detector_end_to_end), which added the exact real-World, two-thread, barrier-synchronized test the issue asked for; closing separately with no code change here.