### PR TITLE
Fix #1762: delete the masked-dead RawDependency.name field

### DIFF
--- a/.claude/issues/1576 1762 2076 2341/ISSUE.md
+++ b/.claude/issues/1576 1762 2076 2341/ISSUE.md
@@ -1,0 +1,38 @@
+# Issue Batch: 1576, 1762, 2076, 2341
+
+## #1576 — SF-D4-03 (esm, byroredux-plugin)
+`crates/plugin/src/esm/cell/support.rs:38-160` — `build_static_object_from_subs` only
+reads a top-level `MODL` subrecord. Some Starfield STAT/BNDS/ACTI/ARMO records carry their
+model reference inside a `BFCB`-wrapped component block instead, so those REFRs drop
+(~140 REFRs, ~0.5% of the audited cell). Suggested fix explicitly depends on SF-D4-01's
+`BFCB`/`BFCE` component walker landing first — need to check whether that walker already
+exists before implementing.
+
+## #1762 — TD8-005 (esm, byroredux-plugin)
+`crates/plugin/src/manifest.rs:70-75` — `RawDependency.name` is parsed from TOML
+(`#[allow(dead_code)]`) but never read into the public `Manifest` (only `.uuid` is mapped).
+Suggested fix: delete the field (default) — serde silently ignores unknown TOML keys with
+no `deny_unknown_fields`, so a `name = "…"` key in a `[[dependencies]]` block still parses
+fine without the field.
+
+## #2076 — TD8-102 (binary, byroredux)
+`byroredux/src/cell_loader/water.rs:77-182` — `spawn_water_plane`'s `blas_specs` parameter
+is discarded unconditionally (`let _ = blas_specs;`) since water meshes are excluded from
+BLAS/TLAS. The interior call site in `load.rs:416,439` allocates a throwaway
+`_blas_dummy: Vec<(u32, u32, u32)>` purely to satisfy the signature. Suggested fix: drop the
+parameter, update both call sites (interior + exterior).
+
+## #2341 — NAVM-01 (esm, byroredux-plugin)
+`crates/plugin/src/esm/records/tests.rs:364` — a stale comment claims FNV NAVM count is 0
+(pre-#1272); a live run of `parse_real_fnv_esm_record_counts` shows 4771 navmeshes, only
+visible via `eprintln!`, no assertion pins it. Suggested fix: update the comment and add
+`assert!(index.navmeshes.len() >= 4000, ...)` alongside the test's existing floor assertions.
+
+## Domain classification
+- #1576, #1762, #2341 → **esm** → `byroredux-plugin`
+- #2076 → **binary** → `byroredux`
+
+## Plan
+All four are small, independent, single-site-ish fixes (well under the 5-file scope-check
+threshold). Investigate #1576's SF-D4-01 dependency first since it may block or reshape the
+fix; the other three are self-contained mechanical cleanups.

--- a/byroredux/src/cell_loader/exterior.rs
+++ b/byroredux/src/cell_loader/exterior.rs
@@ -1363,7 +1363,6 @@ impl ExteriorCellApplyJob {
                 water_center,
                 half,
                 cell.landscape.as_ref(),
-                blas_sink,
             )
             .is_none()
             {

--- a/byroredux/src/cell_loader/load.rs
+++ b/byroredux/src/cell_loader/load.rs
@@ -450,7 +450,6 @@ pub fn load_cell_with_masters(
     // height directly; the water material comes from the global
     // WATR record table.
     if let Some(water_height) = cell.water_height {
-        let mut _blas_dummy: Vec<(u32, u32, u32)> = Vec::new();
         let (water_center, water_half_extent) = water::interior_water_placement(
             cell.references.iter().map(|reference| reference.position),
         );
@@ -473,7 +472,6 @@ pub fn load_cell_with_masters(
             water_center,
             water_half_extent,
             None,
-            &mut _blas_dummy,
         )
         .is_none()
         {

--- a/byroredux/src/cell_loader/water.rs
+++ b/byroredux/src/cell_loader/water.rs
@@ -357,7 +357,6 @@ pub(super) fn spawn_water_plane(
     cell_origin_world_xz: (f32, f32),
     half_extent: f32,
     terrain: Option<&esm::cell::LandscapeData>,
-    blas_specs: &mut Vec<(u32, u32, u32)>,
 ) -> Option<usize> {
     // ── Resolve WATR → engine WaterMaterial (EXAL boundary) ──
     let (mut material, mut kind, mut flow, normal_texture_path, noise_texture_paths) =
@@ -427,10 +426,6 @@ pub(super) fn spawn_water_plane(
             return None;
         }
     };
-    // Suppress unused warning when ray tracing is on — water never
-    // adds a BLAS entry, but other spawn helpers in the same call
-    // chain accumulate into the same vec.
-    let _ = blas_specs;
 
     // Texture resolve — the water material's normal_map_index points
     // here. When the WATR record's TNAM is unset (e.g., default

--- a/crates/plugin/src/esm/records/tests.rs
+++ b/crates/plugin/src/esm/records/tests.rs
@@ -703,10 +703,10 @@ fn parse_real_fnv_esm_record_counts() {
     // percent below the observed count so DLC patches stay green.
     //
     // Observed on FalloutNV.esm:
-    //   WATR=78, NAVI=1, NAVM=0 (NAVM entries live nested under
-    //   CELL children groups on FO3/FNV, not at top level — a
-    //   follow-up can walk those if needed), REGN=276, ECZN=17,
-    //   LGTM=31, HDPT=61, EYES=12, HAIR=67.
+    //   WATR=78, NAVI=1, NAVM=4771 (the per-cell NAVM drain landed in
+    //   #1272; pre-fix this counted 0 because NAVM entries live nested
+    //   under CELL children groups on FO3/FNV, not at top level),
+    //   REGN=276, ECZN=17, LGTM=31, HDPT=61, EYES=12, HAIR=67.
     eprintln!(
         "FNV misc: {} water, {} navi, {} navm, {} region, {} eczn, \
          {} lgtm, {} hdpt, {} eyes, {} hair",
@@ -730,6 +730,14 @@ fn parse_real_fnv_esm_record_counts() {
         1,
         "expected exactly 1 NAVI master (FNV ships one), got {}",
         index.navi_info.len()
+    );
+    // #2341 / NAVM-01 — a real assertion in place of the eprintln-only
+    // count, so a regression in the per-cell NAVM drain (#1272) is
+    // actually caught instead of only visible with --nocapture.
+    assert!(
+        index.navmeshes.len() >= 4000,
+        "expected ≥4000 NAVM navmeshes, got {}",
+        index.navmeshes.len()
     );
     assert!(
         index.regions.len() >= 200,

--- a/crates/plugin/src/manifest.rs
+++ b/crates/plugin/src/manifest.rs
@@ -70,8 +70,6 @@ struct RawPlugin {
 #[derive(Deserialize)]
 struct RawDependency {
     uuid: uuid::Uuid,
-    #[allow(dead_code)]
-    name: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix #2076: drop spawn_water_plane's dead blas_specs parameter
Fix #2341: pin the FNV NAVM count with a floor assertion, fix the stale comment

#1762 (TD8-005) — RawDependency.name was parsed from TOML (#[allow(dead_code)]) but never read into the public Manifest; only .uuid was mapped. Deleted the field — serde silently ignores unknown TOML keys with no deny_unknown_fields, so the existing parse_valid_manifest test's [[dependencies]] block with a name = "BaseMaster.esm" key already covers the round-trip.

#2076 (TD8-102) — spawn_water_plane's blas_specs parameter was dead inside the function (water meshes are excluded from BLAS/TLAS, so the body just did "let _ = blas_specs;"). Dropped the parameter and updated both call sites: exterior.rs's real terrain BLAS accumulator (blas_sink, still used for terrain at its other call site) no longer gets threaded through water; load.rs's interior path no longer fabricates a throwaway _blas_dummy Vec just to satisfy the signature.

#2341 (NAVM-01) — the test comment above parse_real_fnv_esm_record_counts still claimed FNV NAVM=0 (pre-#1272 state). A live run against FalloutNV.esm shows 4771 navmeshes (confirmed via --ignored --nocapture), previously only visible through eprintln! with no assertion catching a regression. Updated the comment and added a floor assertion (>=4000) alongside the test's existing WATR/NAVI/REGN/etc. floors.

#1576 (SF-D4-03) was investigated but not fixed: a prior commit (162877f0) already researched this exact issue and documented that the BFCB component block's field layout has no available reference schema (no reflection dump exists) — implementing a decoder now would be the offset-guessing the project's no-guessing policy forbids. Left open with a status comment rather than force a speculative fix.