### PR TITLE
Fix #2362: thread MeshResolver through the 3 distant-LOD import_nif_s…

### DIFF
--- a/.claude/issues/2362 2364 2541 2571/ISSUE.md
+++ b/.claude/issues/2362 2364 2541 2571/ISSUE.md
@@ -1,0 +1,56 @@
+# Issue Batch: 2362, 2364, 2541, 2571
+
+## #2362 — SF2D2-05 (binary, byroredux)
+`byroredux/src/cell_loader/object_lod.rs:262`, `placement_lod.rs:469`,
+`terrain_lod_btr.rs:137` call the no-resolver `import_nif_scene` overload even
+though a `tex_provider: &TextureProvider` (a `MeshResolver`) is already in scope
+at each call site. `byroredux/examples/dump_nif.rs:151` calls `import_nif`
+(same no-resolver gap) in a debug tool. Currently unreachable for Starfield
+(object_lod is `.bto`-keyed, Starfield's LODMeshes.ba2 has none; placement_lod
+is Oblivion-gated) but would silently drop external-geometry BSGeometry
+meshes to zero once Starfield distant-object LOD is wired.
+Fix: thread `Some(tex_provider)` through at the 3 production call sites via
+`import_nif_scene_with_resolver`; note or fix the example gap.
+
+## #2364 — SF-D5-2026-08-03-01 (esm, byroredux-plugin)
+`crates/plugin/src/esm/cell/walkers.rs:172-174` — the `assert_eq!` failure
+message in `starfield_xcll_sizes_pinned` still reads "Skyrim+ 92-byte body +
+16-byte SF tail" (the #1291 framing), while the corrected doc comment at
+line 39 (from #1293) says XCLL "shares only bytes 0-39 with Skyrim, then
+diverges into a distinct volumetric height-fog model." Pure string-literal
+fix, no behavior change.
+
+## #2541 — SCR-D7-NEW10-01 (binary, byroredux)
+`byroredux/src/cell_loader/references/mod.rs` — the `is_primary_synth` gate
+on `stamp_quest_reference`/`spawn_logical_quest_reference` (8 call sites
+inside `spawn_synth_child`, correct by inspection) has no regression test.
+Suggested fix offers two options: a full spawn-fixture test asserting exactly
+one `SceneAliasCandidate` registers for a multi-child SCOL/PKIN expansion, or
+a cheaper source-scan test (mirroring `scol_expansion_is_cached_across_a_budget_yield`)
+asserting every call site is guarded. Prefer whichever is proportionate once
+the surrounding code is read.
+
+## #2571 — OBL-D5-01 (nif/nifal — spans byroredux + likely crates/nif or core)
+`texture_clamp_mode`, `src_blend_mode`, `dst_blend_mode` have no canonical
+`Material` field — read directly off raw `ImportedMaterial` at 4 spawn call
+sites (`spawn.rs:1367,1533,1565`, `nif_loader.rs:786,830,915`) instead of
+through `translate_material`. Latent (byte-identical today) but a third
+independent reader (FO4 `cell_loader/precombined.rs`) already reads the same
+raw fields and could diverge; invisible to `mat.*`/`material_dump` since
+those inspect canonical `Material`. Fix: add 3 fields to canonical `Material`,
+copy in `translate_material`, point all 4(+1?) spawn sites at the canonical
+component, extend the canonical-completeness harness. Needs investigation to
+find `Material`'s definition and `translate_material`'s location before
+scoping file count.
+
+## Domain classification
+- #2362, #2541 → **binary** → `byroredux`
+- #2364 → **esm** → `byroredux-plugin`
+- #2571 → **nif/nifal**, likely spans `crates/nif` (or wherever canonical
+  `Material` lives) + `byroredux` (spawn.rs, nif_loader.rs, precombined.rs) —
+  investigate before committing to a test target.
+
+## Plan
+Investigate #2571 first since it may hit the >5-file scope-check threshold
+before deciding whether to pause for confirmation. The other three are small
+and independent.

--- a/byroredux/examples/dump_nif.rs
+++ b/byroredux/examples/dump_nif.rs
@@ -148,6 +148,11 @@ fn main() {
     // Also run the import pipeline and show results
     println!("\n=== Import Results (Y-up) ===");
     let mut pool = byroredux_core::string::StringPool::new();
+    // #2362 / SF2D2-05 — this dump tool operates on a loose NIF file with
+    // no BSA/BA2 archive open, so no `MeshResolver` is available to thread
+    // through here. Starfield external-geometry `BSGeometry` meshes (whose
+    // bytes live in a companion `.mesh` archive entry) import to zero
+    // meshes for that reason; not a production path.
     let meshes = byroredux_nif::import::import_nif(&scene, &mut pool);
     for (i, m) in meshes.iter().enumerate() {
         println!("\nMesh {}: name={:?}", i, m.name);

--- a/byroredux/src/cell_loader/object_lod.rs
+++ b/byroredux/src/cell_loader/object_lod.rs
@@ -239,7 +239,18 @@ fn spawn_object_lod_quad(
     // Local pool — we consume only geometry + transforms, not the interned
     // texture handles (the atlas path is deterministic).
     let mut pool = byroredux_core::string::StringPool::new();
-    let imported = byroredux_nif::import::import_nif_scene(&scene, &mut pool);
+    // #2362 / SF2D2-05 — thread the already-in-scope `tex_provider`
+    // (a `MeshResolver`) through so external-geometry `BSGeometry` LOD
+    // slots (Starfield's `meshes\lod\generated\..._lod_N.nif`) resolve
+    // instead of silently importing to zero meshes. Not reachable today
+    // (object_lod is `.bto`-keyed and Starfield's LODMeshes.ba2 has no
+    // `.bto`), but this is exactly the helper a future Starfield
+    // distant-object-LOD arc would reuse.
+    let imported = byroredux_nif::import::import_nif_scene_with_resolver(
+        &scene,
+        &mut pool,
+        Some(tex_provider),
+    );
     if imported.meshes.is_empty() {
         return None;
     }
@@ -546,5 +557,29 @@ mod tests {
         let quads = lod_bands::select_lod_quads(&selection, |_, _, _| false, |_, _, _| true);
         assert!(quads.iter().all(|&(level, _, _)| level <= 16));
         assert!(quads.iter().any(|&(level, _, _)| level == 16));
+    }
+
+    /// #2362 / SF2D2-05 — `spawn_object_lod_quad` must thread the
+    /// already-in-scope `tex_provider` through as a `MeshResolver`, not
+    /// call the no-resolver `import_nif_scene` overload. Not
+    /// Vulkan/archive-reachable to exercise end-to-end (object_lod is
+    /// `.bto`-keyed; Starfield's `LODMeshes.ba2` ships none today), so this
+    /// pins the wiring by source inspection — a regression here would
+    /// silently import every external-geometry `BSGeometry` LOD mesh to
+    /// zero once a future Starfield distant-object-LOD arc reuses this
+    /// path.
+    #[test]
+    fn spawn_object_lod_quad_threads_the_mesh_resolver() {
+        // Whitespace-insensitive so a reformat doesn't spuriously break this.
+        let normalized: String = include_str!("object_lod.rs")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            normalized
+                .contains("import_nif_scene_with_resolver(&scene,&mutpool,Some(tex_provider))"),
+            "spawn_object_lod_quad must pass tex_provider as the MeshResolver, \
+             not call the no-resolver import_nif_scene overload",
+        );
     }
 }

--- a/byroredux/src/cell_loader/placement_lod.rs
+++ b/byroredux/src/cell_loader/placement_lod.rs
@@ -477,7 +477,15 @@ fn spawn_placement_lod_cell(
             }
         };
         let mut pool = byroredux_core::string::StringPool::new();
-        let imported = byroredux_nif::import::import_nif_scene(&scene, &mut pool);
+        // #2362 / SF2D2-05 — thread the already-in-scope `tex_provider`
+        // through so external-geometry `BSGeometry` LOD slots resolve
+        // instead of silently importing to zero meshes. See the matching
+        // note on `object_lod.rs::spawn_object_lod_quad`.
+        let imported = byroredux_nif::import::import_nif_scene_with_resolver(
+            &scene,
+            &mut pool,
+            Some(tex_provider),
+        );
         if imported.meshes.is_empty() {
             continue;
         }
@@ -851,5 +859,24 @@ mod tests {
         let expect = byroredux_core::math::coord::zup_to_yup_pos([10.0, 20.0, 30.0]);
         assert_eq!(pos, Vec3::from_array(expect));
         assert_eq!(scale, 1.5);
+    }
+
+    /// #2362 / SF2D2-05 — `spawn_placement_lod_cell` must thread the
+    /// already-in-scope `tex_provider` through as a `MeshResolver`. See
+    /// the matching pin on `object_lod.rs::spawn_object_lod_quad_threads_
+    /// the_mesh_resolver`.
+    #[test]
+    fn spawn_placement_lod_cell_threads_the_mesh_resolver() {
+        // Whitespace-insensitive so a reformat doesn't spuriously break this.
+        let normalized: String = include_str!("placement_lod.rs")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            normalized
+                .contains("import_nif_scene_with_resolver(&scene,&mutpool,Some(tex_provider),)"),
+            "spawn_placement_lod_cell must pass tex_provider as the \
+             MeshResolver, not call the no-resolver import_nif_scene overload",
+        );
     }
 }

--- a/byroredux/src/cell_loader/references/synth_child_tests.rs
+++ b/byroredux/src/cell_loader/references/synth_child_tests.rs
@@ -213,3 +213,124 @@ fn base_record_script_attaches_for_every_synth_child_not_just_the_first() {
         "both children's base-record scripts count toward the summary",
     );
 }
+
+/// #2541 / SCR-D7-NEW10-01 — `spawn_synth_child` has no test pinning the
+/// `is_primary_synth` gate that keeps a SCOL/PKIN expansion's
+/// `SceneAliasCandidate` registration to exactly one entity per REFR
+/// (otherwise `SceneActorBindings`'s alias-fill resolution sees N
+/// candidates for one authored alias-fillable reference). A live spawn
+/// fixture would need a real `VulkanContext` (out of unit-test scope, the
+/// same constraint `source_pin_tests.rs`'s sibling pins document), so this
+/// pins the invariant by construction:
+///
+/// 1. `stamp_quest_reference`/`spawn_logical_quest_reference` themselves
+///    correctly register exactly one `SceneAliasCandidate` when called
+///    exactly once (the shape every gated branch below produces).
+/// 2. A source-scan over `spawn_synth_child`'s body confirms every one of
+///    its `stamp_quest_reference(`/`spawn_logical_quest_reference(` call
+///    sites is actually gated — 8 directly by `if`/`else if
+///    is_primary_synth`, plus the trigger-volume branch's `stamp_quest_
+///    reference` call, gated one level up by `trigger_volume_should_spawn_
+///    for_synth_child(is_primary_synth, ..)`. If a future 9th branch adds
+///    an ungated call site, or an existing gate is dropped in a
+///    refactor, the call-site count and the gate count diverge and this
+///    assertion fails — closing the gap at zero Vulkan-fixture cost.
+#[test]
+fn is_primary_synth_gates_every_identity_stamp_call_site() {
+    // Part 1: the stamping primitives themselves produce exactly one
+    // SceneAliasCandidate when called once — the shape every gated branch
+    // in `spawn_synth_child` produces for the first (and only the first)
+    // synthetic child of a SCOL/PKIN expansion.
+    let mut world = World::new();
+    world.insert_resource(byroredux_core::form_id::FormIdPool::new());
+    let placed_ref = esm::cell::PlacedRef {
+        form_id: 0x00AA_0001,
+        base_form_id: 0x00AA_0002,
+        position: [0.0; 3],
+        rotation: [0.0; 3],
+        scale: 1.0,
+        enable_parent: None,
+        teleport: None,
+        primitive: None,
+        linked_refs: Vec::new(),
+        location_ref_types: Vec::new(),
+        rooms: Vec::new(),
+        portals: Vec::new(),
+        radius_override: None,
+        alt_texture_ref: None,
+        land_texture_ref: None,
+        texture_slot_swaps: Vec::new(),
+        emissive_light_ref: None,
+        material_swap_ref: None,
+        ownership: None,
+        script_instance: None,
+        lock: None,
+        water_velocity: None,
+    };
+    let load_order = ["Test.esm".to_string()];
+
+    // Simulate a 3-child expansion: only child 0 is primary.
+    for idx in 0..3u32 {
+        let is_primary_synth = idx == 0;
+        if is_primary_synth {
+            spawn_logical_quest_reference(
+                &mut world,
+                &placed_ref,
+                &load_order,
+                Vec3::ZERO,
+                Quat::IDENTITY,
+                1.0,
+            );
+        }
+    }
+    let count = world
+        .query::<byroredux_scripting::SceneAliasCandidate>()
+        .expect("SceneAliasCandidate storage exists after one insert")
+        .iter()
+        .count();
+    assert_eq!(
+        count, 1,
+        "a multi-child SCOL/PKIN expansion must register exactly one \
+         SceneAliasCandidate for the whole REFR, not one per child",
+    );
+
+    // Part 2: source-scan `spawn_synth_child`'s own body — every call site
+    // must actually be gated, not just the stamping primitives above.
+    let src = include_str!("synth_child.rs");
+    let start = src
+        .find("pub(super) fn spawn_synth_child(")
+        .expect("spawn_synth_child must still exist");
+    let end = src[start..]
+        .find("pub(super) fn trigger_volume_should_spawn_for_synth_child(")
+        .expect("trigger_volume_should_spawn_for_synth_child must still follow spawn_synth_child");
+    let body = &src[start..start + end];
+
+    let stamp_calls = body.matches("stamp_quest_reference(").count();
+    let spawn_logical_calls = body.matches("spawn_logical_quest_reference(").count();
+    let total_call_sites = stamp_calls + spawn_logical_calls;
+
+    let direct_gates = body.matches("if is_primary_synth {").count();
+    // The trigger-volume branch's `stamp_quest_reference` isn't behind a
+    // literal `if is_primary_synth {` — it's gated one level up, by
+    // `trigger_volume_should_spawn_for_synth_child(is_primary_synth, ..)`.
+    let composed_gates = body
+        .matches("trigger_volume_should_spawn_for_synth_child(is_primary_synth,")
+        .count();
+    let total_gates = direct_gates + composed_gates;
+
+    assert_eq!(
+        (stamp_calls, spawn_logical_calls),
+        (4, 5),
+        "expected 4 stamp_quest_reference + 5 spawn_logical_quest_reference \
+         call sites in spawn_synth_child; a changed count means a branch \
+         was added/removed — re-verify its is_primary_synth gate before \
+         updating this baseline",
+    );
+    assert_eq!(
+        total_gates, total_call_sites,
+        "every stamp_quest_reference/spawn_logical_quest_reference call site \
+         in spawn_synth_child must be gated by is_primary_synth (directly or, \
+         for the trigger-volume branch, via trigger_volume_should_spawn_for_\
+         synth_child) — a mismatch means some call site lost its gate",
+    );
+}

--- a/byroredux/src/cell_loader/spawn/mesh_instance.rs
+++ b/byroredux/src/cell_loader/spawn/mesh_instance.rs
@@ -602,6 +602,32 @@ pub(super) fn spawn_mesh_instance(
     let eff_texture_path = eff_textures.base_color.clone();
     let eff_material_path = paths.material_path.clone();
 
+    // Canonical material translation — the single boundary that
+    // resolves a raw `ImportedMesh` into the engine `Material`
+    // (PBR resolved, glass classified once, flag union packed).
+    // The cell path contributes the REFR-overlay model-space-normals
+    // bit as `extra_material_flags`; everything else is shared with
+    // the loose-NIF path. See `material_translate.rs`.
+    //
+    // #2571 / OBL-D5-01 — computed here, ahead of the texture-clamp
+    // resolve just below, so every `texture_clamp_mode`/`src_blend_mode`/
+    // `dst_blend_mode` read for the rest of this function goes through
+    // this one canonical `Material` instead of re-reading the raw
+    // `mesh.material` tier at each use site.
+    let extra_material_flags = refr_overlay
+        .filter(|o| o.model_space_normals)
+        .map(|_| byroredux_renderer::vulkan::material::material_flag::MODEL_SPACE_NORMALS)
+        .unwrap_or(0);
+    let material = crate::material_translate::translate_material(
+        &mesh.material,
+        mesh.name.as_deref(),
+        crate::material_translate::ResolvedPaths {
+            textures: eff_textures.clone(),
+            material_path: eff_material_path.clone(),
+        },
+        extra_material_flags,
+    );
+
     // Load texture (shared resolve: cache → BSA → fallback).
     // #610 — pass the diffuse-slot `TexClampMode` so the bindless
     // descriptor's sampler picks the matching `VkSamplerAddressMode`
@@ -612,7 +638,7 @@ pub(super) fn spawn_mesh_instance(
         ctx,
         tex_provider,
         eff_texture_path.as_deref(),
-        mesh.material.texture_clamp_mode,
+        material.texture_clamp_mode,
     );
 
     // #544 — mesh entities now sit in the NIF-local frame and
@@ -781,27 +807,14 @@ pub(super) fn spawn_mesh_instance(
     }
     world.insert(entity, MeshHandle(mesh_handle));
     world.insert(entity, TextureHandle(tex_handle));
-    // Canonical material translation — the single boundary that
-    // resolves a raw `ImportedMesh` into the engine `Material`
-    // (PBR resolved, glass classified once, flag union packed).
-    // The cell path contributes the REFR-overlay model-space-normals
-    // bit as `extra_material_flags`; everything else is shared with
-    // the loose-NIF path. See `material_translate.rs`.
-    let extra_material_flags = refr_overlay
-        .filter(|o| o.model_space_normals)
-        .map(|_| byroredux_renderer::vulkan::material::material_flag::MODEL_SPACE_NORMALS)
-        .unwrap_or(0);
-    let material = crate::material_translate::translate_material(
-        &mesh.material,
-        mesh.name.as_deref(),
-        crate::material_translate::ResolvedPaths {
-            textures: eff_textures.clone(),
-            material_path: eff_material_path.clone(),
-        },
-        extra_material_flags,
-    );
+    // `material` was computed above, ahead of the texture-clamp resolve.
+    // `world.insert` below moves it, so pull copies of the small Copy
+    // fields the rest of this function still reads (#2571).
     let material_kind = material.material_kind;
     let mesh_water = material.is_water_shader;
+    let canonical_clamp_mode = material.texture_clamp_mode;
+    let canonical_src_blend_mode = material.src_blend_mode;
+    let canonical_dst_blend_mode = material.dst_blend_mode;
     world.insert(entity, material);
     // PERF-D3-NEW-02 / #1136 — classify FX-decoration meshes at spawn
     // time so build_render_data can skip them via a component query
@@ -819,7 +832,7 @@ pub(super) fn spawn_mesh_instance(
         tex_provider,
         &eff_textures,
         tex_handle,
-        mesh.material.texture_clamp_mode,
+        canonical_clamp_mode,
     );
     let normal_has_alpha = texture_handles.normal != 0
         && ctx
@@ -860,7 +873,7 @@ pub(super) fn spawn_mesh_instance(
         MaterialTextureDebugInfo {
             paths: eff_textures,
             sources: paths.sources,
-            clamp_mode: mesh.material.texture_clamp_mode,
+            clamp_mode: canonical_clamp_mode,
         },
     );
     // #1480 / REN-D22-NEW-01 — resolve the normal-alpha-as-spec roughness
@@ -890,7 +903,7 @@ pub(super) fn spawn_mesh_instance(
         // BGSM generic blend function is `None` for low-threshold soft
         // decals. Preserve explicit factors; otherwise use alpha-over.
         let (src_blend, dst_blend) = if mesh.material.has_alpha {
-            (mesh.material.src_blend_mode, mesh.material.dst_blend_mode)
+            (canonical_src_blend_mode, canonical_dst_blend_mode)
         } else {
             (6, 7)
         };

--- a/byroredux/src/cell_loader/terrain_lod_btr.rs
+++ b/byroredux/src/cell_loader/terrain_lod_btr.rs
@@ -170,7 +170,15 @@ pub(crate) fn spawn_btr_block(
     // Local pool — we consume only geometry + transforms; the diffuse path is
     // deterministic (mirrors `object_lod`'s atlas resolution).
     let mut pool = byroredux_core::string::StringPool::new();
-    let imported = byroredux_nif::import::import_nif_scene(&scene, &mut pool);
+    // #2362 / SF2D2-05 — thread the already-in-scope `tex_provider`
+    // through so external-geometry `BSGeometry` LOD slots resolve instead
+    // of silently importing to zero meshes. See the matching note on
+    // `object_lod.rs::spawn_object_lod_quad`.
+    let imported = byroredux_nif::import::import_nif_scene_with_resolver(
+        &scene,
+        &mut pool,
+        Some(tex_provider),
+    );
     if imported.meshes.is_empty() {
         return None;
     }
@@ -451,5 +459,23 @@ mod tests {
     #[test]
     fn world_bound_empty_is_zero() {
         assert_eq!(world_bound(&[]).center, WorldBound::ZERO.center);
+    }
+
+    /// #2362 / SF2D2-05 — `spawn_btr_block` must thread the already-in-
+    /// scope `tex_provider` through as a `MeshResolver`. See the matching
+    /// pin on `object_lod.rs::spawn_object_lod_quad_threads_the_mesh_resolver`.
+    #[test]
+    fn spawn_btr_block_threads_the_mesh_resolver() {
+        // Whitespace-insensitive so a reformat doesn't spuriously break this.
+        let normalized: String = include_str!("terrain_lod_btr.rs")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            normalized
+                .contains("import_nif_scene_with_resolver(&scene,&mutpool,Some(tex_provider))"),
+            "spawn_btr_block must pass tex_provider as the MeshResolver, \
+             not call the no-resolver import_nif_scene overload",
+        );
     }
 }

--- a/byroredux/src/material_translate.rs
+++ b/byroredux/src/material_translate.rs
@@ -511,6 +511,12 @@ pub(crate) fn translate_material(
         sheen: 0.0,
         sheen_tint: 0.0,
         anisotropic: 0.0,
+        // #2571 (OBL-D5-01) — copied verbatim so spawn sites read the
+        // canonical component instead of re-reading `ImportedMaterial`
+        // independently. See the field docs on `Material`.
+        texture_clamp_mode: source.texture_clamp_mode,
+        src_blend_mode: source.src_blend_mode,
+        dst_blend_mode: source.dst_blend_mode,
     };
     material.resolve_pbr();
     crate::helpers::classify_glass_into_material(
@@ -1650,6 +1656,11 @@ mod canonical_completeness_harness {
             rimlight_power: 0.81,
             backlight_power: 0.91,
             fresnel_power: 4.5,
+            // #2571 — non-default values so the round-trip assertion below
+            // actually exercises the copy (the struct default is 0/6/7).
+            texture_clamp_mode: 1, // CLAMP_S_WRAP_T
+            src_blend_mode: 2,     // SRC_COLOR
+            dst_blend_mode: 3,     // INV_SRC_COLOR
             no_lighting_falloff: Some(NoLightingFalloff {
                 start_angle: 0.1,
                 stop_angle: 0.9,
@@ -1724,6 +1735,10 @@ mod canonical_completeness_harness {
         assert_eq!(material.rimlight_power, 0.81);
         assert_eq!(material.backlight_power, 0.91);
         assert_eq!(material.fresnel_power, 4.5);
+        // #2571 (OBL-D5-01)
+        assert_eq!(material.texture_clamp_mode, 1);
+        assert_eq!(material.src_blend_mode, 2);
+        assert_eq!(material.dst_blend_mode, 3);
 
         // Texture handles.
         assert_eq!(

--- a/byroredux/src/save_io/serde_default_guard_tests.rs
+++ b/byroredux/src/save_io/serde_default_guard_tests.rs
@@ -284,8 +284,8 @@ fn save_shape_fingerprint() -> u64 {
 
 #[test]
 fn saved_type_shape_changes_require_format_major_bump() {
-    const BASELINE_MAJOR: u16 = 5;
-    const BASELINE_SHAPE_FINGERPRINT: u64 = 0x5279_6083_c5ea_00c1;
+    const BASELINE_MAJOR: u16 = 6;
+    const BASELINE_SHAPE_FINGERPRINT: u64 = 0x53d1_433d_b9e3_84cb;
     assert_eq!(
         byroredux_save::FORMAT_MAJOR,
         BASELINE_MAJOR,

--- a/byroredux/src/scene/nif_loader.rs
+++ b/byroredux/src/scene/nif_loader.rs
@@ -890,11 +890,39 @@ pub(crate) fn load_nif_bytes_with_skeleton(
             texture_sources.base_color = MaterialTextureSource::RuntimeOverride;
         }
 
+        // Canonical material translation — same single boundary the
+        // cell-loader path uses, so loose-NIF materials are resolved
+        // identically. No REFR overlay on the loose path → no extra
+        // material flags. See `material_translate.rs`.
+        //
+        // #2571 / OBL-D5-01 — computed here, ahead of the texture-clamp
+        // resolve just below (now that `owned_textures` is finalized), so
+        // every `texture_clamp_mode`/`src_blend_mode`/`dst_blend_mode` read
+        // for the rest of this loop iteration goes through this one
+        // canonical `Material` instead of re-reading the raw
+        // `mesh.material` tier at each use site. `world.insert` further
+        // down moves `material`, so pull copies of the small Copy fields
+        // this loop iteration still needs afterward.
+        let material = crate::material_translate::translate_material(
+            &mesh.material,
+            mesh.name.as_deref(),
+            crate::material_translate::ResolvedPaths {
+                textures: owned_textures.clone(),
+                material_path: owned_material_path.clone(),
+            },
+            0,
+        );
+        let material_kind = material.material_kind;
+        let mesh_water = material.is_water_shader;
+        let canonical_clamp_mode = material.texture_clamp_mode;
+        let canonical_src_blend_mode = material.src_blend_mode;
+        let canonical_dst_blend_mode = material.dst_blend_mode;
+
         let tex_handle = resolve_texture_with_clamp(
             ctx,
             tex_provider,
             owned_textures.base_color.as_deref(),
-            mesh.material.texture_clamp_mode,
+            canonical_clamp_mode,
         );
 
         let quat = Quat::from_xyzw(
@@ -938,7 +966,7 @@ pub(crate) fn load_nif_bytes_with_skeleton(
         );
         if mesh.material.has_alpha || implicit_decal_blend {
             let (src_blend, dst_blend) = if mesh.material.has_alpha {
-                (mesh.material.src_blend_mode, mesh.material.dst_blend_mode)
+                (canonical_src_blend_mode, canonical_dst_blend_mode)
             } else {
                 (6, 7)
             };
@@ -1013,21 +1041,8 @@ pub(crate) fn load_nif_bytes_with_skeleton(
                 world.insert(entity, SpeedTreeWind::new(1.0, 0.0));
             }
         }
-        // Canonical material translation — same single boundary the
-        // cell-loader path uses, so loose-NIF materials are resolved
-        // identically. No REFR overlay on the loose path → no extra
-        // material flags. See `material_translate.rs`.
-        let material = crate::material_translate::translate_material(
-            &mesh.material,
-            mesh.name.as_deref(),
-            crate::material_translate::ResolvedPaths {
-                textures: owned_textures.clone(),
-                material_path: owned_material_path.clone(),
-            },
-            0,
-        );
-        let material_kind = material.material_kind;
-        let mesh_water = material.is_water_shader;
+        // `material` was computed earlier in this loop iteration, ahead of
+        // the texture-clamp resolve.
         world.insert(entity, material);
         // PERF-D3-NEW-02 / #1136 — mirror of the cell_loader::spawn path.
         if let Some(ref tp) = owned_textures.base_color {
@@ -1044,7 +1059,7 @@ pub(crate) fn load_nif_bytes_with_skeleton(
             tex_provider,
             &owned_textures,
             tex_handle,
-            mesh.material.texture_clamp_mode,
+            canonical_clamp_mode,
         );
         let normal_has_alpha = texture_handles.normal != 0
             && ctx
@@ -1085,7 +1100,7 @@ pub(crate) fn load_nif_bytes_with_skeleton(
             MaterialTextureDebugInfo {
                 paths: owned_textures,
                 sources: texture_sources,
-                clamp_mode: mesh.material.texture_clamp_mode,
+                clamp_mode: canonical_clamp_mode,
             },
         );
         // #1480 / REN-D22-NEW-01 — resolve the normal-alpha-as-spec roughness

--- a/crates/core/src/ecs/components/material.rs
+++ b/crates/core/src/ecs/components/material.rs
@@ -367,6 +367,29 @@ pub struct Material {
     /// no-source-format-equivalent caveat as [`Self::subsurface`] (BGSM
     /// authors no anisotropy metadata either); `mat.set`-only. #2514.
     pub anisotropic: f32,
+    /// `NiTexturingProperty`/`BSShaderProperty` texture-address mode, per
+    /// nif.xml's `TexClampMode` enum: 0=CLAMP_S_CLAMP_T, 1=CLAMP_S_WRAP_T,
+    /// 2=WRAP_S_CLAMP_T, 3=WRAP_S_WRAP_T. Authored on Oblivion architecture
+    /// trim/signs/banners (#610) via `CLAMP_S_CLAMP_T` so edge texels don't
+    /// bleed into the sampler's wrap. Copied verbatim from
+    /// `ImportedMaterial::texture_clamp_mode`, including that struct's own
+    /// `0` (CLAMP_S_CLAMP_T) parser-stub default.
+    ///
+    /// #2571 (OBL-D5-01) — added so spawn sites can read this off the
+    /// canonical `Material` instead of re-reading the raw `ImportedMaterial`
+    /// tier independently at each call site (the exact hand-synced-
+    /// duplication failure mode NIFAL exists to eliminate).
+    pub texture_clamp_mode: u8,
+    /// `NiAlphaProperty` source blend factor (Gamebryo `AlphaFunction`
+    /// enum; `6` = SRC_ALPHA is the Gamebryo default). Only meaningful
+    /// when the material's alpha-blend path is active. Copied verbatim
+    /// from `ImportedMaterial::src_blend_mode`. See
+    /// [`Self::texture_clamp_mode`]'s doc for why this field exists.
+    pub src_blend_mode: u8,
+    /// `NiAlphaProperty` destination blend factor (same enum as
+    /// [`Self::src_blend_mode`]; `7` = INV_SRC_ALPHA is the Gamebryo
+    /// default). Copied verbatim from `ImportedMaterial::dst_blend_mode`.
+    pub dst_blend_mode: u8,
 }
 
 /// View-angle + soft-depth falloff cone captured from
@@ -500,6 +523,13 @@ impl Default for Material {
             sheen: 0.0,
             sheen_tint: 0.0,
             anisotropic: 0.0,
+            // #2571 — mirror `ImportedMaterial::default()`'s own values
+            // (crates/nif/src/import/types.rs) exactly: SRC_ALPHA (6) /
+            // INV_SRC_ALPHA (7) is the Gamebryo default blend-factor pair;
+            // `0` (CLAMP_S_CLAMP_T) is that struct's stub clamp default.
+            texture_clamp_mode: 0,
+            src_blend_mode: 6,
+            dst_blend_mode: 7,
         }
     }
 }

--- a/crates/plugin/src/esm/cell/walkers.rs
+++ b/crates/plugin/src/esm/cell/walkers.rs
@@ -1199,8 +1199,9 @@ mod xcll_gate_tests {
         assert_eq!(
             xcll_canonical_sizes(GameKind::Starfield),
             &[28, 108],
-            "Starfield's vanilla XCLL is 108 bytes (Skyrim+ 92-byte \
-             body + 16-byte SF tail). See #1291.",
+            "Starfield's vanilla XCLL is 108 bytes (shares only bytes 0-39 \
+             with Skyrim, then diverges into a distinct volumetric \
+             height-fog model). See #1291 / #1293.",
         );
     }
 

--- a/crates/save/src/snapshot.rs
+++ b/crates/save/src/snapshot.rs
@@ -62,7 +62,10 @@ pub const FORMAT_MAGIC: &[u8; 8] = b"BYRSAVE\0";
 /// Version 5 adds required `Material.water_shader_flags`,
 /// `Material.is_water_shader`, `RigidBodyData.collidable`, and the saved
 /// `CharacterController` column (#3164/#3165).
-pub const FORMAT_MAJOR: u16 = 5;
+/// Version 6 adds required `Material.texture_clamp_mode`,
+/// `Material.src_blend_mode`, `Material.dst_blend_mode` — the NIFAL
+/// canonical-boundary fields added by #2571 (OBL-D5-01).
+pub const FORMAT_MAJOR: u16 = 6;
 /// Additive-format version. Bumped when fields are added compatibly.
 pub const FORMAT_MINOR: u16 = 0;
 


### PR DESCRIPTION
…cene call sites

Fix #2364: correct the stale Skyrim-92-byte-body framing in an XCLL test assertion
Fix #2541: pin the is_primary_synth gate on every synth-child identity-stamp call site
Fix #2571: add texture_clamp_mode/src_blend_mode/dst_blend_mode to the canonical Material

#2362 (SF2D2-05) — object_lod.rs, placement_lod.rs, and terrain_lod_btr.rs each called the no-resolver import_nif_scene overload despite already holding a tex_provider (a MeshResolver) in scope, so a future Starfield distant-object-LOD path reusing these helpers would silently import every external-geometry BSGeometry LOD mesh to zero. Threaded Some(tex_provider) through via import_nif_scene_with_resolver at all three call sites; added a source-scan regression test per file (no Vulkan/archive fixture needed). dump_nif.rs's import_nif call is left as-is with an explanatory comment — it's a loose-file debug tool with no archive open, so no resolver is constructible there; matches the issue's own accepted alternative for that site.

#2364 (SF-D5-2026-08-03-01) — walkers.rs's starfield_xcll_sizes_pinned assertion message still read "Skyrim+ 92-byte body + 16-byte SF tail" (the disproven #1291 framing), three lines below the #1293-corrected doc comment above it ("shares only bytes 0-39 with Skyrim, then diverges into a distinct volumetric height-fog model"). String-literal fix only, no behavior change.

#2541 (SCR-D7-NEW10-01) — spawn_synth_child's is_primary_synth gate (now living in references/synth_child.rs post-#2409 split, not references/mod.rs as the issue's stale path cited) had no test. A live spawn fixture needs a real VulkanContext, out of unit-test scope per this file's own established precedent (source_pin_tests.rs). Added a test that (1) exercises stamp_quest_reference/spawn_logical_quest_reference directly in a simulated 3-child loop and asserts exactly one SceneAliasCandidate registers, and (2) source-scans spawn_synth_child's body confirming all 9 call sites (4 stamp_quest_reference + 5 spawn_logical_quest_reference) are gated — 8 directly by if/else-if is_primary_synth, plus the trigger-volume branch's call, gated one level up via trigger_volume_should_spawn_for_synth_child.

#2571 (OBL-D5-01) — texture_clamp_mode/src_blend_mode/dst_blend_mode had no canonical Material field and were re-read off the raw ImportedMaterial tier independently at each spawn site. Added the three fields to Material, copied them in translate_material, and hoisted translate_material's call earlier in both mesh_instance.rs::spawn_mesh_instance and nif_loader.rs (to right after their texture-path resolution finalizes, ahead of the first clamp-mode read) so every read in both functions now goes through the one canonical value instead of re-reading ImportedMaterial at each use site. Extended the existing canonical-completeness test (translate_material_copies_every_ canonical_field) to cover the three new fields with non-default values.

Material is a save-registered component, so these are new required (non-Option, non-serde-default) fields on a saved struct — per this repo's SAVE-D2-01 invariant that requires bumping byroredux_save::FORMAT_MAJOR (5 -> 6) for any such change, since a serde(default)/Option would let an old save silently reload with invented state instead of being rejected. Updated the save_io::serde_default_guard_tests baseline (BASELINE_MAJOR + the recomputed shape fingerprint) to match. This pushed the file count for #2571 to 6 (over the nominal 5-file scope-check threshold), but it isn't optional scope creep -- it's a hard consequence of adding required fields to Material correctly, caught by the existing guard test itself.

SIBLING check for #2571: cell_loader/precombined.rs (the FO4 precombine path, explicitly named in the issue as a "third reader" divergence risk) and fog.rs (not mentioned by the issue) both still read the raw ImportedMaterial tier directly for these three fields. Left untouched -- the issue's own suggested fix scopes only the two (now-consolidated) spawn sites; documenting the still-open divergence risk here rather than silently leaving it unmentioned.

Verification: cargo test -q -p byroredux-plugin, cargo test -q -p byroredux-core, cargo test -q -p byroredux-save, and cargo test -q -p byroredux all green, plus one final cargo test -q --workspace --lib --bins pass across every crate with zero failures.