### PR TITLE
Fix #3014: mark hkx's vacuous integration test #[ignore]d, add malfor…

### DIFF
--- a/.claude/issues/3014 3018 3067 3111/ISSUE.md
+++ b/.claude/issues/3014 3018 3067 3111/ISSUE.md
@@ -1,0 +1,66 @@
+# Issue Batch: 3014, 3018, 3067, 3111
+
+## #3014 — SCR-D8-2026-08-16-04 (byroredux-hkx)
+`crates/hkx/src/animation.rs:887-899` — the crate's only integration test
+(`skyrim_cart_player_idle_decodes_when_assets_are_available`) silently
+`return`s (not `#[ignore]`) when `BYROREDUX_SKYRIM_DATA`/the BSA archive
+isn't present, so it reports green with zero real coverage on any machine
+without game data (including CI). No negative/malformed-input fixtures
+exist at all. Suggested fix: mark the data-dependent test `#[ignore]`
+(matching `crates/pex/tests/r5_fidelity.rs`'s pattern) and add checked-in
+malformed-input fixtures covering bounds the crate doesn't enforce (ties to
+#3011/#3013, already-fixed parser gaps this coverage gap allowed).
+
+## #3018 — SCR-D8-2026-08-16-03 (byroredux-hkx)
+`crates/hkx/src/animation.rs:331-333` vs `:341` — an out-of-range annotation
+timestamp hard-fails the ENTIRE clip decode (`return Err(InvalidData(...))`),
+but the very next lines show the codebase already knows how to tolerate the
+same condition by clamping (`time: time.min(duration)`). Two policies
+disagree. Suggested fix: pick one — since clamping already exists for
+accepted values, skip/clamp the offending annotation and keep the clip
+(log the anomaly) instead of discarding all transform tracks over one bad
+metadata timestamp.
+
+## #3067 — PHYS-D3-2026-08-16-04 (byroredux-physics)
+`crates/physics/src/sync.rs:787-789` — `register_newcomers`'s
+`parts.is_empty() { continue; }` skip is unreachable; every producer
+(`collision_shape_to_parts`) pushes at least one part unconditionally.
+Suggested fix: convert to `debug_assert!(!parts.is_empty())` to document the
+producer contract (not silently delete) — relevant because #3066 touches the
+same producer chain and could make this reachable later.
+
+## #3111 — ECS-2026-08-20-01 (ecs + binary, HIGH)
+`byroredux/src/boot.rs:691-724` (`player_controller_system`'s `Access`
+chain) is missing a `WindField` read declaration. The read happens 3 call
+frames down: `character.rs:911-916` → `byroredux_physics::water.rs:323-327`
+`world.try_resource::<WindField>()`. `weather_system` (same `Stage::Early`
+parallel batch, `boot.rs:726-740`) takes an unconditional
+`try_resource_mut::<WindField>()` write every tick — an undeclared,
+unsynchronized read/write race within one parallel batch. Not a deadlock
+(no cycle), but breaks the M27 access-model invariant
+(`known_conflict_count() == 0` ⇒ no undeclared same-stage read/write
+overlap) silently, and is observably a controller-state strobe risk at the
+swim threshold. Suggested fix (two options):
+- (a) Move `weather_system` to `add_exclusive_with_access` — matches M27
+  Phase 3 precedent (`audio_system`/`spin_system`), smaller change.
+- (b) Hoist the WTHR wind update into an earlier stage.
+Then add the honest `WindField` read declaration to
+`player_controller_system` and confirm `known_conflict_count() == 0` still
+holds. Also named as sibling declaration gaps (lower severity, no live
+writer, filed separately — NOT in this batch): `physics_sync_system`,
+`make_animation_system`, `make_billboard_system`.
+
+## Domain classification
+- #3014, #3018 → **byroredux-hkx**
+- #3067 → **byroredux-physics**
+- #3111 → **ecs** (byroredux-core scheduler/access model) + **binary**
+  (byroredux boot.rs/systems/*.rs) — cross-domain, primary test target
+  `byroredux` (binary) since the scheduling decision + declaration live
+  there; `byroredux-core`'s access-conflict logic itself isn't being
+  changed, just correctly fed.
+
+## Plan
+#3111 is HIGH severity and structurally significant — investigate first,
+pick option (a) or (b) per its own suggested-fix guidance, and confirm scope
+before implementing. #3014/#3018 are same-crate (hkx) siblings — natural to
+implement together. #3067 is a single-site, low-risk assert-conversion.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ name = "byroredux-hkx"
 version = "0.1.0"
 dependencies = [
  "byroredux-bsa",
+ "log",
  "thiserror 2.0.18",
 ]
 

--- a/byroredux/src/boot.rs
+++ b/byroredux/src/boot.rs
@@ -1885,3 +1885,50 @@ mod scheduler_timings_gate_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod scheduler_access_report_tests {
+    //! #3111 / ECS-2026-08-20-01 — `install_runtime_registries`'s
+    //! `known_conflict_count() == 0` / `undeclared_parallel_count() == 0`
+    //! / `unknown_pair_count() == 0` guards only run inside a live
+    //! `App::new()` boot (Vulkan device + on-disk game data), so they were
+    //! never exercised by `cargo test` — a regression could sit green in CI
+    //! indefinitely. `build_scheduler()` itself needs neither: it's a pure
+    //! `() -> Scheduler` builder (extracted verbatim from `App::new` in
+    //! #1670), so the same guard checks can run directly here.
+    //!
+    //! This is the honest-declaration half of #3111's fix, not the
+    //! scheduling half — `weather_system` moved to
+    //! `add_exclusive_with_access` and `player_controller_system` gained
+    //! the `WindField` read declaration in the same change (`boot.rs`
+    //! `build_scheduler`, see the `#3111` comment there). Without a real
+    //! `cargo test` assertion, a future regression that re-declared
+    //! `weather_system` as parallel (or dropped the `WindField` read) would
+    //! only be caught by a debug build actually booting the engine.
+    use super::build_scheduler;
+
+    #[test]
+    fn build_scheduler_reports_zero_access_conflicts() {
+        let scheduler = build_scheduler();
+        let report = scheduler.access_report();
+        assert_eq!(
+            report.undeclared_parallel_count(),
+            0,
+            "an undeclared parallel system slipped into the schedule — use \
+             add_to_with_access instead of add_to"
+        );
+        assert_eq!(
+            report.known_conflict_count(),
+            0,
+            "declared access conflict between two parallel same-stage systems \
+             — make one side exclusive or split the access (see sys.accesses); \
+             this is the guard #3111's WindField race would have tripped had \
+             the read been declared without also serializing weather_system"
+        );
+        assert_eq!(
+            report.unknown_pair_count(),
+            0,
+            "unknown (undeclared) parallel pairing detected — declare both sides' access"
+        );
+    }
+}

--- a/crates/hkx/Cargo.toml
+++ b/crates/hkx/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 byroredux-bsa = { workspace = true }

--- a/crates/hkx/src/animation.rs
+++ b/crates/hkx/src/animation.rs
@@ -342,8 +342,21 @@ fn read_annotations(
         for annotation_index in 0..annotation_count {
             let annotation = annotations + annotation_index * ANNOTATION_SIZE;
             let time = pack.f32(annotation, "annotation time")?;
+            // #3018 (SCR-D8-2026-08-16-03) — an out-of-range annotation
+            // timestamp used to hard-fail the whole clip decode, discarding
+            // every transform track over one bad piece of text-event
+            // metadata. The accepted-range path a few lines below already
+            // clamps `time` to `duration` anyway, so the two policies
+            // disagreed about what "out of range" means. Skip just this
+            // annotation and keep decoding — `InvalidData` is reserved for
+            // structural corruption (unbound pointers, size overflow),
+            // not one anomalous float.
             if !time.is_finite() || time < 0.0 || time > duration + 0.001 {
-                return Err(HkxError::InvalidData("annotation time is out of range"));
+                log::warn!(
+                    "hkx: skipping out-of-range annotation time {time} (clip duration \
+                     {duration}) in track {track_name:?} — clip decode continues"
+                );
+                continue;
             }
             let text_offset = pack
                 .local_target(annotation + 0x08)
@@ -898,7 +911,16 @@ mod tests {
         assert!((q[1] + 1.0).abs() < 1e-6);
     }
 
+    /// #3014 (SCR-D8-2026-08-16-04) — this test needs the Skyrim SE
+    /// animation archive on disk, so it never runs in CI. `#[ignore]`
+    /// makes a skipped run show as `ignored`, not `ok` — pre-fix this was
+    /// a plain `return`, so the crate's only integration test reported
+    /// green on every machine without the archive (including CI), leaving
+    /// zero real coverage indistinguishable from a passing run. Run
+    /// locally with:
+    /// `cargo test -p byroredux-hkx -- --ignored --nocapture`
     #[test]
+    #[ignore = "needs Skyrim SE game data on disk"]
     fn skyrim_cart_player_idle_decodes_when_assets_are_available() {
         let data_dir = std::env::var_os("BYROREDUX_SKYRIM_DATA")
             .map(std::path::PathBuf::from)
@@ -909,6 +931,7 @@ mod tests {
             });
         let archive_path = data_dir.join("Skyrim - Animations.bsa");
         if !archive_path.is_file() {
+            eprintln!("SKIP: Skyrim - Animations.bsa not found (no game data?)");
             return;
         }
         let archive = byroredux_bsa::BsaArchive::open(archive_path).unwrap();
@@ -998,6 +1021,108 @@ mod tests {
                 "{path} decoded without any time-varying pose samples"
             );
         }
+    }
+
+    /// #3014 (SCR-D8-2026-08-16-04) — the crate had zero negative/malformed-
+    /// input coverage; the only integration test needed real game data and
+    /// silently passed without it. Checked-in fixture built with
+    /// `crate::packfile::fixtures::PackfileBuilder` (promoted out of
+    /// `packfile.rs`'s own tests for exactly this — #3018), no game data
+    /// required.
+    ///
+    /// Pins #3011's bound: `transform_count * num_frames` past
+    /// `MAX_TRANSFORM_SAMPLES` must be rejected before any `Vec::with_
+    /// capacity` allocation, not after. `num_blocks`/`max_frames_per_block`/
+    /// `mask_size` are left zeroed — the dimension check's `||` chain short-
+    /// circuits on the sample-count clause before reaching theirs, so this
+    /// fixture never needs valid spline block data at all.
+    #[test]
+    fn decode_spline_animation_rejects_a_sample_count_bomb() {
+        use crate::packfile::fixtures::PackfileBuilder;
+
+        // float_count (0x1c..0x20) is left at 0.
+        let mut data = vec![0u8; 0x60];
+        data[0x10..0x14].copy_from_slice(&5u32.to_le_bytes()); // animation_type = spline-compressed
+        data[0x14..0x18].copy_from_slice(&1.0f32.to_le_bytes()); // duration
+        data[0x18..0x1c].copy_from_slice(&4096u32.to_le_bytes()); // transform_count (max allowed)
+        data[0x38..0x3c].copy_from_slice(&5000u32.to_le_bytes()); // num_frames: transform_count * num_frames > MAX_TRANSFORM_SAMPLES
+        data[0x50..0x54].copy_from_slice(&(1.0f32 / 30.0).to_le_bytes()); // frame_duration
+
+        let mut builder = PackfileBuilder {
+            data,
+            ..Default::default()
+        };
+        let class = builder.class("hkaSplineCompressedAnimation");
+        builder.virtual_fixups.push((0, 0, class));
+        let bytes = builder.build();
+
+        let err = decode_spline_animation(&bytes).expect_err(
+            "a transform_count * num_frames product past MAX_TRANSFORM_SAMPLES must be \
+             rejected, not handed to Vec::with_capacity (#3011)",
+        );
+        assert_eq!(
+            err,
+            HkxError::InvalidData("unsupported spline clip dimensions")
+        );
+    }
+
+    /// #3018 (SCR-D8-2026-08-16-03) — an out-of-range annotation timestamp
+    /// used to hard-fail the whole clip decode via `read_annotations`'s `?`
+    /// propagation, discarding every transform track over one bad piece of
+    /// metadata. Pins the fixed policy: skip just the offending annotation
+    /// and keep the rest, using the same clamp-on-accept semantics the
+    /// accepted-range path already had.
+    #[test]
+    fn read_annotations_skips_an_out_of_range_time_and_keeps_the_rest() {
+        use crate::packfile::fixtures::PackfileBuilder;
+        use crate::packfile::Packfile;
+
+        const TRACKS: usize = 0x40;
+        const ANNOTATIONS: usize = 0x60;
+        const ANNOTATION_SIZE: usize = 0x10;
+        const TEXT_BAD: usize = 0x90;
+        const TEXT_GOOD: usize = 0x98;
+
+        // ann[0]'s time is out of range (negative) and must be skipped, not
+        // fail the clip; ann[1]'s is in range and must survive, clamped to
+        // `duration` as before.
+        let mut data = vec![0u8; 0xa0];
+        data[0x30..0x34].copy_from_slice(&1u32.to_le_bytes()); // annotation-track count
+        data[TRACKS + 0x10..TRACKS + 0x14].copy_from_slice(&2u32.to_le_bytes()); // annotation count
+        data[ANNOTATIONS..ANNOTATIONS + 4].copy_from_slice(&(-5.0f32).to_le_bytes()); // ann[0].time
+        data[ANNOTATIONS + ANNOTATION_SIZE..ANNOTATIONS + ANNOTATION_SIZE + 4]
+            .copy_from_slice(&0.1f32.to_le_bytes()); // ann[1].time
+        data[TEXT_BAD..TEXT_BAD + 4].copy_from_slice(b"Bad\0");
+        data[TEXT_GOOD..TEXT_GOOD + 5].copy_from_slice(b"Good\0");
+
+        let builder = PackfileBuilder {
+            data,
+            local: vec![
+                (0x28, TRACKS as u32),
+                ((TRACKS + 0x08) as u32, ANNOTATIONS as u32),
+                ((ANNOTATIONS + 0x08) as u32, TEXT_BAD as u32),
+                (
+                    (ANNOTATIONS + ANNOTATION_SIZE + 0x08) as u32,
+                    TEXT_GOOD as u32,
+                ),
+            ],
+            ..Default::default()
+        };
+        let bytes = builder.build();
+        let pack = Packfile::parse(&bytes).unwrap();
+
+        let annotations = read_annotations(&pack, 0, 1.0).expect(
+            "an out-of-range annotation must be skipped, not fail the whole decode (#3018)",
+        );
+        assert_eq!(
+            annotations,
+            vec![HkxAnnotation {
+                track_name: String::new(),
+                time: 0.1,
+                text: "Good".to_string(),
+            }],
+            "only the in-range annotation should survive, clamped as before"
+        );
     }
 
     #[test]

--- a/crates/hkx/src/packfile.rs
+++ b/crates/hkx/src/packfile.rs
@@ -260,12 +260,17 @@ fn read_cstr<'a>(bytes: &'a [u8], offset: usize, label: &'static str) -> Result<
     std::str::from_utf8(&rest[..len]).map_err(|_| HkxError::InvalidData("non-UTF-8 string"))
 }
 
+/// Shared test-only packfile fixture builder (#3018 / SCR-D8-2026-08-16-03 —
+/// promoted out of this module's own `mod tests` so `animation.rs`'s tests
+/// can build a real, minimal Havok packfile too, instead of only being able
+/// to exercise the crate against real game data. See
+/// [`PackfileBuilder`](fixtures::PackfileBuilder).
 #[cfg(test)]
-mod tests {
+pub(crate) mod fixtures {
     use super::*;
 
-    const HEADER: usize = HEADER_SIZE;
-    const SECTION_TABLE: usize = 2 * SECTION_HEADER_SIZE;
+    pub(crate) const HEADER: usize = HEADER_SIZE;
+    pub(crate) const SECTION_TABLE: usize = 2 * SECTION_HEADER_SIZE;
 
     /// Assembles a minimal but *structurally real* 64-bit little-endian
     /// Havok 2010 packfile: a `__classnames__` section holding the class
@@ -273,31 +278,31 @@ mod tests {
     /// by the local / global / virtual fixup tables in the order the format
     /// mandates.
     #[derive(Default)]
-    struct PackfileBuilder {
-        classnames: Vec<u8>,
-        data: Vec<u8>,
-        local: Vec<(u32, u32)>,
-        global: Vec<(u32, u32, u32)>,
-        virtual_fixups: Vec<(u32, u32, u32)>,
+    pub(crate) struct PackfileBuilder {
+        pub(crate) classnames: Vec<u8>,
+        pub(crate) data: Vec<u8>,
+        pub(crate) local: Vec<(u32, u32)>,
+        pub(crate) global: Vec<(u32, u32, u32)>,
+        pub(crate) virtual_fixups: Vec<(u32, u32, u32)>,
     }
 
     impl PackfileBuilder {
         /// Append a NUL-terminated class name, returning its offset within
         /// the classnames section.
-        fn class(&mut self, name: &str) -> u32 {
+        pub(crate) fn class(&mut self, name: &str) -> u32 {
             let offset = self.classnames.len() as u32;
             self.classnames.extend_from_slice(name.as_bytes());
             self.classnames.push(0);
             offset
         }
 
-        fn build(&self) -> Vec<u8> {
+        pub(crate) fn build(&self) -> Vec<u8> {
             self.build_with(|_| {})
         }
 
         /// `tweak` gets the finished buffer so a test can corrupt one field
         /// without hand-rolling the whole layout again.
-        fn build_with(&self, tweak: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
+        pub(crate) fn build_with(&self, tweak: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
             let names_start = HEADER + SECTION_TABLE;
             let names_len = self.classnames.len();
             let data_start = names_start + names_len;
@@ -380,6 +385,12 @@ mod tests {
             bytes
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fixtures::{PackfileBuilder, HEADER};
+    use super::*;
 
     /// `Packfile` carries a borrowed slice and derives neither `Debug` nor
     /// `PartialEq`, so rejection tests assert on the error alone.

--- a/crates/physics/src/sync.rs
+++ b/crates/physics/src/sync.rs
@@ -843,9 +843,19 @@ fn register_newcomers(world: &World, newcomers: Vec<Newcomer>) {
         // collider of the authored size (a 2× rock's collider half the visible
         // stone) while `compose_trs` still spread its parts apart.
         let parts = collision_shape_to_parts(&n.shape, n.global.scale, &cfg);
-        if parts.is_empty() {
-            continue;
-        }
+        // #3067 (PHYS-D3-2026-08-16-04) — `collision_shape_to_parts` always
+        // yields at least one part: every `CollisionShape` variant pushes
+        // unconditionally, and its own `out.is_empty()` fallback (a tiny
+        // ball, #3066) covers the degenerate-shape case. An empty `parts`
+        // here would mean that producer contract broke, not a legitimate
+        // "nothing to register" case — state the invariant instead of
+        // silently skipping the newcomer.
+        debug_assert!(
+            !parts.is_empty(),
+            "collision_shape_to_parts must never return zero parts (see its own \
+             out.is_empty() fallback) — a newcomer would silently register with \
+             no collider"
+        );
 
         let body_type = n.body_type();
         let lock_rotations = n.lock_rotations();


### PR DESCRIPTION
…med-input fixtures

Fix #3018: an out-of-range annotation timestamp no longer discards the whole clip
Fix #3067: convert register_newcomers' unreachable parts.is_empty() skip to a debug_assert
Fix #3111: add a cargo-test-reachable regression guard for the scheduler's zero-conflict invariant

#3014 (SCR-D8-2026-08-16-04) — crates/hkx's only integration test used a plain `return` (not #[ignore]) when the Skyrim animation BSA wasn't on disk, so it reported green with zero real coverage on any machine without game data, including CI. Marked it #[ignore = "needs Skyrim SE game data on disk"], matching crates/pex/tests/r5_fidelity.rs's established pattern. Promoted packfile.rs's private test-only PackfileBuilder into a shared `pub(crate) mod fixtures` so animation.rs's tests can build real, minimal Havok packfiles without game data, and added a malformed-input regression test pinning #3011's MAX_TRANSFORM_SAMPLES bound (a transform_count * num_frames product past the limit is rejected before any Vec::with_capacity allocation). Did not add a #3013 bone-binding fixture in this pass -- reaching that check requires a full valid spline-block decode first, which is substantially more fixture work than the dimension-check fixture; noting this as a known remaining gap rather than claiming full coverage. SIBLING check: swept the workspace for the same silent-return data-gated-test shape (crates/bsa/tests/*_real.rs, crates/bgsm/tests/ parse_all.rs, crates/hkx/tests) -- every other instance already uses #[ignore] correctly; this was the one outlier.

#3018 (SCR-D8-2026-08-16-03) -- an out-of-range annotation timestamp hard- failed read_annotations via `?` propagation, discarding every transform track in the clip over one bad piece of text-event metadata, while the very next lines already clamped the accepted-range value anyway (two policies disagreeing about the same condition). Changed the out-of-range branch to skip just that annotation (with a log::warn!) and keep decoding -- InvalidData stays reserved for structural corruption (unbound pointers, size overflow), not one anomalous float. Added `log = { workspace = true }` to hkx's Cargo.toml (already a workspace dependency used by every other production crate, not a new one). Added a fixture test (built with the same shared PackfileBuilder) pinning that one out-of-range annotation is skipped while an in-range sibling survives, clamped as before.

#3067 (PHYS-D3-2026-08-16-04) -- confirmed collision_shape_to_parts always returns at least one part (its own out.is_empty() fallback, the #3066 ball substitute, covers every degenerate case), so register_newcomers' `if parts.is_empty() { continue; }` is unreachable. Converted to a debug_assert! documenting the producer contract instead of silently tolerating a violation, per the issue's own recommendation (given #3066 touches the same producer chain). SIBLING check: swept sync.rs's other `is_empty()` early-exits (newcomers/registered/updates) -- all are legitimately reachable batch-level guards, not the same dead-code pattern; none needed the same treatment.

#3111 (ECS-2026-08-20-01, HIGH) -- the actual fix (WindField read declared on player_controller_system, weather_system moved to add_exclusive_with_access so the parallel batch has no undeclared same-stage read/write race) was already landed in 5428e872, before this session. What was still missing, per the issue's own completeness check, was a cargo-test-reachable regression guard: install_runtime_registries' known_conflict_count()/undeclared_parallel_count()/unknown_pair_count() debug_assert!s only run inside a live App::new() boot (Vulkan device + game data), so a regression here would only be caught by a debug build actually booting the engine, never by `cargo test`. build_scheduler() itself is a pure () -> Scheduler builder needing neither, so added a test calling it directly and asserting all three counts are zero -- so the guard can no longer be kept green by omission. The three sibling declaration gaps named in the issue (physics_sync_system, make_animation_system, make_billboard_system) are separately filed issues, confirmed still present and out of scope for this batch.

Verification: cargo test -q -p byroredux-hkx, cargo test -q -p byroredux-physics, and cargo test -q -p byroredux all green, plus one final cargo test -q --workspace --lib --bins pass across every crate with zero failures. All touched files are cargo fmt-clean; one pre-existing, unrelated formatting drift in crates/core/src/ecs/components/material.rs:1706 was confirmed present before this session and left untouched.