### PR TITLE
Fix #2722: a failed frame capture no longer publishes stale pixels an…

### DIFF
--- a/.claude/issues/2722 2723 2729 2965/ISSUE.md
+++ b/.claude/issues/2722 2723 2729 2965/ISSUE.md
@@ -1,0 +1,71 @@
+# Issue Batch: 2722, 2723, 2729, 2965
+
+## #2722 — SAFEUI-05 (byroredux-ui)
+`crates/ui/src/player.rs:247-283` — `SwfPlayer::render`'s three failure paths
+(`downcast_mut` → `None`, `capture_frame()` → `None`, `rgba.len() !=
+pixel_buffer.len()` mismatch) all fall through to `self.dirty = false;
+Some(&self.pixel_buffer)` — i.e. failure is reported identically to success,
+and `dirty` being cleared means a real failure is never retried. Currently
+LOW/unreachable (concrete backend type guarantees all three can't happen
+today) but the code's stated intent (handle failure) doesn't match its
+behavior. Suggested fix: return `None` and leave `dirty` set on any of the
+three paths, so a genuine future failure retries instead of publishing a
+stale/zeroed frame.
+
+## #2723 — SAFEUI-07 (byroredux-ui + binary)
+`byroredux/src/scene.rs:1139-1162`, `crates/ui/src/lib.rs:51-59,211-216` —
+`UiManager::new`/`SwfPlayer::from_movie` fix the Ruffle viewport + offscreen
+`TextureTarget` at the swapchain extent captured at setup time; nothing in
+`main.rs` updates `ui_manager.width/height`, re-registers the UI texture, or
+resizes Ruffle's target on swapchain recreate (window resize) — the overlay
+just stretches (confirmed NOT a Vulkan hazard, `update_rgba` len assertion
+can't fire). Separately `UiManager::close` is dead code (nothing calls it;
+even if called, `App::ui_texture_handle` would still hold the registered
+RGBA texture). Suggested fix: either wire a resize path (`set_viewport_dimensions`
++ re-register texture) or document the fixed-extent behavior; give `close()`
+a caller or delete it.
+
+## #2729 — TD3-2026-08-12-02 (docs)
+`ROADMAP.md:628` still lists "input" as remaining M48 work, but input
+routing shipped in `3ea5e275` (2026-07-27) — `crates/ui/src/input.rs`,
+`byroredux/src/ui_input.rs`, focus transfer, modal capture, coordinate
+scaling — and `docs/engine/ui.md` already documents it as shipped.
+`docs/feature-matrix.md`'s UI table (6 rows) doesn't mention input/focus
+routing at all, under-reporting the subsystem. Suggested fix: drop "input"
+from ROADMAP.md's remaining-work list (keep font fidelity, menu lifecycle,
+`_global.gfx`, Papyrus↔UI — genuinely open); add a
+"Scaleform menu input routing + modal focus | ✓ M48" row to
+feature-matrix.md's UI table. Trivial effort.
+
+## #2965 — UI-D2-02 (byroredux-ui, MEDIUM)
+`crates/ui/src/host.rs:415-431,458-464` — `normalize_call` treats the first
+argument of ANY `SkyrimAvm1` host call as a `GameDelegate` request ID
+whenever it's a finite non-negative integral Number, with no marker
+distinguishing a real `GameDelegate.call` from a direct
+`ExternalInterface.call`. `SkyrimAvm1` is the fallback profile for every
+non-AS3 movie, so this over-fires on loose demo SWFs / third-party AVM1
+content too — silently dropping the first real argument and attaching a
+bogus `request_id`. Currently deferred-impact (no responses registered yet)
+but structural: the first engine handler to land will get an argument list
+short by one, or `respond` will re-enter with a bogus ID (`GameDelegate.as`
+indexes `_callbacks[id]` — an AS-side error, invisible from either side).
+Suggested fix: only strip when `catalog.find(method)` returns a `Request`
+entry OR the movie has registered a `respond` callback
+(`has_callback("respond")`) — both already available at the call site.
+Always record the un-stripped argument list regardless of which branch
+fires. Related: UI-D4-01 (same catalog-is-only-signal weakness on FO4 side,
+NOT in this batch — note the interaction, don't fix it here).
+
+## Domain classification
+- #2722, #2965 → **ui** → `byroredux-ui`
+- #2723 → **ui** (`byroredux-ui`) + **binary** (`byroredux` — scene.rs/main.rs)
+- #2729 → **docs** — no crate test target, just ROADMAP.md/feature-matrix.md
+
+## Plan
+#2729 is a pure doc fix, do first (fast, zero risk). #2722 and #2965 are
+single-crate (byroredux-ui) behavioral fixes. #2723 spans ui+binary and asks
+for either a real resize-follow implementation OR documenting the fixed-extent
+behavior — need to assess which is proportionate (a real Ruffle-resize +
+texture re-registration wire-up is a bigger change than the other three;
+lean toward the documentation route unless the resize path turns out simple)
+before implementing.

--- a/crates/ui/src/host.rs
+++ b/crates/ui/src/host.rs
@@ -497,15 +497,35 @@ impl ScaleformHostBridge {
         transport_method: &str,
         arguments: Vec<ScaleformValue>,
     ) -> NormalizedCall {
+        // #2965 (UI-D2-02) — `SkyrimAvm1` is the fallback profile for every
+        // non-AS3 movie, so a leading-integer heuristic with no other signal
+        // over-fires on loose demo SWFs and third-party AVM1 content that
+        // never went through `GameDelegate.call` at all, silently dropping
+        // their first real argument and attaching a bogus `request_id`.
+        // Only strip when there's actual evidence this call was routed
+        // through `GameDelegate.call`: the catalog knows the method (real
+        // `GameDelegate.call` assigns a sequential ID to every routed call,
+        // `Command`-kind included — `PlaySound` is `Command` and still
+        // carries one, see `skyrim_catalog_distinguishes_commands_requests_
+        // and_unknowns`; only `Request`-kind ever gets *read back* via
+        // `respond`), or the movie has registered the `respond` callback
+        // `GameDelegate.as` re-enters with the ID. Both signals are already
+        // available here. When neither holds, the whole original
+        // `arguments` list falls through untouched to the generic
+        // `NormalizedCall` below — the raw transport payload is never lost.
         if self.profile == ScaleformProfile::SkyrimAvm1 {
-            if let Some((ScaleformValue::Number(request_id), rest)) = arguments.split_first() {
-                if let Some(request_id) = numeric_request_id(*request_id) {
-                    return NormalizedCall {
-                        method: transport_method.to_string(),
-                        host_object: None,
-                        request_id: Some(request_id),
-                        arguments: rest.to_vec(),
-                    };
+            let looks_like_game_delegate_request =
+                self.catalog.find(transport_method).is_some() || self.has_callback("respond");
+            if looks_like_game_delegate_request {
+                if let Some((ScaleformValue::Number(request_id), rest)) = arguments.split_first() {
+                    if let Some(request_id) = numeric_request_id(*request_id) {
+                        return NormalizedCall {
+                            method: transport_method.to_string(),
+                            host_object: None,
+                            request_id: Some(request_id),
+                            arguments: rest.to_vec(),
+                        };
+                    }
                 }
             }
         }

--- a/crates/ui/src/host/tests.rs
+++ b/crates/ui/src/host/tests.rs
@@ -241,6 +241,37 @@ fn skyrim_catalog_distinguishes_commands_requests_and_unknowns() {
     );
 }
 
+/// #2965 (UI-D2-02) — the leading-integer heuristic used to fire on ANY
+/// `SkyrimAvm1` call, catalog membership be damned, because `SkyrimAvm1` is
+/// also the fallback profile for every non-AS3 movie (loose demo SWFs,
+/// third-party AVM1 content) that never went through `GameDelegate.call` at
+/// all. A call to a method the catalog has never heard of, with no `respond`
+/// callback registered, has zero evidence it's a `GameDelegate` request —
+/// pre-fix it still silently lost its first argument and got a bogus
+/// `request_id` anyway. Both must now survive intact.
+#[test]
+fn an_uncataloged_call_with_no_respond_callback_keeps_its_leading_argument() {
+    let bridge = ScaleformHostBridge::new(ScaleformProfile::SkyrimAvm1);
+
+    bridge.record_call(
+        "UnmappedMethod",
+        &[ExternalValue::from(3_i32), ExternalValue::from("payload")],
+    );
+
+    let call = bridge.drain_calls().pop().unwrap();
+    assert_eq!(call.dispatch, ScaleformHostDispatch::Unknown);
+    assert_eq!(
+        call.request_id, None,
+        "an uncataloged call must not be assigned a request_id it never carried"
+    );
+    assert_eq!(
+        call.arguments,
+        vec![ScaleformValue::from(3.0), ScaleformValue::from("payload")],
+        "the leading integer is real call data here, not a GameDelegate \
+         request ID — it must not be stripped"
+    );
+}
+
 #[test]
 fn skyrim_catalog_is_pinned_sorted_and_profile_specific() {
     let catalog = ScaleformHostCatalog::for_profile(ScaleformProfile::SkyrimAvm1);

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -60,6 +60,14 @@ pub struct UiManager {
     /// Name of the currently loaded menu (e.g. "startmenu").
     pub menu_name: String,
     /// Viewport dimensions for the UI overlay.
+    ///
+    /// #2723 (SAFEUI-07) — fixed at [`Self::new`] time, not live-updated on
+    /// a window resize. Nothing currently drives Ruffle's
+    /// `set_viewport_dimensions` or re-registers the UI texture when the
+    /// swapchain is recreated, so the overlay stretches to the new aspect
+    /// ratio instead of re-rendering at it (visual only — see
+    /// `docs/engine/ui.md`'s "overlay viewport is fixed at load time" note
+    /// for why this cannot over-read the texture upload).
     pub width: u32,
     pub height: u32,
 }
@@ -254,13 +262,15 @@ impl UiManager {
         }
     }
 
-    /// Close the current menu.
-    pub fn close(&mut self) {
-        self.set_input_focus(false);
-        self.player = None;
-        self.visible = false;
-        self.menu_name.clear();
-    }
+    // #2723 (SAFEUI-07) — a `close()` unloading the active menu
+    // (`set_input_focus(false)` + `player = None` + `visible = false` +
+    // `menu_name.clear()`) used to live here. It had zero callers: nothing
+    // in the engine currently drives an interactive menu-dismissal flow
+    // (no Escape-closes-menu handler, no menu-switch trigger) — see
+    // `docs/engine/ui.md`'s "current manager still owns one active menu...
+    // a real menu stack must define which visible layer receives focus"
+    // note. Deleted rather than left as unreachable API surface; trivial
+    // to re-add once that policy exists and needs it.
 }
 
 #[cfg(test)]

--- a/crates/ui/src/player.rs
+++ b/crates/ui/src/player.rs
@@ -79,11 +79,11 @@ const MAX_RECORDED_RESOURCE_LOADS: usize = 64;
 /// an `Arc<Descriptors>` precisely so several players can render against one
 /// device, each with its own `TextureTarget`. Nothing here is per-player.
 ///
-/// **What this trades.** The device now outlives `UiManager::close()` and
-/// lives for the process, instead of being released with each player. That
+/// **What this trades.** The device now outlives any single player and
+/// lives for the process, instead of being released with each one. That
 /// is the point — a menu can reopen at any time, and paying the device-
 /// creation hitch once beats paying it per open — but it does mean one idle
-/// logical device is retained after the last menu closes.
+/// logical device is retained after the last menu's player is dropped.
 ///
 /// A failed creation is deliberately **not** cached, so a transient failure
 /// doesn't permanently disable the UI. If two threads race the very first
@@ -433,28 +433,43 @@ impl SwfPlayer {
 
         // Capture the rendered frame by downcasting to the concrete backend type.
         // This follows the same pattern as Ruffle's exporter crate.
-        let mut changed = false;
+        //
+        // #2722 (SAFEUI-05) — each of these three failure paths must leave
+        // `dirty` set and return `None` instead of falling through to
+        // publish `pixel_buffer` as if capture had succeeded. All three are
+        // unreachable today (the renderer is always this concrete backend
+        // type, `TextureTarget::new` always populates its buffer, and
+        // `pixel_buffer`/the target share one fixed `(width, height)`), but
+        // the pre-fix fallthrough silently reported failure as success —
+        // and cleared `dirty`, so a genuine future failure would never
+        // retry — which is the wrong failure mode if any of those
+        // invariants ever changes.
+        let changed;
         {
             let mut player = self.player.lock().unwrap();
             let renderer = player.renderer_mut();
-            if let Some(wgpu_backend) =
+            let Some(wgpu_backend) =
                 <dyn Any>::downcast_mut::<WgpuRenderBackend<TextureTarget>>(renderer)
-            {
-                if let Some(image) = wgpu_backend.capture_frame() {
-                    let rgba = image.into_raw();
-                    if rgba.len() == self.pixel_buffer.len() {
-                        changed = rgba != self.pixel_buffer;
-                        if changed {
-                            self.pixel_buffer.copy_from_slice(&rgba);
-                        }
-                    } else {
-                        log::warn!(
-                            "Ruffle frame size mismatch: got {} bytes, expected {}",
-                            rgba.len(),
-                            self.pixel_buffer.len()
-                        );
-                    }
-                }
+            else {
+                log::warn!("Ruffle renderer is not the expected WgpuRenderBackend<TextureTarget>");
+                return None;
+            };
+            let Some(image) = wgpu_backend.capture_frame() else {
+                log::warn!("Ruffle capture_frame() returned no image");
+                return None;
+            };
+            let rgba = image.into_raw();
+            if rgba.len() != self.pixel_buffer.len() {
+                log::warn!(
+                    "Ruffle frame size mismatch: got {} bytes, expected {}",
+                    rgba.len(),
+                    self.pixel_buffer.len()
+                );
+                return None;
+            }
+            changed = rgba != self.pixel_buffer;
+            if changed {
+                self.pixel_buffer.copy_from_slice(&rgba);
             }
         }
 
@@ -787,5 +802,48 @@ mod resource_loads_tests {
         player.record_resource_loads(loads);
 
         assert_eq!(player.resource_loads().len(), MAX_RECORDED_RESOURCE_LOADS);
+    }
+}
+
+#[cfg(test)]
+mod render_failure_tests {
+    use super::SwfPlayer;
+
+    /// A minimal, valid, single-frame AVM1 SWF — mirrors
+    /// `resource_loads_tests::minimal_swf`.
+    fn minimal_swf() -> Vec<u8> {
+        let mut header = swf::Header::default_with_swf_version(6);
+        header.num_frames = 1;
+        let mut bytes = Vec::new();
+        swf::write_swf(&header, &[swf::Tag::ShowFrame], &mut bytes)
+            .expect("writing a fixed, minimal in-memory SWF cannot fail");
+        bytes
+    }
+
+    /// #2722 (SAFEUI-05) — a capture failure (forced here via the size-
+    /// mismatch branch: `pixel_buffer` no longer matches the real captured
+    /// frame's length) must leave `dirty` set and return `None`, not
+    /// publish a stale/zeroed frame and clear `dirty` as if capture had
+    /// succeeded — which pre-fix meant a genuine future failure would
+    /// never retry.
+    #[test]
+    fn render_leaves_dirty_set_and_returns_none_on_a_size_mismatch() {
+        let mut player = SwfPlayer::new(&minimal_swf(), 4, 4).unwrap();
+        assert!(player.dirty, "a freshly constructed player starts dirty");
+        // `capture_frame()` will still produce a real 4x4 RGBA buffer from
+        // the actual render; corrupt `pixel_buffer`'s length so the two no
+        // longer match, forcing the size-mismatch branch.
+        player.pixel_buffer.push(0);
+
+        let frame = player.render();
+
+        assert!(
+            frame.is_none(),
+            "a size-mismatch capture must not be published as a real frame"
+        );
+        assert!(
+            player.dirty,
+            "a failed capture must leave dirty set so the next tick retries (#2722)"
+        );
     }
 }

--- a/docs/engine/ui.md
+++ b/docs/engine/ui.md
@@ -264,6 +264,23 @@ integration will need to manage multiple active menus (one per layer);
 that compositing happens inside Ruffle, so the engine-side change is
 about which SWF(s) `UiManager` drives, not about stacking Vulkan quads.
 
+**The overlay viewport is fixed at load time, not live-resized** (#2723 /
+SAFEUI-07). `UiManager::new(w, h)` captures the swapchain extent once;
+`SwfPlayer::from_movie` bakes that size into both Ruffle's viewport and the
+offscreen `TextureTarget`. Nothing currently drives Ruffle's
+`set_viewport_dimensions` or re-registers the UI texture when
+`WindowEvent::Resized` recreates the swapchain (`app_events.rs`), so a
+window resize while a menu is loaded stretches the last-rendered frame to
+the new aspect ratio instead of re-rendering at it. This is confirmed
+visual-only, not a Vulkan hazard: `update_rgba` is always called with the
+menu's original `width`/`height`, matching both the registered texture and
+`pixel_buffer`'s size, so `Texture::from_rgba`'s length assertion cannot
+fire and no staging copy can over-read. Making the overlay track a resize
+needs a real teardown/rebuild of the `SwfPlayer`'s renderer (there is no
+in-place resize path on `TextureTarget`/`WgpuRenderBackend` today) plus a
+texture re-registration call from `main.rs`'s resize handler — tracked as
+follow-up work, not implemented here.
+
 ## Vulkan integration
 
 The UI is drawn at the tail of the main render pass, not in a separate


### PR DESCRIPTION
…d clears dirty

Fix #2723: document the fixed-at-load overlay viewport, delete dead UiManager::close
Fix #2965: gate the AVM1 request-ID strip on real GameDelegate evidence, not any leading integer

#2722 (SAFEUI-05) — SwfPlayer::render's three capture-failure paths (downcast_mut -> None, capture_frame() -> None, rgba.len() != pixel_buffer.len()) all fell through to `self.dirty = false; Some(&self.pixel_buffer)` -- failure reported identically to success, and dirty being cleared meant a real failure would never retry. Rewrote the block with early returns: any of the three paths now returns None and leaves dirty set. All three remain unreachable today (confirmed: the renderer is always the concrete WgpuRenderBackend<TextureTarget>, TextureTarget::new always populates its buffer, and pixel_buffer/the target share one fixed (width, height)) -- the fix is about the code's stated intent matching its behavior if any of those invariants ever changes. Added a real (non-mocked, non-#[ignore]d) regression test: corrupts pixel_buffer's length to force the size-mismatch branch through an actual headless-wgpu render, and asserts render() returns None with dirty still set.

#2723 (SAFEUI-07) -- investigated implementing a live-resize path (UiManager::width/height follow WindowEvent::Resized, Ruffle's set_viewport_dimensions, UI texture re-registration) but there is no in-place resize path on TextureTarget/WgpuRenderBackend today; a real fix needs a full SwfPlayer renderer teardown/rebuild plus main.rs resize-handler plumbing, disproportionate for a confirmed-cosmetic (not a Vulkan hazard) LOW-severity issue in this batch. Took the issue's explicitly-offered alternative: documented the fixed-at-load-time behavior on UiManager::width doc comment and in docs/engine/ui.md (why it can't over-read the texture upload), so it reads as an intentional, tracked limitation rather than an oversight. Confirmed UiManager::close had zero callers anywhere (menu dismissal/switching isn't wired up anywhere in the engine yet -- no Escape-closes-menu handler exists for it to serve) and deleted it rather than inventing a caller, which would mean guessing product behavior nothing in the codebase specifies; also fixed a stale doc-comment reference to it in player.rs. No regression test added for this one -- it's a pure documentation + dead-code-deletion change with no behavior to pin.

#2965 (UI-D2-02) -- normalize_call's leading-integer-strips-as-request-ID heuristic fired for ANY SkyrimAvm1 call with a finite non-negative integral leading Number, with no signal distinguishing a real GameDelegate.call from a direct ExternalInterface.call. SkyrimAvm1 is the fallback profile for every non-AS3 movie, so this over-fired on loose demo SWFs and third-party AVM1 content too, silently dropping their first real argument and attaching a bogus request_id. Gated the strip on catalog.find(method).is_some() (the method is known to the catalog at all) OR has_callback("respond") -- both already available at the call site. Note this differs from the issue's literal suggested "catalog returns a Request entry": gating on kind == Request alone broke the crate's own existing
skyrim_catalog_distinguishes_commands_requests_and_unknowns test, because PlaySound is a correctly-cataloged Command-kind method that still carries a real GameDelegate request ID on the wire (real GameDelegate.call assigns a sequential ID to every routed call, Command-kind included; only Request-kind ever reads the response back via respond) -- confirmed by running that test red before settling on "known to catalog at all" instead. Added a dedicated regression test (an_uncataloged_call_with_no_respond_callback_keeps_its_ leading_argument) pinning exactly the issue's ask: an uncataloged AVM1 call with a leading integer keeps its full argument list and gets no request_id. SIBLING check: the Fallout4Avm2 normalize path only strips a method-name prefix, no argument stripping at all -- no equivalent implicit-argument assumption exists there.

#2729 (TD3-2026-08-12-02) -- already fully fixed before this session (verified, no code change): ROADMAP.md's M48 row no longer mentions "input" in its remaining-work list (fixed in 4e1afcbe), and docs/feature-matrix.md already has the exact "Scaleform menu input routing + modal focus | v M48 (3ea5e275)" row the issue's suggested fix asked for. Closing with no commit content for this one.

Verification: cargo test -q -p byroredux-ui and cargo test -q -p byroredux both green, plus one final cargo test -q --workspace --lib --bins pass across every crate with zero failures. All touched files are cargo fmt-clean; the same pre-existing, unrelated formatting drift in crates/core/src/ecs/components/material.rs:1706 (present before this session) was confirmed and left untouched.