### PR TITLE
Fix #3125: swim_vertical_velocity's damping is now dt-correct, not fr…

### DIFF
--- a/.claude/issues/3122 3125 3128 3130/ISSUE.md
+++ b/.claude/issues/3122 3125 3128 3130/ISSUE.md
@@ -1,0 +1,58 @@
+# Issues 3122, 3125, 3128, 3130 — Physics (PHYSAL) audit findings, 2026-08-20
+
+All four originate from `docs/audits/AUDIT_PHYSICS_2026-08-20.md`.
+
+## #3122 (MEDIUM, bug+performance) — apply_buoyancy fast path unreachable in shipping binary
+- `crates/physics/src/water.rs:484-511` — `waves_active` gate is effectively always true
+  (TotalTime always present at boot; WaterMaterial::wave_amplitude default 0.05 >> 1e-4 threshold),
+  so the "quiesced scene" fast path never engages in the real binary.
+- Regression test `buoyant_body_sleeps_so_static_fast_path_re_engages` (water.rs:1296) doesn't
+  insert TotalTime, so it tests an unreachable config.
+- Fix: choose (a) drop dead waves_active gate + cheaper reachable check (surfaces non-empty AND
+  some body has WaterContact/awake), or (b) event-driven wave following (only bodies with
+  WaterContact). Insert TotalTime into the test. Restate docstring precondition.
+
+## #3125 (MEDIUM, bug) — swim_vertical_velocity frame-rate dependent damping
+- `byroredux/src/systems/character.rs:964-984` — `prev_velocity * 0.72 + spring * dt` mixes
+  dt-free per-frame decay (0.72) with dt-scaled spring term.
+- Fix: replace 0.72 with dt-correct exponential decay `exp(-SWIM_DAMPING * dt)` calibrated so
+  `SWIM_DAMPING ≈ 19.7` reproduces 0.72 at 60fps. Add multi-dt regression test.
+- Sibling check: jump branch at :975-978 also has `prev_velocity * 0.15` raw term — check too.
+
+## #3128 (LOW, bug) — advance_breath refills breath reserve on zero-dt tick
+- `byroredux/src/systems/character.rs:994-1010` — `!head_submerged || dt <= 0.0` collapses two
+  cases; dt<=0.0 should be a no-op, not full refill.
+- Fix: split branches — `!head_submerged` → (MAX_BREATH, zero); `dt <= 0.0` → preserve previous
+  breath/remainder.
+
+## #3130 (LOW, documentation/doc-rot) — pull_dynamic stale lock-ordering comment
+- `crates/physics/src/sync.rs:1075-1080` — comment describes drops that now happen ~85 lines
+  earlier (sync.rs:1002-1003, post #2404 restructure). Move comment to the actual drop site;
+  reword to state invariant directly (Transform write never taken while RapierHandles/
+  RigidBodyData read guard live) — preserve #2135 ABBA-risk mention.
+
+## Domain
+All four → `byroredux-physics` crate (Havok→Rapier physics layer) + #3125/#3128 also touch
+`byroredux` binary (`byroredux/src/systems/character.rs`).
+
+## Resolution
+
+- **#3125, #3128, #3130** — fixed in this pass (see commit).
+- **#3122 — already fixed, closed without a new commit.** It's a duplicate of #3135
+  (same root cause, filed from the performance-audit angle, already CLOSED). #3135's fix
+  landed in `d628acfc` ("fix(watal): restore buoyancy quiescence", 2026-08-21) — replaced
+  the dead `waves_active` gate with `waves_require_contact_rescan`, which only requires a
+  rescan when a live `WaterContact` exists near the surface, so a water cell with nothing
+  floating in it still takes the quiesced-scene fast path. Verified: unit test
+  `default_authored_waves_only_rescan_nearby_live_contacts` (`water.rs:1008`) pins exactly
+  this — a settled cell running `WaterMaterial::default()` amplitude does NOT force a
+  rescan; a live contact inside the crest band does. Full `byroredux-physics` suite
+  (148 tests) passes at HEAD.
+  - The `buoyant_body_sleeps_so_static_fast_path_re_engages` test's lack of `TotalTime`
+    is not a masking bug in practice: it pins a *different* invariant
+    (`PhysicsWorld::step`'s own no-awake-bodies fast path / wake discipline), which never
+    depended on `waves_active`/`waves_require_rescan` — the wake decision is driven solely
+    by the ≥0.1 BU depth-delta check at `water.rs:679-684`, unaffected by whether the scan
+    itself runs every frame. No SIBLING gap found in the other two physics fast-path tests
+    (`world.rs` — `wake_re_engages_stepping`, `per_frame_forces_can_be_applied_without_arming_the_fast_path`);
+    neither touches `TotalTime`/waves.

--- a/byroredux/src/systems/character.rs
+++ b/byroredux/src/systems/character.rs
@@ -957,6 +957,12 @@ fn player_water_state(
 /// game-invariant; water records do not author movement physics.
 const SWIM_HEIGHT_SCALE: f32 = 0.35;
 
+/// Per-second exponential decay rate for the swim vertical-velocity spring
+/// (see [`swim_vertical_velocity`]). Chosen so `exp(-SWIM_DAMPING / 60.0) ==
+/// 0.72`, reproducing the originally tuned 60 fps feel while making the
+/// integrator dt-correct at any refresh rate (#3125).
+const SWIM_DAMPING: f32 = 19.71;
+
 #[inline]
 fn swimlevel_reached(center_y: f32, surface_y: f32, half_span: f32) -> bool {
     center_y < surface_y - half_span * SWIM_HEIGHT_SCALE
@@ -983,7 +989,12 @@ pub(crate) fn swim_vertical_velocity(
     }
     let target_y = surface_y - half_span * SWIM_HEIGHT_SCALE;
     let spring = (target_y - center_y) * (5.0 + 7.0 * fraction.clamp(0.0, 1.0));
-    (prev_velocity * 0.72 + spring * dt).clamp(-120.0, 160.0)
+    // #3125 — the decay must be per-second, not per-frame, or the swimmer's
+    // approach speed to the waterline varies with refresh rate (a fixed
+    // `* 0.72` per call decays ~4.8x faster in wall-clock terms at 144 fps
+    // than at 30 fps). `integrate_vertical`'s terrestrial sibling is already
+    // dt-correct via `gravity * dt`; this mirrors that.
+    (prev_velocity * (-SWIM_DAMPING * dt).exp() + spring * dt).clamp(-120.0, 160.0)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1004,12 +1015,26 @@ fn advance_breath(
 ) -> (f32, DrowningDamage) {
     const MAX_BREATH: f32 = 15.0;
     const DROWNING_DAMAGE_PER_SECOND: f32 = 12.0;
-    if !head_submerged || dt <= 0.0 {
+    if !head_submerged {
         return (
             MAX_BREATH,
             DrowningDamage {
                 whole: 0.0,
                 remainder: 0.0,
+            },
+        );
+    }
+    if dt <= 0.0 {
+        // #3128 — no time passed, so this must be a no-op: preserve the
+        // accumulated breath and fractional damage instead of refilling the
+        // reserve. `!head_submerged` above is the only case that should
+        // reset state; collapsing the two into one guard let a zero-dt tick
+        // (paused / re-entrant call) refill a drowning player to full air.
+        return (
+            previous_breath.clamp(0.0, MAX_BREATH),
+            DrowningDamage {
+                whole: 0.0,
+                remainder: previous_damage_remainder.max(0.0),
             },
         );
     }
@@ -1400,6 +1425,50 @@ mod tests {
         assert!(v > -120.0, "water drag must reduce a falling speed");
     }
 
+    /// #3125 — one step at 1/60s and two half-steps at 1/120s must land close
+    /// together. The old `prev_velocity * 0.72` decay was per-frame, not
+    /// per-second, so it diverged sharply across frame rates (~7.8 BU/s here
+    /// vs the ~0.15 BU/s of remaining Euler discretization error below).
+    #[test]
+    fn swim_damping_is_frame_rate_independent() {
+        let (center_y, surface_y, half_span, fraction, jump_velocity) =
+            (70.0, 100.0, 50.0, 0.6, 380.0);
+        let full = swim_vertical_velocity(
+            -40.0,
+            center_y,
+            surface_y,
+            half_span,
+            fraction,
+            1.0 / 60.0,
+            jump_velocity,
+            false,
+        );
+        let half1 = swim_vertical_velocity(
+            -40.0,
+            center_y,
+            surface_y,
+            half_span,
+            fraction,
+            1.0 / 120.0,
+            jump_velocity,
+            false,
+        );
+        let half2 = swim_vertical_velocity(
+            half1,
+            center_y,
+            surface_y,
+            half_span,
+            fraction,
+            1.0 / 120.0,
+            jump_velocity,
+            false,
+        );
+        assert!(
+            (full - half2).abs() < 0.3,
+            "swim damping should be ~frame-rate independent: one 1/60s step = {full}, two 1/120s steps = {half2}"
+        );
+    }
+
     #[test]
     fn authored_water_wave_height_is_bounded_and_time_varying() {
         let material = WaterMaterial {
@@ -1444,6 +1513,19 @@ mod tests {
         let (_, second) = advance_breath(0.0, first.remainder, true, 1.0 / 60.0);
         assert!(second.whole >= 0.0);
         assert!(second.remainder < 1.0);
+    }
+
+    /// #3128 — a zero-dt tick while submerged must be a no-op, not a full
+    /// refill. Only `!head_submerged` (surfacing) should reset the reserve.
+    #[test]
+    fn zero_dt_tick_while_submerged_does_not_refill_breath() {
+        let (breath, damage) = advance_breath(3.0, 0.6, true, 0.0);
+        assert_eq!(breath, 3.0, "no time passed — breath must not be refilled");
+        assert_eq!(damage.whole, 0.0, "no time passed — no damage accrues");
+        assert_eq!(
+            damage.remainder, 0.6,
+            "accumulated fractional damage must survive a zero-dt tick"
+        );
     }
 
     #[test]

--- a/crates/physics/src/sync.rs
+++ b/crates/physics/src/sync.rs
@@ -1067,6 +1067,13 @@ fn pull_dynamic(world: &World) {
             dynamic_handles.push((entity, handles.body));
         }
     }
+    // #2135 — the `RapierHandles`/`RigidBodyData` read guards are dropped
+    // here, before the `Transform` write lock is ever taken below (`updates`
+    // carries everything the write pass needs). `character_controller_system`
+    // acquires the reverse pair — a `Transform` read held across
+    // `RapierHandles` — so a `Transform` write ever overlapping a live
+    // `RapierHandles`/`RigidBodyData` read here would be the ABBA edge
+    // against it.
     drop(handles_q);
     drop(body_q);
 
@@ -1142,11 +1149,9 @@ fn pull_dynamic(world: &World) {
         }
     }
 
-    // Drop the `RapierHandles`/`RigidBodyData` read guards before taking
-    // the `Transform` write lock below — `updates` already carries
-    // everything needed. `character_controller_system` acquires the
-    // reverse pair (`Transform` read held across `RapierHandles`), so
-    // overlapping the two orders would be an ABBA risk (#2135).
+    // The `RapierHandles`/`RigidBodyData` read guards are already dropped
+    // (see the #2135 note above) — nothing here holds them across this
+    // `Transform` write.
     if updates.is_empty() {
         return;
     }


### PR DESCRIPTION
…ame-rate dependent

Fix #3128: advance_breath no longer refills the breath reserve on a zero-dt tick
Fix #3130: relocate pull_dynamic's #2135 lock-ordering comment to where the guards are actually dropped

swim_vertical_velocity mixed a dt-scaled spring term with a dt-free multiplicative decay (`prev_velocity * 0.72`), so the swimmer's approach speed to the waterline varied ~4.8x across the 30-144 fps range the project targets. Replaced the fixed per-frame factor with a per-second exponential decay (`SWIM_DAMPING`, calibrated so it reproduces the previous 60 fps feel), matching the dt-correct integration already used by the terrestrial sibling `integrate_vertical`. Added a regression test asserting two 1/120s steps land close to one 1/60s step. Left the one-shot jump-impulse branch (`prev_velocity * 0.15`) unchanged — it fires at most once per jump (latched by `wants_jump`), so it does not compound across frames the way a per-tick decay does.

advance_breath collapsed "surfaced" (`!head_submerged`) and "no time passed" (`dt <= 0.0`) into one early return that always refilled the breath reserve to MAX_BREATH and discarded the accumulated fractional drowning damage. A zero-dt tick should be a no-op. Split the guard so only `!head_submerged` refills; `dt <= 0.0` now preserves the previous breath and damage remainder. Added a regression test pinning this. (character_controller_system's own `dt <= 0.0` early return makes this currently unreachable in the shipping loop, so this is hardening rather than an observed bug, per the audit finding.)

pull_dynamic's lock-ordering comment described drops (`RapierHandles`/ `RigidBodyData` read guards released before the `Transform` write lock) that the #2404 storage/resource-guard split had already moved ~75 lines earlier. Moved the comment to the actual drop site and restated it as the invariant itself, keeping the #2135 ABBA-risk cross-reference to character_controller_system.

#3122 (apply_buoyancy's quiesced-scene fast path) is a duplicate of the already-closed #3135 — its fix (waves_require_contact_rescan, landed in d628acfc) already addresses the described defect and is pinned by `default_authored_waves_only_rescan_nearby_live_contacts`; closed separately with no additional code change needed.

Verified: cargo test -q -p byroredux-physics (148 passed), cargo test -q -p byroredux (1522 passed + platform-gated ignores), cargo test -q --workspace --exclude byroredux-scripting (all green). byroredux-scripting's own lib/test suite (328 tests) passes separately; its `fragment_coverage` example fails to compile on main independent of this change (pre-existing, out of scope).