### PR TITLE
Fix #3217: add nested-ladder regression test for the LVLI 0x02-vs-0x0…

### DIFF
--- a/.claude/issues/3217/ISSUE.md
+++ b/.claude/issues/3217/ISSUE.md
@@ -1,99 +1,50 @@
-# #3217 — SKY-2026-08-20-D3-01: TES5 LVLF bit 0x02 is a per-count re-roll, not "take all" — 1,491 of 5,118 Skyrim NPCs over-expand their outfit (mean 38.7 items vs 2.5, worst case 1,612)
+# Issue #3217 — SKY-2026-08-20-D3-01
 
-**Issue**: #3217 — https://github.com/matiaszanolli/ByroRedux/issues/3217
-**Finding ID**: `SKY-2026-08-20-D3-01`
-**Severity**: HIGH
-**Dimension**: 3 — NPC equip (M41)
-**Audit**: `/audit-skyrim` — `docs/audits/AUDIT_SKYRIM_2026-08-20.md` (HEAD `bb0b92f2`, 2026-08-20 comprehensive suite)
-**Labels**: high, legacy-compat, import-pipeline, gameplay, bug
-**Filed**: 2026-08-20 · `/audit-publish`
+TES5 LVLF bit 0x02 ("calculate for each item in count") is treated as a
+multi-pick trigger identical to 0x04 ("Use All"), but it actually means
+"repeat the single roll `count` times" — for count==1 (the vanilla case)
+that's single-pick. Current code at `crates/plugin/src/equip.rs:411`
+treats `flags & (0x02 | 0x04) != 0` as multi-pick, over-expanding 1,491 of
+5,118 Skyrim.esm NPCs' outfits (mean 38.7 items vs correct 2.5).
 
----
-
-**Audit**: `/audit-skyrim` — `docs/audits/AUDIT_SKYRIM_2026-08-20.md` (Dim 3 — NPC equip / M41), HEAD `bb0b92f2`
-**Finding ID**: `SKY-2026-08-20-D3-01`
-
-- **Severity**: HIGH
-- **Status**: **NEW — the unfixed half of CLOSED #3069.** #3069 fixed the `0x04` "Use All" half exactly as it recommended (verified in place at `equip.rs:411`, pinned by the test at `:791`). #3069's own Impact section also called out *"the inverse error is also present … over-equipping"* — **that half shipped unchanged.** Filed as a new issue rather than reopening because it is a separate rule with its own measured blast radius; cross-referenced both ways.
-
-## Location
-
-`crates/plugin/src/equip.rs:411`
-
-```rust
-let multi_pick = lvli.flags & (0x02 | 0x04) != 0;
-if multi_pick { … }
-```
-
-Doc premise at `:346-350`.
-
-## Description
-
-The resolver treats `0x02` and `0x04` as interchangeable multi-pick triggers. They are not:
-
-- TES5 `LVLF` bit 2 (`0x04`, xEdit **"Use All"**) means *add every entry*.
-- TES5 `LVLF` bit 1 (`0x02`, **"Calculate for each item in count"**) means *repeat the single roll `count` times*.
-
-Expanding every eligible entry on a `0x02` list turns a **level-tier ladder** into a bundle.
-
-## Evidence
-
-Independent Python walk of `Skyrim.esm`'s OTFT->LVLI closure (481 `OTFT`, 3 075 `LVLI`, 5 118 `NPC_`):
-
-```
-OTFT-reachable LVLI:                    279
-  LVLF histogram: 0x03 x162, 0x04 x49, 0x02 x30, 0x00 x37, 0x01 x1
-  bit 0x02 set AND bit 0x04 clear:      192   (69 %)
-OTFTs containing >= 1 such list:      70 / 481
-NPC_ whose default outfit does:     1491 / 5118  (29 %)
-```
-
-A representative list — unambiguously a tier ladder, not a set:
-
-```
-LVLI 000FDA10 LItemEnchArmorHeavyGauntletsNoDragon  flags=0x03
-    lvl= 1 SublistEnchArmorIronGauntlets01
-    lvl= 4 SublistEnchArmorIronGauntlets02
-    lvl= 7 SublistEnchArmorSteelGauntlets01
-    lvl=13 SublistEnchArmorDwarvenGauntlets02
-    lvl=19 SublistEnchArmorSteelPlateGauntlets02
-    lvl=26 SublistEnchArmorOrcishGauntlets03
-    lvl=33 SublistEnchArmorEbonyGauntlets03      (18 entries total)
-```
-
-Each sublist is itself `flags=0x03` with five enchantment variants, so the expansion multiplies. Simulating both rules over every NPC that has an outfit (3 633 of them) at `actor_level = 38`:
-
-```
-mean flattened outfit size, current rule (0x02|0x04):   38.74 items
-mean flattened outfit size, single-pick on 0x02:         2.50 items
-NPCs whose outfit flattens to > 20 items:             1238 / 3633
-worst case: dunIronbindBeemJa                          1612 items  (single-pick: 5)
-            DA13Orchendor                               219 items  (single-pick: 6)
-            DA13EncAfflicted05* family (x several)      196 items  (single-pick: 2)
-```
-
-## Impact
-
-**1 491 of 5 118 `Skyrim.esm` NPCs over-expand their outfit** — 34 % of *outfitted* NPCs receive 20+ spurious inventory rows, mean **38.7 items against a correct 2.5**, worst case **1 612 `ItemStack`s on a single actor**.
-
-The *worn* result is mostly salvaged by downstream luck: `equipment_slots.equip()` is last-write-wins over the expansion order (`byroredux/src/npc_spawn.rs:866`) and the weapon picker takes max damage (`:846-853`), so the highest tier usually ends up on the body. But that is an accident of ordering, not a rule — and every inventory-facing surface is wrong by an order of magnitude: loot, barter, pickpocket, save-snapshot size, per-actor allocation.
-
-FO3/FNV/Oblivion `LVLF` has no `0x04`, so the shared `0x02` arm makes this Skyrim/FO4-shaped.
+## Fix
+Make `0x04` the sole multi-pick trigger; `0x02` alone routes to single-pick.
 
 ## Related
+- #3069 (CLOSED) — fixed the 0x04 half; this is the 0x02 half it named but
+  didn't ship.
+- Shared arm affects FO3/FNV/Oblivion/FO4 too (SIBLING check) — but LVLF
+  0x04 doesn't exist pre-Skyrim, so need to verify 0x02 semantics are
+  identical there.
 
-- **#3069** (CLOSED) — fixed the complementary `0x04` half; this is the half it named but did not ship. Please cross-link on close.
-- #896 — LVLI dispatch in outfits
-- #2094 — occupancy filter (operates on meshes; does not prune the inventory)
-- #2956 — `Use Stats` template inheritance, same delta
+## Domain
+`byroredux-plugin` (ESM record parsing / leveled list resolution).
 
-## Suggested Fix
+## Resolution
 
-Make `0x04` the sole multi-pick trigger and route `0x02` back to the single-pick arm. `0x02`'s faithful meaning — repeat the roll `count` times — is the same base FormID `count` times, which for `count == 1` (the vanilla case in every list sampled above) is exactly single-pick.
+The code fix, doc comments, and the exact fixture test the issue asked for
+(`flags = 0x03` ladder, levels 1/4/7, asserting a single expansion) were
+**already landed on `main`** in commit `bfdc3d3f` ("Add tests for body piece
+masks and equip state handling", 2026-08-23) — both explicitly reference
+`#3217`. Confirmed at HEAD:
+- `crates/plugin/src/equip.rs:411` — `multi_pick = lvli.flags & 0x04 != 0`
+  (0x02 no longer treated as multi-pick).
+- `expand_leveled_calculate_each_item_still_picks_one_tier` test exists and
+  passes.
 
-Pin with a fixture `LVLI` carrying `flags = 0x03` and level-1/4/7 entries asserting **one** expansion, alongside the existing `flags = 0x04` all-expand guard at `:791`.
+**SIBLING** — the `0x02` arm is shared by all games (LVLI/LVLF parsing is
+one code path, `container.rs:190`). `0x04` ("Use All") is a TES5/FO4-only
+xEdit flag; FO3/FNV/Oblivion content never sets it, so `multi_pick` is
+`false` there regardless — the fix is not merely inert but *correct* for
+those games too, since `0x02`'s "repeat the roll `count` times" meaning is
+identical across the family and was never "Use All" pre-Skyrim.
 
-## Completeness Checks
-- [ ] **SIBLING**: the same `0x02` arm is shared by FO3/FNV/Oblivion/FO4 leveled-list expansion — confirm the change is correct (or inert) for each
-- [ ] **TESTS**: a fixture `LVLI` with `flags = 0x03` and a level ladder asserts a single expansion; the existing `0x04` all-expand guard still passes
-- [ ] **TESTS**: an outfit-level test asserts the flattened size for a known multi-tier `OTFT` (e.g. `dunIronbindBeemJa`) is single-digit, not four-digit
+**Added in this pass**: the second suggested test was still missing — an
+outfit-level regression proving nested `0x03` ladders (a tier ladder whose
+entries are themselves `0x03` enchant-variant sublists, the exact
+`dunIronbindBeemJa` shape) don't combinatorially explode.
+`expand_leveled_nested_tier_ladders_do_not_combinatorially_explode`
+(`crates/plugin/src/equip.rs`) asserts the flattened result is a single
+item, not 18×5. (A literal `dunIronbindBeemJa` fixture would need real
+Skyrim.esm data baked into the test, which the suite avoids elsewhere —
+this synthetic fixture reproduces the same two-level-ladder shape.)

--- a/crates/plugin/src/equip.rs
+++ b/crates/plugin/src/equip.rs
@@ -782,6 +782,47 @@ mod tests {
         assert_eq!(out, vec![0x00BB_BBBB]);
     }
 
+    /// #3217 — the real-world shape (`dunIronbindBeemJa`'s outfit) that
+    /// motivated this fix: a `flags = 0x03` tier ladder whose entries are
+    /// themselves `flags = 0x03` enchant-variant sublists. Treating `0x02`
+    /// as multi-pick multiplied the two levels of expansion together
+    /// (18 tiers × 5 variants → hundreds of items on one actor); with only
+    /// `0x04` triggering multi-pick, both levels single-pick and the whole
+    /// outfit slot resolves to exactly one item.
+    #[test]
+    fn expand_leveled_nested_tier_ladders_do_not_combinatorially_explode() {
+        let mut idx = empty_index();
+        // Five enchant variants for the tier the actor's level actually
+        // reaches (level 4) — a `0x03` sublist, same as the tier itself.
+        for variant in 0..5u32 {
+            add_armo(&mut idx, 0x00A0_0000 + variant);
+        }
+        add_lvli(
+            &mut idx,
+            0x00B0_0000, // tier-4 enchant sublist
+            0x03,
+            (0..5u32)
+                .map(|variant| (1, 0x00A0_0000 + variant, 1))
+                .collect(),
+        );
+        // A second tier the actor's level does NOT reach, to prove the
+        // outer ladder still single-picks instead of unioning tiers.
+        add_lvli(&mut idx, 0x00C0_0000, 0x03, vec![(1, 0x00A0_0000, 1)]);
+        add_lvli(
+            &mut idx,
+            0x00D0_0000, // outer tier ladder
+            0x03,
+            vec![(1, 0x00C0_0000, 1), (4, 0x00B0_0000, 1)],
+        );
+        let mut out = Vec::new();
+        expand_leveled_form_id(0x00D0_0000, 5, &idx, &mut out);
+        assert_eq!(
+            out.len(),
+            1,
+            "nested 0x03 ladders must single-pick at every level, not multiply: got {out:?}"
+        );
+    }
+
     #[test]
     fn expand_leveled_use_all_flag_lands_all_eligible() {
         let mut idx = empty_index();


### PR DESCRIPTION
…4 multi-pick fix

The actual defect (TES5 LVLF bit 0x02 "calculate for each item in count" treated as a multi-pick trigger identical to 0x04 "Use All", over-expanding 1,491 of 5,118 Skyrim.esm NPCs' outfits) and its fixture regression test were already fixed on main in bfdc3d3f, prior to this pass — verified `multi_pick = lvli.flags & 0x04 != 0` at equip.rs:411 and the `expand_leveled_calculate_each_item_still_picks_one_tier` test both stand.

What was still missing from the issue's completeness checklist: an outfit-level test proving the real-world failure shape — a `0x03` tier ladder whose own entries are themselves `0x03` enchant-variant sublists (the `dunIronbindBeemJa` pattern, which multiplied 18 tiers x 5 variants into hundreds of items) — doesn't combinatorially explode when both ladder levels correctly single-pick. Added
`expand_leveled_nested_tier_ladders_do_not_combinatorially_explode`, asserting the flattened result is exactly one item.

Also confirmed the SIBLING concern: the `0x02`/`0x04` arm is one shared code path across all games. `0x04` is a TES5/FO4-only xEdit flag that FO3/FNV/Oblivion content never sets, so the fix is correct (not merely inert) for the whole family, since `0x02`'s "repeat the roll count times" meaning never differed across games.

Verified: cargo test -q -p byroredux-plugin (780 passed), cargo test -q --workspace --exclude byroredux-scripting (all green; that crate's own example-build failure is pre-existing and unrelated, tracked separately).