### PR TITLE
Fix #2262 #2263 #2273: repair three stale audit-tool/comment passages…

### DIFF
--- a/.claude/commands/audit-tech-debt/SKILL.md
+++ b/.claude/commands/audit-tech-debt/SKILL.md
@@ -117,7 +117,7 @@ Tech-debt findings default to **LOW** (see `_audit-severity.md`). Promote only o
      echo "TODO/FIXME/HACK/XXX:   $(grep -RInE '(TODO|FIXME|HACK|XXX)\b' crates byroredux | wc -l)"
      echo "allow(dead_code):      $(grep -RInE 'allow\(dead_code\)' crates byroredux | wc -l)"
      echo "unimplemented!/todo!(): $(grep -RInE 'unimplemented!|todo!\(\)' crates byroredux | wc -l)"
-     echo "#[ignore] tests:        $(grep -RIn '#\[ignore\]' . | wc -l)"
+     echo "#[ignore] tests:        $(grep -RIn '^\s*#\[ignore\]' --include='*.rs' crates byroredux | wc -l)"
      echo "files >2000 production LOC: $(for f in $(find crates byroredux -name '*.rs'); do echo "$(prod_loc "$f")"; done | awk '$1>2000' | wc -l)"
      echo "test files >2000 total LOC (lower priority, separate bucket): $(find crates byroredux -name '*.rs' -exec wc -l {} + | awk '$1>2000 && $2!="total"' | wc -l | xargs -I{} echo {})"
    } > /tmp/audit/tech-debt/baseline.txt
@@ -125,7 +125,10 @@ Tech-debt findings default to **LOW** (see `_audit-severity.md`). Promote only o
    Orientation only (will drift — re-run, never quote): the marker total runs ~20,
    `unimplemented!/todo!()` is currently **0** (the engine prefers explicit
    fallbacks over panics — a fresh `todo!()` is therefore notable), `#[ignore]`
-   runs in the mid-hundreds (mostly Vulkan/smoke gating, not debt).
+   runs in the low hundreds when scoped to `.rs` sources under `crates`/`byroredux`
+   (mostly Vulkan/smoke gating, not debt) — do not compare against a raw
+   whole-repo grep, which also matches markdown prose mentioning the literal
+   string `#[ignore]` (#2262).
    The **production**->2000-LOC set (Dim 1's actual subject, re-verified
    2026-08-19 with *prod_loc*) is currently 4 files: `context/mod.rs`
    (~4060), `context/draw.rs` (~3490 — most of its file-total length, not
@@ -304,8 +307,12 @@ grep -RInE '(TODO|HACK)' crates/renderer/shaders/
 - Does it name a milestone (M21, M29, …) now complete per ROADMAP.md?
 - `// TODO: implement` on a path now reachable from a shipped CLI flag → promote (see severity table).
 - **False positives to exclude**: `XXXX` is the ESM extended-size sub-record tag
-  (`crates/plugin/src/esm/reader.rs`, `records/misc/magic.rs`) — protocol, not a
-  marker. `// FIXME note` referencing a *reference implementation's* FIXME (e.g.
+  — protocol, not a marker. Key this on comment content ("references the ESM
+  `XXXX` extended-size escape"), not an enumerated file list — new legitimate
+  consumers appear over time (past sites: `esm/reader.rs`,
+  `esm/cell/wrld.rs`; `records/misc/magic.rs` uses the literal `*b"XXXX"` byte
+  pattern as an arbitrary-wrong-type test sentinel, same false-positive class).
+  `// FIXME note` referencing a *reference implementation's* FIXME (e.g.
   `crates/bgsm/src/bgem.rs`) is documentation of upstream, not our debt.
 - **Must-not-delete**: the third-party attribution block atop
   `crates/renderer/shaders/triangle.frag` (GLSL-PathTracer MIT notice + Burley
@@ -374,7 +381,7 @@ cargo machete 2>/dev/null || echo "cargo machete not installed — scan Cargo.to
 ### Dimension 9: Test Hygiene
 **Discovery**:
 ```bash
-grep -RIn '#\[ignore\]' . | grep -v target/
+grep -RIn '^\s*#\[ignore\]' --include='*.rs' crates byroredux
 ```
 Most `#[ignore]`s gate Vulkan/smoke tests that need a GPU or on-disk game data —
 those are **not** debt. Triage the rest:

--- a/.claude/issues/2262 2263 2264 2273/ISSUE.md
+++ b/.claude/issues/2262 2263 2264 2273/ISSUE.md
@@ -1,0 +1,28 @@
+# Issues 2262, 2263, 2264, 2273 — doc-rot batch fix
+
+## #2262 — audit-tech-debt/SKILL.md #[ignore]-count baseline recipe unscoped
+- `grep -RIn '#\[ignore\]' .` scans whole repo textually (323), including markdown
+  self-references, instead of scoping to `.rs` sources under crates/byroredux (135
+  raw mentions, 96 actual attribute lines).
+- Fix: scope both Phase-1 baseline grep and Dimension-9 discovery grep to
+  `--include='*.rs' crates byroredux`, matching the other two baseline metrics
+  in the same block. Recommended: `grep -RIn '^\s*#\[ignore\]' --include='*.rs' crates byroredux | wc -l`
+
+## #2263 — XXXX-protocol false-positive exclusion list stale
+- `.claude/commands/audit-tech-debt/SKILL.md` Dimension-5 exclusion note only names
+  `reader.rs` and `records/misc/magic.rs`.
+- Commit 560c6741d (#1849) added two more legit references:
+  `crates/plugin/src/esm/cell/wrld.rs:175`, `crates/plugin/src/esm/cell/mod.rs:871`
+- Fix: extend file list, or better, key exclusion on comment content instead of file paths.
+
+## #2264 — ROADMAP.md calls PACK/QUST/DIAL/MESG/PERK/SPEL/MGEF "stubs"
+- **Already fixed** by an unrelated commit `f6555b7b` (2026-08-19), 17 days after
+  this issue was filed (2026-08-02). ROADMAP.md:1021 already reads "PACK /
+  QUST / DIAL / MESG / PERK / SPEL / MGEF now fully parsed (#446/#447 closed;
+  see M24.2/M43 rows above for decode detail)" — exactly what the issue asked
+  for. No code change needed; closing with a note pointing at that commit.
+
+## #2273 — MaterialTable collision-policy comment stale field count
+- `crates/renderer/src/vulkan/material.rs:1143` says "75 scalar fields" but
+  GpuMaterial has 87 fields / 348 bytes since 2026-07-27 growth.
+- Fix: update to 87, or reference `size_of::<GpuMaterial>()` instead of restating count.

--- a/crates/renderer/src/vulkan/material.rs
+++ b/crates/renderer/src/vulkan/material.rs
@@ -1328,7 +1328,10 @@ impl MaterialTable {
     /// one — a hash collision (or a drift between the producer hash
     /// and `hash_gpu_material_fields`) fires a panic with the colliding
     /// hash in the message. In release we trust the hash; collisions
-    /// (rare on FxHash's 64-bit output over 92 scalar fields, #1368)
+    /// (rare on FxHash's 64-bit output over `GpuMaterial`'s full scalar
+    /// field set — see `size_of::<GpuMaterial>()`, currently pinned by
+    /// `gpu_material_size_is_432_bytes`, rather than restating a field
+    /// count here that drifts on every struct growth, #1368/#2273)
     /// would silently alias to the first-seen material at that hash.
     pub fn intern_by_hash(
         &mut self,


### PR DESCRIPTION
…; #2264 already fixed

#2262: audit-tech-debt/SKILL.md's Phase-1 baseline and Dimension-9 discovery greps for '#[ignore]' scanned the whole repo textually, picking up markdown prose (including the skill's own discovery line and prior audit reports quoting the count) instead of just .rs sources. Both now scoped to --include='*.rs' crates byroredux, matching the other two baseline metrics in the same block. Also corrected the stale 'mid-hundreds' orientation figure and warned against comparing against a raw whole-repo grep.

#2263: the Dimension-5 XXXX-protocol false-positive exclusion enumerated reader.rs and records/misc/magic.rs by file path, missing esm/cell/wrld.rs (added by 560c6741d, #1849). Investigation found the mod.rs reference the issue also cited has since been removed (OFST field deleted by a919fcd7), so re-keyed the exclusion on comment content instead of an enumerated file list per the issue's own suggested fix, so new legitimate consumers don't require another manual update.

#2273: MaterialTable::intern_by_hash's collision-policy comment cited a scalar field count (75, later independently bumped to 92 by today's ceb69d24) that has drifted at least three times as GpuMaterial has grown — it's actually 108 fields / 432 bytes as of ceb69d24. Replaced the restated count with a pointer to size_of::<GpuMaterial>() and the existing gpu_material_size_is_432_bytes size pin, so it can't go stale on the next field addition.

#2264: already fixed by an unrelated commit (f6555b7b, 2026-08-19) that landed 17 days after this issue was filed — ROADMAP.md:1021 already reads 'PACK / QUST / DIAL / MESG / PERK / SPEL / MGEF now fully parsed (#446/#447 closed; see M24.2/M43 rows above for decode detail)', exactly what the issue asked for. No code change needed.

All changes are documentation/comment-only; cargo check -q across the full workspace is clean with zero warnings.